### PR TITLE
[POC] Progressive form enhancement

### DIFF
--- a/client/src/lib/form.ts
+++ b/client/src/lib/form.ts
@@ -1,0 +1,90 @@
+import { invalidate } from "$app/navigation";
+
+// this action (https://svelte.dev/tutorial/actions) allows us to
+// progressively enhance a <form> that already works without JS
+export function enhance(
+  form: HTMLFormElement,
+  {
+    pending,
+    error,
+    result,
+  }: {
+    pending?: ({
+      data,
+      form,
+    }: {
+      data: FormData;
+      form: HTMLFormElement;
+    }) => void;
+    error?: ({
+      data,
+      form,
+      response,
+      error,
+    }: {
+      data: FormData;
+      form: HTMLFormElement;
+      response: Response | null;
+      error: Error | null;
+    }) => void;
+    result?: ({
+      data,
+      form,
+      response,
+    }: {
+      data: FormData;
+      response: Response;
+      form: HTMLFormElement;
+    }) => void;
+  } = {}
+): { destroy: () => void } {
+  let current_token: unknown;
+
+  async function handle_submit(e: Event) {
+    const token = (current_token = {});
+
+    e.preventDefault();
+
+    const data = new FormData(form);
+
+    if (pending) pending({ data, form });
+
+    try {
+      const response = await fetch(form.action, {
+        method: form.method,
+        headers: {
+          accept: "application/json",
+        },
+        body: data,
+      });
+
+      if (token !== current_token) return;
+
+      if (response.ok) {
+        if (result) result({ data, form, response });
+
+        const url = new URL(form.action);
+        url.search = url.hash = "";
+        invalidate(url.href);
+      } else if (error) {
+        error({ data, form, error: null, response });
+      } else {
+        console.error(await response.text());
+      }
+    } catch (e: any) {
+      if (error) {
+        error({ data, form, error: e, response: null });
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  form.addEventListener("submit", handle_submit);
+
+  return {
+    destroy() {
+      form.removeEventListener("submit", handle_submit);
+    },
+  };
+}

--- a/client/src/routes/datasets/_api.ts
+++ b/client/src/routes/datasets/_api.ts
@@ -1,0 +1,35 @@
+import { getApiUrl } from "src/lib/fetch";
+
+export async function api(
+  request: Request,
+  resource: string,
+  data?: Record<string, unknown>
+) {
+  const res = await fetch(`${getApiUrl()}${resource}`, {
+    method: request.method,
+    headers: {
+      "content-type": "application/json",
+    },
+    body: data && JSON.stringify(data),
+  });
+
+  // If this is a <form> submission, be sure to redirect to the client page,
+  // rather than letting the browser show the `action` URL (which points to the API result).
+  if (
+    res.ok &&
+    request.method !== "GET" &&
+    request.headers.get("accept") != "application/json"
+  ) {
+    return {
+      status: 303,
+      headers: {
+        location: "/",
+      },
+    };
+  }
+
+  return {
+    status: res.status,
+    body: await res.json(),
+  };
+}

--- a/client/src/routes/datasets/index.ts
+++ b/client/src/routes/datasets/index.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { api } from "./_api";
+
+export const get: RequestHandler = async ({ request }) => {
+  return await api(request, "/datasets/");
+};
+
+export const post: RequestHandler = async ({ request }) => {
+  const form = await request.formData();
+  return api(request, "/datasets/", {
+    title: form.get("title"),
+    description: form.get("description"),
+  });
+};
+
+export const put: RequestHandler = async ({ request }) => {
+  const form = await request.formData();
+  return api(request, `/datasets/${form.get("id")}/`, {
+    title: form.get("title"),
+    description: form.get("description"),
+  });
+};
+
+export const del: RequestHandler = async ({ request }) => {
+  const form = await request.formData();
+  return api(request, `/datasets/${form.get("id")}/`);
+};

--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -14,7 +14,7 @@ const config = {
 
     // Override http methods in the Todo forms
     methodOverride: {
-      allowed: ["PATCH", "DELETE"],
+      allowed: ["PUT", "PATCH", "DELETE"],
     },
 
     vite,

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from server.domain.common.types import ID
 
@@ -12,3 +12,20 @@ class DatasetRead(BaseModel):
 class DatasetCreate(BaseModel):
     title: str
     description: str
+
+
+class DatasetUpdate(BaseModel):
+    title: str
+    description: str
+
+    @validator("title")
+    def check_title_not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("title must not be empty")
+        return value
+
+    @validator("description")
+    def check_description_not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("description must not be empty")
+        return value

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -7,5 +7,11 @@ class CreateDataset(Command[ID]):
     description: str
 
 
+class UpdateDataset(Command[None]):
+    id: ID
+    title: str
+    description: str
+
+
 class DeleteDataset(Command[None]):
     id: ID

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -6,7 +6,7 @@ from server.domain.datasets.entities import Dataset
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.repositories import DatasetRepository
 
-from .commands import CreateDataset, DeleteDataset
+from .commands import CreateDataset, DeleteDataset, UpdateDataset
 from .queries import GetAllDatasets, GetDatasetByID
 
 
@@ -18,6 +18,19 @@ async def create_dataset(command: CreateDataset) -> ID:
         description=command.description,
     )
     return await repository.insert(dataset)
+
+
+async def update_dataset(command: UpdateDataset) -> None:
+    repository = resolve(DatasetRepository)
+
+    pk = command.id
+    dataset = await repository.get_by_id(pk)
+    if dataset is None:
+        raise DatasetDoesNotExist(pk)
+
+    dataset.update(title=command.title, description=command.description)
+
+    await repository.update(dataset)
 
 
 async def delete_dataset(command: DeleteDataset) -> None:

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -10,3 +10,7 @@ class Dataset(Entity):
 
     class Config:
         orm_mode = True
+
+    def update(self, title: str, description: str) -> None:
+        self.title = title
+        self.description = description

--- a/server/domain/datasets/repositories.py
+++ b/server/domain/datasets/repositories.py
@@ -19,5 +19,8 @@ class DatasetRepository(Repository):
     async def insert(self, entity: Dataset) -> ID:
         raise NotImplementedError  # pragma: no cover
 
+    async def update(self, entity: Dataset) -> None:
+        raise NotImplementedError  # pragma: no cover
+
     async def delete(self, id: ID) -> None:
         raise NotImplementedError  # pragma: no cover

--- a/server/infrastructure/datasets/module.py
+++ b/server/infrastructure/datasets/module.py
@@ -1,9 +1,14 @@
-from server.application.datasets.commands import CreateDataset, DeleteDataset
+from server.application.datasets.commands import (
+    CreateDataset,
+    DeleteDataset,
+    UpdateDataset,
+)
 from server.application.datasets.handlers import (
     create_dataset,
     delete_dataset,
     get_all_datasets,
     get_dataset_by_id,
+    update_dataset,
 )
 from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
 from server.seedwork.application.modules import Module
@@ -12,6 +17,7 @@ from server.seedwork.application.modules import Module
 class DatasetsModule(Module):
     command_handlers = {
         CreateDataset: create_dataset,
+        UpdateDataset: update_dataset,
         DeleteDataset: delete_dataset,
     }
 

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import List, Optional
 
-from sqlalchemy import Column, String, delete, insert, select
+from sqlalchemy import Column, String, delete, insert, select, update
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import NoResultFound
 
@@ -50,6 +50,16 @@ class SqlDatasetRepository(DatasetRepository):
             result = await session.execute(stmt)
             await session.commit()
             return result.scalar_one()
+
+    async def update(self, entity: Dataset) -> None:
+        async with self._db.session() as session:
+            stmt = (
+                update(DatasetModel)
+                .where(DatasetModel.id == entity.id)
+                .values(**entity.dict(exclude={"id"}))
+            )
+            await session.execute(stmt)
+            await session.commit()
 
     async def delete(self, id: ID) -> None:
         async with self._db.session() as session:


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/56#discussion_r801508452

On discutait sur #56 de s'il serait possible de supporter le "progressive form enhancements" (pas sûr de comment on nomme cette technique en français ?), à savoir l'assurance que le site puisse tourner sans JavaScript, pour que ce dernier ne serve qu'à "augmenter" le site côté navigateur.

https://en.wikipedia.org/wiki/Progressive_enhancement

Voici un POC d'implémentation, qui reprend l'approche soulignée ici https://github.com/sveltejs/kit/issues/1203 et que SvelteKit semble tout indiquer avec le support inclus d'une option de [surchage de méthode HTTP](https://kit.svelte.dev/docs#routing-endpoints-http-method-overrides) qui permet d'envoyer un `_method=<...>` à son serveur lors des envois de formulaires.

(Au passage, ça permet de montrer que le CRUD #55 fonctionne très bien et peut être dès à présent intégré au front : car on a dans le `index.svelte` ici un exemple de CRUD complet !)

@magopian C'est toi qui a soulevé ce sujet, est-ce que tu pourrais développer l'intérêt que tu trouves à cette approche ?

De mon point de vue :

- Bénéfice éco-conception : en s'assurant qu'un minimum de tâches sont faites dans le client (puisque le site est sensé fonctionner sans JS, ce qui implique que la majorité du rendu est faite côté serveur), on réduit la charge sur le terminal, et donc on limite le déclenchement de renouvellement de matériel (moindre sensation de lenteur)
- Bénéfice accessibilité : ? (Lecture écran automatique facilitée ?)
- Autres ?