### PR TITLE
Facilitate and document per-branch databases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/catalogage"
+APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/${DB:-catalogage}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,16 +113,9 @@ Le serveur de développement est configurable à l'aide des variables d'environn
 |---|---|---|
 | `APP_DATABASE_URL` | URL vers la base de données PostgreSQL | `postgresql+asyncpg://localhost:5432/catalogage` |
 
-Définissez les valeurs spécifiques à votre situation dans un fichier `.env` placé à la racine du projet.
+Définissez les valeurs spécifiques à votre situation dans un fichier `.env` placé à la racine du projet, que vous pouvez créer à partir du modèle `.env.example`.
 
-Exemple :
-
-```bash
-# .env
-APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:6543/catalogage"
-```
-
-Les variables peuvent aussi être passées en arguments, par exemple :
+Les variables peuvent aussi être passées en arguments, elles sont alors utilisées en priorité par rapport au `.env`. Par exemple :
 
 ```bash
 APP_DATABASE_URL="..." make serve
@@ -143,3 +136,49 @@ make dbdiagram
 Ce qui génèrera `docs/db.png`.
 
 Le format de `docs/db.erd.json` reprend celui de [`erdot`](https://github.com/ehne/ERDot), dont la documentation peut donc vous être utile.
+
+## Trucs et astuces
+
+### Base de données de branche
+
+Si vous travaillez sur une branche qui inclut une modification de la base de données (exemple : ajout d'une table, altération d'une colonne...), il peut être pratique d'utiliser une base de données spécifique à cette branche ("BDD de branche"). Cela permet de garder la base `catalogage` en l'état si jamais vous deviez travailler à nouveau à partir de `master`.
+
+Pour ce faire, créez d'abord une copie de votre base de données comme suit :
+
+```bash
+createdb -T catalogage catalogage-toto
+```
+
+> Si vous utilisez Docker Compose, vous devrez exécuter cette commande à l'intérieur du conteneur : `$ docker-compose exec postgresql createdb ...`.
+
+Vous devez maintenant indiquer aux commandes `make` d'utiliser cette base `catalogage-toto`.
+
+En principe, vous pourriez le faire en spécifiant une `APP_DATABASE_URL` en entier (voir [Configuration](#configuration)). Par exemple : `$ APP_DATABASE_URL=asyncpg://localhost:5432/catalogage-toto make serve`. Mais c'est peut-être un peu lourd.
+
+Nous vous proposons donc mieux : si vous avez créé un `.env` à partir de `.env.example`, votre `APP_DATABASE_URL` acceptera par défaut une variable d'environnement `DB` permettant de ne passer que le nom de la base de données le serveur doit s'adresser.
+
+Vous pouvez alors indiquer aux commandes `make` d'utiliser cette BDD de branche comme suit :
+
+```bash
+# Créer une migration à partir de la BDD de branche
+DB=catalogage-toto name=add-some-table make migration
+
+# Lancer les migrations sur la BDD de branche
+DB=catalogage-toto make migrate
+
+# Démarrer le serveur en utilisant la BDD de branche
+DB=catalogage-toto make serve
+```
+
+Lorsque vous n'avez plus besoin de votre BDD de branche (par exemple quand celle-ci a été _mergée_), vous pouvez la supprimer :
+
+```bash
+dropdb catalogage-toto
+```
+
+En pratique, le processus est donc le suivant :
+
+1. Créer une branche
+2. Créer une BDD de branche à partir de votre BDD de développement principale.
+3. Utiliser `DB=... make ...`.
+4. Supprimer cette BDD de branche lorsque vous n'en avez plus besoin.


### PR DESCRIPTION
## Description

Documentation d'un _workflow_ suggéré pour gérer la BDD de dev quand on jongle entre des branches qui y apportent des modifications.

## Motivation

J'ai l'habitude de créer une BDD par branche qui nécessite des modifications à la BDD. En effet :+1: 

- Ca permet de tester des évolutions de la DB à partir d'une DB "en l'état", comme cela se produit en prod (plutôt qu'à partir d'une DB "propre")
- Ca permet d'éviter de devoir effacer la DB de dev en jonglant entre les branches (les notres ou celles d'autres personnes, pour de la review par ex), et ainsi perdre les éventuelles données de test qu'on y a mises.

Comme ce n'est pas forcément intuitif et que pour ma part ce procédé me convient très bien, je me suis dis qu'il serait d'autant mieux de le documenter pour que tout le monde en profite. :-)