### PR TITLE
Revamp API/SSR/browser wiring

### DIFF
--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -1,5 +1,6 @@
 // Vite reads this from .env files.
 // See: https://vitejs.dev/guide/env-and-mode.html#env-files
-const { VITE_API_PORT } = import.meta.env;
+const { VITE_API_BROWSER_URL, VITE_API_SSR_URL } = import.meta.env;
 
-export const API_PORT = VITE_API_PORT || "3579";
+export const API_BROWSER_URL = VITE_API_BROWSER_URL || "http://localhost:3579";
+export const API_SSR_URL = VITE_API_SSR_URL || "http://localhost:3579";

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -2,5 +2,10 @@
 // See: https://vitejs.dev/guide/env-and-mode.html#env-files
 const { VITE_API_BROWSER_URL, VITE_API_SSR_URL } = import.meta.env;
 
-export const API_BROWSER_URL = VITE_API_BROWSER_URL || "http://localhost:3579";
-export const API_SSR_URL = VITE_API_SSR_URL || "http://localhost:3579";
+const stringOnly = (value: any) =>
+  typeof value === "string" ? value : undefined;
+
+export const API_BROWSER_URL =
+  stringOnly(VITE_API_BROWSER_URL) || "http://localhost:3579";
+export const API_SSR_URL =
+  stringOnly(VITE_API_SSR_URL) || "http://localhost:3579";

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,0 +1,25 @@
+import type { Handle } from "@sveltejs/kit";
+
+const getApiUrl = (clientHost: string): string => {
+  return `http://${clientHost}/api/`;
+};
+
+// See: https://kit.svelte.dev/docs/hooks#handle
+export const handle: Handle = async ({ event, resolve }) => {
+  const clientHost = event.url.host;
+
+  const response = await resolve(event);
+
+  if (response.body) {
+    // Avoid re-fetching in the browser by patching Svelte's hydration (1) data-url
+    // so that it matches what the browser would request.
+    // (1) See: https://kit.svelte.dev/docs/appendix#hydration
+    const body = await response.text();
+    const apiDataUrl = /data-url="http(s?):\/\/[^/]+\//g
+    const clientDataUrl = `data-url="${getApiUrl(clientHost)}`;
+    const patchedBody = body.replace(apiDataUrl, clientDataUrl);
+    return new Response(patchedBody, response);
+  }
+
+  return response;
+};

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,28 +1,9 @@
 import type { Handle } from "@sveltejs/kit";
-import { API_BROWSER_URL, API_SSR_URL } from "./env";
-
-const shouldApplyHydrateFix = API_SSR_URL != API_BROWSER_URL;
-
-const getApiUrl = (clientHost: string) => {
-  return `http://${clientHost}/api`;
-};
+import { maybePatchDataUrl } from "$lib/fetch";
 
 // See: https://kit.svelte.dev/docs/hooks#handle
 export const handle: Handle = async ({ event, resolve }) => {
-  const clientHost = event.url.host;
-
-  const response = await resolve(event);
-
-  if (shouldApplyHydrateFix && response.body) {
-    // Avoid re-fetching in the browser by patching Svelte's hydration (1) data-url
-    // so that it matches what the browser would request.
-    // (1) See: https://kit.svelte.dev/docs/appendix#hydration
-    const body = await response.text();
-    const apiDataUrl = `data-url="${API_SSR_URL}`;
-    const browserDataUrl = `data-url="${getApiUrl(clientHost)}`;
-    const patchedBody = body.replace(apiDataUrl, browserDataUrl);
-    return new Response(patchedBody, response);
-  }
-
+  let response = await resolve(event);
+  response = await maybePatchDataUrl(response, event.url);
   return response;
 };

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,7 +1,10 @@
 import type { Handle } from "@sveltejs/kit";
+import { API_BROWSER_URL, API_SSR_URL } from "./env";
 
-const getApiUrl = (clientHost: string): string => {
-  return `http://${clientHost}/api/`;
+const shouldApplyHydrateFix = API_SSR_URL != API_BROWSER_URL;
+
+const getApiUrl = (clientHost: string) => {
+  return `http://${clientHost}/api`;
 };
 
 // See: https://kit.svelte.dev/docs/hooks#handle
@@ -10,14 +13,14 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   const response = await resolve(event);
 
-  if (response.body) {
+  if (shouldApplyHydrateFix && response.body) {
     // Avoid re-fetching in the browser by patching Svelte's hydration (1) data-url
     // so that it matches what the browser would request.
     // (1) See: https://kit.svelte.dev/docs/appendix#hydration
     const body = await response.text();
-    const apiDataUrl = /data-url="http(s?):\/\/[^/]+\//g
-    const clientDataUrl = `data-url="${getApiUrl(clientHost)}`;
-    const patchedBody = body.replace(apiDataUrl, clientDataUrl);
+    const apiDataUrl = `data-url="${API_SSR_URL}`;
+    const browserDataUrl = `data-url="${getApiUrl(clientHost)}`;
+    const patchedBody = body.replace(apiDataUrl, browserDataUrl);
     return new Response(patchedBody, response);
   }
 

--- a/client/src/lib/fetch.ts
+++ b/client/src/lib/fetch.ts
@@ -1,6 +1,15 @@
 import { browser } from "$app/env";
 import { API_BROWSER_URL, API_SSR_URL } from "src/env";
 
+/**
+ * Return the base API URL to be used for `fetch()` requests by the client.
+ *
+ * Example usage:
+ * ```
+ * const url = `${getApiUrl()}/some/resource/`;
+ * const response = await fetch(url);
+ * ```
+ */
 export const getApiUrl = () => {
   if (browser) {
     // This is:
@@ -12,4 +21,66 @@ export const getApiUrl = () => {
   // In live environments (prod/staging/etc), this ensures we don't travel the Internet
   // when making requests during SSR (Server-Side Rendering).
   return API_SSR_URL;
+};
+
+export const maybePatchDataUrl = async (
+  response: Response,
+  requestUrl: URL
+): Promise<Response> => {
+  /**
+   * NOTE: What's with all this?
+   *
+   * When using `load`, SvelteKit has a technique called _hydration_ to send data
+   * fetched during SSR to the browser.
+   * See: https://kit.svelte.dev/docs/appendix#hydration
+   *
+   * It is fairly easy for this technique to fail, which typically results in duplicated requests
+   * to the API server. SvelteKit can't warn us about it yet.
+   * See also: https://github.com/sveltejs/kit/issues/3729
+   *
+   * One key thing for hydration to work is that the `data-url` of the special
+   * HTML tag included in the SSR HTML should match the URL of a request the browser
+   * might do once it loads the app.
+   *
+   * As per our API-client wiring strategy (see `getApiUrl()` above), this is _generally_ the case.
+   * But in some situations these URLs may be different (1), e.g. because in live environments
+   * SSR and browser API calls are made to different locations.
+   *
+   * So right now we need this patch (2) to ensure `data-url` values match in that case too.
+   *
+   * See: https://github.com/etalab/catalogage-donnees/issues/71
+   */
+
+  // (1)
+  const shouldPatchDataUrl = API_SSR_URL !== API_BROWSER_URL;
+
+  if (!shouldPatchDataUrl) {
+    return response;
+  }
+
+  if (!response.body) {
+    return response;
+  }
+
+  // (2)
+  const ssrDataUrl = API_SSR_URL;
+  const browserDataUrl = ensureHasOrigin(
+    `http://${requestUrl.host}`,
+    API_BROWSER_URL
+  );
+  const body = await response.text();
+  const patchedBody = body.replace(
+    `data-url="${ssrDataUrl}`,
+    `data-url="${browserDataUrl}`
+  );
+
+  return new Response(patchedBody, response);
+};
+
+const ensureHasOrigin = (origin: string, value: string) => {
+  const isPath = value.startsWith("/");
+  if (isPath) {
+    return `${origin}${value}`;
+  }
+  return value;
 };

--- a/client/src/lib/fetch.ts
+++ b/client/src/lib/fetch.ts
@@ -1,20 +1,15 @@
 import { browser } from "$app/env";
-import { API_PORT } from "src/env";
+import { API_BROWSER_URL, API_SSR_URL } from "src/env";
 
 export const getApiUrl = () => {
-  if (!browser) {
-    // During SSR, request the local API server directly,
-    // no need to travel through the Internet.
-    // This works in all environments - local development or live production.
-    return `http://localhost:${API_PORT}`;
+  if (browser) {
+    // This is:
+    // * http://localhost:3579 on local.
+    // * /api when live (sends requests to Nginx, which serves the frontend app).
+    return API_BROWSER_URL;
   }
-  // In the browser, request /api on the current domain.
-  // * This works in production because this will request
-  //   https://<domain>/api/..., which is the public URL to the
-  //   API server (as exposed via Nginx).
-  // * This works in development because Vite is configured
-  //   to proxy localhost:3000/api/... to the local API server.
-  // (We can't just switch on `NODE_ENV` because we don't have access
-  // to `process.env` from here.)
-  return "/api";
+  // This is always http://localhost:3579.
+  // In live environments (prod/staging/etc), this ensures we don't travel the Internet
+  // when making requests during SSR (Server-Side Rendering).
+  return API_SSR_URL;
 };

--- a/client/src/lib/repositories/datasets.spec.ts
+++ b/client/src/lib/repositories/datasets.spec.ts
@@ -13,7 +13,7 @@ test("The datasets endpoint behaves as expected", async () => {
 
   const fakeFetch: Fetch = async (request) => {
     expect(request.method).toBe("GET");
-    expect(request.url).toBe(`http://localhost:3579/datasets/`);
+    expect(new URL(request.url).pathname).toBe("/datasets/");
 
     const body = JSON.stringify(fakeDatasets);
     const headers = { "Content-Type": "application/json" };

--- a/client/src/lib/repositories/datasets.spec.ts
+++ b/client/src/lib/repositories/datasets.spec.ts
@@ -1,6 +1,5 @@
 import type { Dataset } from "src/definitions/datasets";
 import type { Fetch } from "src/definitions/fetch";
-import { API_PORT } from "src/env";
 import { getDatasets } from "./datasets";
 
 test("The datasets endpoint behaves as expected", async () => {
@@ -14,7 +13,7 @@ test("The datasets endpoint behaves as expected", async () => {
 
   const fakeFetch: Fetch = async (request) => {
     expect(request.method).toBe("GET");
-    expect(request.url).toBe(`http://localhost:${API_PORT}/datasets/`);
+    expect(request.url).toBe(`http://localhost:3579/datasets/`);
 
     const body = JSON.stringify(fakeDatasets);
     const headers = { "Content-Type": "application/json" };

--- a/client/src/tests/e2e/contribuer.spec.js
+++ b/client/src/tests/e2e/contribuer.spec.js
@@ -17,8 +17,8 @@ test.describe("Basic form submission", () => {
 
     const button = page.locator("button[type='submit']");
     const [request, response, _] = await Promise.all([
-      page.waitForRequest("**/api/datasets/"),
-      page.waitForResponse("**/api/datasets/"),
+      page.waitForRequest("**/datasets/"),
+      page.waitForResponse("**/datasets/"),
       button.click(),
     ]);
     expect(await button.textContent()).toContain("Contribution");

--- a/client/src/tests/e2e/home.spec.js
+++ b/client/src/tests/e2e/home.spec.js
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 test.describe("Catalog list", () => {
   test("Visits the home page", async ({ page }) => {
     await page.goto("/");
-    await page.waitForResponse("**/api/datasets/");
 
     await expect(page).toHaveTitle("Catalogue");
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -9,22 +9,6 @@ dotenv.config({
   path: path.resolve("..", ".env"),
 });
 
-function getProxy() {
-  // Return the proxy to use for the Vite dev server (not used in production).
-  // See: https://vitejs.dev/config/#server-proxy
-  const API_PORT = process.env.VITE_API_PORT || "3579";
-
-  return {
-    // Proxy requests to /api to the local API server.
-    // We need this in development to match the live configuration
-    // which exposes the API on /api on the web server.
-    "/api": {
-      target: `http://localhost:${API_PORT}`,
-      rewrite: (path) => path.replace(/^\/api/, ""), // "/api/..." -> "/..."
-    },
-  };
-}
-
 /**
  * @type {import('vite').UserConfig}
  */
@@ -35,9 +19,6 @@ export const config = {
       src: path.resolve("./src"),
       $lib: path.resolve("./src/lib"),
     },
-  },
-  server: {
-    proxy: getProxy(),
   },
 };
 

--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -104,7 +104,12 @@ Le serveur d'API est configurable à l'aide des variables d'environnement suivan
 | `APP_SERVER_MODE` | Un mode d'opération qui configure Uvicorn en conséquence : <br> - `local` : pour le développement local (_hot reload_ activé, etc) <br> - `live` : pour tout déploiement tel que défini via Ansible (voir [Opérations](./ops.md)) | `local` |
 | `APP_DATABASE_URL` | URL vers la base de données PostgreSQL | `postgresql+asyncpg://localhost:5432/catalogage` |
 | `APP_PORT` | Port du server d'API | `3579` |
-| `VITE_API_PORT` | Doit être égal à `APP_PORT` si jamais ce dernier diffère de sa valeur par défaut, afin de permettre la communication directe entre le frontend et le serveur d'API le cas échéant (SSR, proxy local...). Pour plus de contexte, voir [#48](https://github.com/etalab/catalogage-donnees/pull/48) | `3579` |
+| `VITE_API_BROWSER_URL` | (1) URL utilisée par le navigateur lors de requêtes d'API | `http://localhost:3579` |
+| `VITE_API_SSR_URL` | (1) URL utilisée par le serveur frontend lors de requêtes d'API | `http://localhost:3579` |
+
+> Notes : 
+>
+> * (1) Ces options n'existent que pour la configuration de production, où le service est déployé via Nginx. Elles ne doivent typiquement pas être modifiées lors du développement local.
 
 Définissez les valeurs spécifiques à votre situation dans un fichier `.env` placé à la racine du projet, que vous pouvez créer à partir du modèle `.env.example`.
 

--- a/ops/ansible/roles/web/templates/.env.j2
+++ b/ops/ansible/roles/web/templates/.env.j2
@@ -1,4 +1,5 @@
 APP_SERVER_MODE=live
 APP_PORT="{{ api_port }}"
 APP_DATABASE_URL="{{ database_url }}"
-VITE_API_PORT="{{ api_port }}"
+VITE_API_BROWSER_URL="/api"
+VITE_API_SSR_URL="http://localhost:{{ api_port }}"


### PR DESCRIPTION
Closes #71 

Voir #71 pour l'explication du problème

Cette PR :

* Ajoute un `hook` (sorte de middleware côté Svelte) pour patcher l'URL envoyée par Svelte lors de la _hydration_. Celle-ci doit correspondre à l'URL que requêterait le client, sinon les requêtes faites lors d'un `load` sont dupliquées.
* Modifie la config pour savoir quelle URL le frontend doit requêter en SSR / navigateur : la règle simple est désormais "appeler directement l'API, _sauf_ dans le navigateur en prod, où il faut passer par Nginx". Pour cela, modif des variables de conf pour plus facilement raisonner : `API_SSR_URL` et `API_BROWSER_URL`.

(Ça règle donc aussi un pb pas décrit dans #71, à savoir que lorsqu'on lançait l'app buildée localement, le frontend appelait `POST http://localhost:3000/api/datasets` dans la page de contribution, ce qui est une 404. C'est résolu car il continuera d'appeler `POST http://localhost:3579/datasets/`, sauf en prod où on aura configuré `API_BROWSER_URL` en conséquence.)