### PR TITLE
Fix coverage detection on SQLAlchemy calls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 omit = server/migrations/*
+concurrency = thread, greenlet


### PR DESCRIPTION
Suite de #24 

Cette PR corrige le comportement de la détection de _coverage_ pour les lignes suivant un appel à la BDD.

En effet, le support de _async_ dans SQLAlchemy fait appel à [greenlet](https://pypi.org/project/greenlet/), une implémentation de coroutines pour Python. Coverage.py a besoin d'un flag explicite pour être compatible avec greenlet (par défaut `concurrency = thread` seulement), sinon les lignes suivant un appel à greenlet peuvent ne pas être détectées (voir https://github.com/nedbat/coveragepy/issues/1082), comme c'est le cas ici.

Le coverage monte 91% -> 97%, car des lignes étaient ignorées à cause de ce pb. :-)

```
============================= test session starts ==============================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/florimond/dev/prj-catalogue/catalogage-donnees, configfile: setup.cfg, testpaths: tests
plugins: asyncio-0.16.0, cov-3.0.0, anyio-3.4.0
collected 17 items

tests/test_app.py .                                                      [  5%]
tests/api/test_auth.py ..............                                    [ 88%]
tests/api/test_datasets.py .                                             [ 94%]
tests/domain/test_datasets.py .                                          [100%]

---------- coverage: platform linux, python 3.8.12-final-0 -----------
Name                                             Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------
server/__init__.py                                   0      0   100%
server/api/__init__.py                               0      0   100%
server/api/app.py                                   11      0   100%
server/api/auth/__init__.py                          2      0   100%
server/api/auth/dependencies.py                     14      0   100%
server/api/auth/routes.py                           29      3    90%   34-37
server/api/auth/schemas.py                          10      0   100%
server/api/datasets/__init__.py                      2      0   100%
server/api/datasets/routes.py                       37      0   100%
server/api/datasets/schemas.py                       7      0   100%
server/api/routes.py                                11      0   100%
server/api/security.py                               2      0   100%
server/application/__init__.py                       0      0   100%
server/application/auth/__init__.py                  0      0   100%
server/application/auth/commands.py                  6      0   100%
server/application/auth/handlers.py                 25      2    92%   26-27
server/application/auth/queries.py                   4      0   100%
server/application/datasets/__init__.py              0      0   100%
server/application/datasets/commands.py              6      0   100%
server/application/datasets/handlers.py             23      0   100%
server/application/datasets/queries.py               8      0   100%
server/config/__init__.py                            2      0   100%
server/config/di.py                                 48      0   100%
server/config/settings.py                           22      0   100%
server/domain/__init__.py                            0      0   100%
server/domain/auth/__init__.py                       0      0   100%
server/domain/auth/entities.py                       7      0   100%
server/domain/auth/exceptions.py                     6      0   100%
server/domain/auth/repositories.py                   8      0   100%
server/domain/common/__init__.py                     0      0   100%
server/domain/common/exceptions.py                   5      0   100%
server/domain/common/types.py                        1      0   100%
server/domain/datasets/__init__.py                   0      0   100%
server/domain/datasets/entities.py                   7      0   100%
server/domain/datasets/exceptions.py                 3      0   100%
server/domain/datasets/repositories.py               9      0   100%
server/infrastructure/__init__.py                    0      0   100%
server/infrastructure/adapters/__init__.py           0      0   100%
server/infrastructure/adapters/json.py               9      4    56%   7-9, 13
server/infrastructure/adapters/messages.py          18      2    89%   26-27
server/infrastructure/auth/__init__.py               0      0   100%
server/infrastructure/auth/module.py                 7      0   100%
server/infrastructure/auth/repositories.py          34      4    88%   43-46
server/infrastructure/database.py                   13      0   100%
server/infrastructure/datasets/__init__.py           0      0   100%
server/infrastructure/datasets/module.py             7      0   100%
server/infrastructure/datasets/repositories.py      40      0   100%
server/main.py                                       4      4     0%   1-6
server/seedwork/application/__init__.py              0      0   100%
server/seedwork/application/commands.py              5      0   100%
server/seedwork/application/messages.py              7      1    86%   11
server/seedwork/application/modules.py               5      0   100%
server/seedwork/application/queries.py               5      0   100%
server/seedwork/application/types.py                 5      0   100%
server/seedwork/domain/__init__.py                   0      0   100%
server/seedwork/domain/entities.py                   3      0   100%
server/seedwork/domain/repositories.py               6      0   100%
tests/__init__.py                                    0      0   100%
tests/api/__init__.py                                0      0   100%
tests/api/test_auth.py                              29      0   100%
tests/api/test_datasets.py                          25      0   100%
tests/conftest.py                                   38      0   100%
tests/domain/__init__.py                             0      0   100%
tests/domain/test_datasets.py                       21      0   100%
tests/test_app.py                                    7      0   100%
------------------------------------------------------------------------------
TOTAL                                              603     20    97%

Required test coverage of 90% reached. Total coverage: 96.68%

============================== 17 passed in 1.11s ==============================
```