### PR TITLE
[Demo] Replace part of web layer by another framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # App
 asyncpg==0.25.0
 alembic==1.7.5
+falcon==3.0.1
 fastapi==0.70.0
 punq==0.5
 pydantic[email]==1.8.2

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -4,6 +4,7 @@ from server.config import Settings
 from server.config.di import resolve
 from server.infrastructure.database import Database
 
+from . import datasets
 from .routes import router
 
 
@@ -17,5 +18,6 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(router)
+    app.mount("/datasets/", datasets.app)
 
     return app

--- a/server/api/datasets/__init__.py
+++ b/server/api/datasets/__init__.py
@@ -1,5 +1,5 @@
-from .routes import router
+from .routes import app
 
 __all__ = [
-    "router",
+    "app",
 ]

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -4,7 +4,7 @@ from starlette.responses import RedirectResponse
 from server.config import Settings
 from server.config.di import resolve
 
-from . import auth, datasets
+from . import auth
 
 router = APIRouter()
 
@@ -15,4 +15,3 @@ def index(settings: Settings = Depends(lambda: resolve(Settings))) -> str:
 
 
 router.include_router(auth.router)
-router.include_router(datasets.router)


### PR DESCRIPTION
J'ouvre cette PR pour immédiatement la fermer dans la foulée, car l'objectif ici n'est pas de merger ces changements mais de garder une trace d'une petite démonstration purement technique.

Cette PR démontre l'intérêt de l'approche "architecture hexagonale" (cf #17).

En effet, je montre ici comment on pourrait concrètement remplacer une partie de la couche web (actuellement FastAPI) par un autre framework ([Falcon](https://falconframework.org/)), avec une surface de changement minimale qui en particulier ne touche qu'au dossier `api`. Les couches `domain`, `application` et `infrastructure` ne sont pas impactés.

(N.B. L'autre déterminant ici est [ASGI](https://asgi.readthedocs.io/en/latest/), l'interface qui permet une inter-opérabilité entre les divers frameworks asynchrones Python - et donc ici de faire coexister une partie en FastAPI, et une autre partie en Falcon.)