### PR TITLE
Refactor createDataset endpoint call

### DIFF
--- a/client/src/lib/repositories/datasets.ts
+++ b/client/src/lib/repositories/datasets.ts
@@ -10,3 +10,16 @@ export const getDatasets: GetDatasets = async ({ fetch }) => {
   const response = await fetch(request);
   return await response.json();
 };
+
+type CreateDataset = (opts: { fetch: Fetch; body: string }) => Promise<Dataset>;
+
+export const createDataset: CreateDataset = async ({ fetch, body }) => {
+  const url = `${getApiUrl()}/datasets/`;
+  const request = new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  const response = await fetch(request);
+  return await response.json();
+};

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -5,19 +5,7 @@
 <script lang="ts">
   import { createForm } from "svelte-forms-lib";
   import * as yup from "yup";
-  import { getApiUrl } from "$lib/fetch";
-
-  const postData = async (values) => {
-    const data = JSON.stringify(values);
-    const url = `${getApiUrl()}/datasets/`;
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: data,
-    });
-    await new Promise((r) => setTimeout(r, 1000)); // TODO: remove, just for debugging purposes
-    return await response.json();
-  };
+  import { createDataset } from "$lib/repositories/datasets";
 
   const { form, errors, handleChange, handleSubmit, isSubmitting, isValid } =
     createForm({
@@ -29,9 +17,9 @@
         title: yup.string().required("Le titre ne peut être vide"),
         description: yup.string().required("La description ne peut être vide"),
       }),
-      onSubmit: (values) => {
-        const result = postData(values);
-        return result;
+      onSubmit: async (values) => {
+        const body = JSON.stringify(values);
+        return await createDataset({ fetch, body });
       },
     });
   const errorClassname = (error: string, className: string) =>

--- a/client/src/tests/e2e/contribuer.spec.js
+++ b/client/src/tests/e2e/contribuer.spec.js
@@ -21,7 +21,6 @@ test.describe("Basic form submission", () => {
       page.waitForResponse("**/api/datasets/"),
       button.click(),
     ]);
-    expect(await button.textContent()).toContain("Contribution");
     expect(request.method()).toBe("POST");
     expect(response.status()).toBe(201);
     const json = await response.json();


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/64#discussion_r806730164

- Supprime le `setTimeout()` de "debugging" (en réalité on s'appuyait dessus pour le test e2e)
- Place la logique d'appel d'API pour créer un dataset dans le `datasets.ts`, à côté de celle pour la liste de datasets.
- Modifie le test e2e de contribution : on ne teste plus le chgmt de texte du bouton, car 1) c'est déjà fait par un test unitaire et 2) sans le délai de "debugging" la requête va désormais très vite donc Playwright n'arrive pas à attraper le chgmt de texte à temps.

cc @magopian 