### PR TITLE
Fix browser/API routing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "start-server": "cd .. && make serve",
     "test-e2e": "playwright test",
-    "test-e2e:ci": "start-server-and-test start-server '3579/docs|3000' test-e2e",
+    "test-e2e:ci": "start-server-and-test start-server '3579/api/docs|3000' test-e2e",
     "test:watch": "vitest watch",
     "test:coverage": "npm run test -- --coverage"
   },

--- a/client/src/lib/fetch.ts
+++ b/client/src/lib/fetch.ts
@@ -1,5 +1,9 @@
+import { browser } from "$app/env";
 import { API_PORT } from "src/env";
 
 export const getApiUrl = () => {
-  return `http://localhost:${API_PORT}/api`;
+  if (!browser) {
+    return `http://localhost:${API_PORT}/api`;
+  }
+  return "/api";
 };

--- a/client/src/lib/fetch.ts
+++ b/client/src/lib/fetch.ts
@@ -1,20 +1,5 @@
-import { browser } from "$app/env";
 import { API_PORT } from "src/env";
 
 export const getApiUrl = () => {
-  if (!browser) {
-    // During SSR, request the local API server directly,
-    // no need to travel through the Internet.
-    // This works in all environments - local development or live production.
-    return `http://localhost:${API_PORT}`;
-  }
-  // In the browser, request /api on the current domain.
-  // * This works in production because this will request
-  //   https://<domain>/api/..., which is the public URL to the
-  //   API server (as exposed via Nginx).
-  // * This works in development because Vite is configured
-  //   to proxy localhost:3000/api/... to the local API server.
-  // (We can't just switch on `NODE_ENV` because we don't have access
-  // to `process.env` from here.)
-  return "/api";
+  return `http://localhost:${API_PORT}/api`;
 };

--- a/client/src/lib/repositories/datasets.spec.ts
+++ b/client/src/lib/repositories/datasets.spec.ts
@@ -14,7 +14,7 @@ test("The datasets endpoint behaves as expected", async () => {
 
   const fakeFetch: Fetch = async (request) => {
     expect(request.method).toBe("GET");
-    expect(request.url).toBe(`http://localhost:${API_PORT}/datasets/`);
+    expect(request.url).toBe(`http://localhost:${API_PORT}/api/datasets/`);
 
     const body = JSON.stringify(fakeDatasets);
     const headers = { "Content-Type": "application/json" };

--- a/client/src/tests/e2e/home.spec.js
+++ b/client/src/tests/e2e/home.spec.js
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 test.describe("Catalog list", () => {
   test("Visits the home page", async ({ page }) => {
     await page.goto("/");
-    await page.waitForResponse("**/api/datasets/");
 
     await expect(page).toHaveTitle("Catalogue");
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -9,22 +9,6 @@ dotenv.config({
   path: path.resolve("..", ".env"),
 });
 
-function getProxy() {
-  // Return the proxy to use for the Vite dev server (not used in production).
-  // See: https://vitejs.dev/config/#server-proxy
-  const API_PORT = process.env.VITE_API_PORT || "3579";
-
-  return {
-    // Proxy requests to /api to the local API server.
-    // We need this in development to match the live configuration
-    // which exposes the API on /api on the web server.
-    "/api": {
-      target: `http://localhost:${API_PORT}`,
-      rewrite: (path) => path.replace(/^\/api/, ""), // "/api/..." -> "/..."
-    },
-  };
-}
-
 /**
  * @type {import('vite').UserConfig}
  */
@@ -35,9 +19,6 @@ export const config = {
       src: path.resolve("./src"),
       $lib: path.resolve("./src/lib"),
     },
-  },
-  server: {
-    proxy: getProxy(),
   },
 };
 

--- a/ops/ansible/roles/web/templates/nginx.conf.j2
+++ b/ops/ansible/roles/web/templates/nginx.conf.j2
@@ -22,6 +22,6 @@ server {
 
     location /api/ {
         include proxy_params;
-        proxy_pass http://api/;
+        proxy_pass http://api;
     }
 }

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -8,7 +8,7 @@ from server.infrastructure.database import Database
 from .routes import router
 
 origins = [
-    "http://localhost:3000",
+    "http://localhost",
 ]
 
 

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -20,6 +20,7 @@ def create_app() -> FastAPI:
         on_startup=[db.create_all],
         docs_url=settings.docs_url,
     )
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,

--- a/server/api/auth/routes.py
+++ b/server/api/auth/routes.py
@@ -11,7 +11,7 @@ from server.seedwork.application.messages import MessageBus
 from .dependencies import get_current_user
 from .schemas import CheckAuthResponse, UserCreate, UserRead
 
-router = APIRouter(prefix="/auth", tags=["auth"])
+router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 
 @router.post("/users/", response_model=UserRead, status_code=201)

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -17,7 +17,7 @@ from server.seedwork.application.messages import MessageBus
 
 from .schemas import DatasetCreate, DatasetRead, DatasetUpdate
 
-router = APIRouter(prefix="/datasets", tags=["datasets"])
+router = APIRouter(prefix="/api/datasets", tags=["datasets"])
 
 
 @router.get("/", response_model=List[DatasetRead])

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     server_mode: ServerMode = "local"
     database_url: str = "postgresql+asyncpg://localhost:5432/catalogage"
     port: int = 3579
-    docs_url: str = "/docs"
+    docs_url: str = "/api/docs"
     testing: bool = False
 
     class Config:

--- a/server/main.py
+++ b/server/main.py
@@ -30,8 +30,6 @@ if __name__ == "__main__":
             # connecting client, rather than the connecting Nginx proxy.
             # See: https://www.uvicorn.org/deployment/#running-behind-nginx
             proxy_headers=True,
-            # Match Nginx mount path.
-            root_path="/api",
         )
 
     uvicorn.run("server.main:app", **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,8 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
     from server.api.app import create_app
 
     app = create_app()
+    base_url = "http://testserver/api"
 
     async with LifespanManager(app):
-        async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(app=app, base_url=base_url) as client:
             yield client

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,9 +4,9 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_index(client: httpx.AsyncClient) -> None:
-    response = await client.get("/")
+    response = await client.get("http://testserver/")
     assert response.status_code == 307
-    assert response.headers["Location"] == "http://testserver/docs"
+    assert response.headers["Location"] == "http://testserver/api/docs"
 
 
 @pytest.mark.parametrize("origin", ["http://localhost:3000"])


### PR DESCRIPTION
Closes #71 

Lire #71 pour le descriptif du problème

Cette PR apporte les changements suivants :

- Les endpoints d'API sont maintenant dispo sur la base `/api/`, au lieu de `/`, pour faire correspondre le local et la prod.
- Le proxy de dev est retiré, et le frontend appelle l'API via `/api/` dans tous les cas.

## Vérifications

Au-delà des tests, j'ai déployé cette branche sur la [VM de test](https://github.com/etalab/catalogage-donnees/blob/master/docs/fr/ops.md#test), en faisant les vérifications suivantes :

- [x] Le déploiement se déroule correctement
- [x] En accédant à la page d'accueil, plus de requêtes en double
- [ ] En faisant de même à partir d'un build local (`make build && make serve-dist`), la page charge correctement, et il est tjr possible d'ajouter des fiches de données par la page Contribuer.