### PR TITLE
Tweak dataset list css

### DIFF
--- a/client/src/lib/components/DatasetList/DatasetList.spec.ts
+++ b/client/src/lib/components/DatasetList/DatasetList.spec.ts
@@ -31,11 +31,4 @@ describe("Test the dataset list", () => {
     });
     expect(getAllByRole("listitem")).toHaveLength(3);
   });
-
-  test("Items are separated by rulers", () => {
-    const { getAllByRole } = render(DatasetList, {
-      props: { datasets: fakeDatasets },
-    });
-    expect(getAllByRole("separator")).toHaveLength(2);
-  });
 });

--- a/client/src/lib/components/DatasetList/DatasetList.svelte
+++ b/client/src/lib/components/DatasetList/DatasetList.svelte
@@ -5,20 +5,8 @@
   export let datasets: Dataset[];
 </script>
 
-<ul>
-  {#each datasets as dataset, index (dataset.id)}
-    {@const lastChild = index === datasets.length - 1}
+<ul class="fr-raw-list">
+  {#each datasets as dataset (dataset.id)}
     <DatasetListItem {dataset} />
-    {#if !lastChild}
-      <hr />
-    {/if}
   {/each}
 </ul>
-
-<style>
-  ul {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-  }
-</style>

--- a/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
+++ b/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
@@ -4,7 +4,7 @@
   export let dataset: Dataset;
 </script>
 
-<li class="fr-pb-2w">
+<li class="fr-p-2w">
   <div class="fr-container">
     <div class="fr-grid-row">
       <div class="fr-col-2">
@@ -44,3 +44,9 @@
     </div>
   </div>
 </li>
+
+<style>
+  li:not(:last-child) {
+    border-bottom: 1px solid var(--border-default-grey);
+  }
+</style>


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/64#discussion_r806724037

2 petits ajustements au CSS suite à #64 

* Usage de `fr-raw-list`
* Séparateur via CSS plutôt que du markup HTML