### PR TITLE
Add formats to dataset contribution page

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -14,6 +14,6 @@ export const DATA_FORMAT_SHORT_NAMES: { [K in DataFormat]: string } = {
   file_gis: "SIG",
   api: "API",
   database: "BDD",
-  website: "WWW",
-  other: "AUTRE",
+  website: "Web",
+  other: "Autre",
 };

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,0 +1,19 @@
+import type { DataFormat } from "./definitions/datasets";
+
+export const DATA_FORMAT_LABELS: { [K in DataFormat]: string } = {
+  file_tabular: "Fichier tabulaire (XLS, XLSX, CSV, ...)",
+  file_gis: "Fichier SIG (Shapefile, ...)",
+  api: "API (REST, GraphQL, ...)",
+  database: "Base de données",
+  website: "Site web",
+  other: "Autre",
+};
+
+export const DATA_FORMAT_SHORT_NAMES: { [K in DataFormat]: string } = {
+  file_tabular: "CSV",
+  file_gis: "SIG",
+  api: "API",
+  database: "BDD",
+  website: "WWW",
+  other: "AUTRE",
+};

--- a/client/src/definitions/datasets.d.ts
+++ b/client/src/definitions/datasets.d.ts
@@ -1,5 +1,15 @@
+// Matches enum on the backend.
+type DataFormat =
+  | "file_tabular"
+  | "file_gis"
+  | "api"
+  | "database"
+  | "website"
+  | "other";
+
 export interface Dataset {
   id: string;
   title: string;
   description: string;
+  formats: DataFormat[];
 }

--- a/client/src/lib/components/DatasetList/DatasetList.spec.ts
+++ b/client/src/lib/components/DatasetList/DatasetList.spec.ts
@@ -24,7 +24,7 @@ describe("Test the dataset list", () => {
       title: "Masse salariale du secteur privé",
       description:
         "Masse salariale telle que calculée par l'Urssaf et publiée dans le Baromètre économique.",
-      formats: ["file_tabular"]
+      formats: ["file_tabular"],
     },
   ];
 

--- a/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
+++ b/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import type { Dataset } from "src/definitions/datasets";
+  import { DATA_FORMAT_SHORT_NAMES } from "src/constants";
 
   export let dataset: Dataset;
+
+  const formatFormats = (dataset: Dataset) => {
+    return dataset.formats
+      .map((format) => DATA_FORMAT_SHORT_NAMES[format])
+      .join(", ");
+  };
 </script>
 
 <li class="fr-pb-2w">
@@ -23,7 +30,7 @@
           <div class="fr-grid-row">
             <span class="fr-col"> France </span>
             <span class="fr-col"> 2010-2018 </span>
-            <span class="fr-col"> CSV, API, BDD </span>
+            <span class="fr-col"> {formatFormats(dataset)} </span>
             <span class="fr-col"> Qualité : haute </span>
             <span class="fr-col"> Open data </span>
           </div>

--- a/client/src/lib/repositories/datasets.spec.ts
+++ b/client/src/lib/repositories/datasets.spec.ts
@@ -8,6 +8,7 @@ test("The datasets endpoint behaves as expected", async () => {
       id: "uuid1",
       title: "Inventaire des arbres et forêts",
       description: "Fichier de l'ensemble des arbres et forêts de France.",
+      formats: ["database"],
     },
   ];
 

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -26,7 +26,7 @@
     initialValues: {
       title: "",
       description: "",
-      dataFormats: [] as boolean[],
+      dataFormats: dataFormatSelected,
     },
     validationSchema: yup.object().shape({
       title: yup.string().required("Le titre ne peut être vide"),

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -156,7 +156,7 @@
       </legend>
       <div class="fr-fieldset__content">
         {#each dataFormatChoices as { value, label }, index (value)}
-          {@const id = `dataformats-${index}`}
+          {@const id = `dataformats-${value}`}
           <div class="fr-checkbox-group">
             <input
               type="checkbox"

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -155,7 +155,10 @@
         : null}
       role="group"
     >
-      <legend class="fr-fieldset__legend fr-text--regular" id="dataformats-hint-legend">
+      <legend
+        class="fr-fieldset__legend fr-text--regular"
+        id="dataformats-hint-legend"
+      >
         Format(s) des données
         <span class="fr-hint-text" id="select-hint-dataformats-hint">
           Sélectionnez ici les différents formats de données qu'un réutilisateur

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -6,6 +6,7 @@
   import { createForm } from "svelte-forms-lib";
   import * as yup from "yup";
   import { getApiUrl } from "$lib/fetch";
+  import { DATA_FORMAT_LABELS } from "src/constants";
 
   const postData = async (values) => {
     const data = JSON.stringify(values);
@@ -19,23 +20,63 @@
     return await response.json();
   };
 
-  const { form, errors, handleChange, handleSubmit, isSubmitting, isValid } =
-    createForm({
-      initialValues: {
-        title: "",
-        description: "",
-      },
-      validationSchema: yup.object().shape({
-        title: yup.string().required("Le titre ne peut être vide"),
-        description: yup.string().required("La description ne peut être vide"),
-      }),
-      onSubmit: (values) => {
-        const result = postData(values);
-        return result;
-      },
-    });
-  const errorClassname = (error: string, className: string) =>
-    error ? className : "";
+  const dataFormatChoices = Object.entries(DATA_FORMAT_LABELS).map(
+    ([value, label]) => ({ value, label })
+  );
+
+  const dataFormatSelected = dataFormatChoices.map(() => false);
+
+  const {
+    form,
+    errors,
+    handleChange,
+    handleSubmit,
+    updateValidateField,
+    isSubmitting,
+    isValid,
+  } = createForm({
+    initialValues: {
+      title: "",
+      description: "",
+      dataFormats: [] as boolean[],
+    },
+    validationSchema: yup.object().shape({
+      title: yup.string().required("Le titre ne peut être vide"),
+      description: yup.string().required("La description ne peut être vide"),
+      dataFormats: yup
+        .array(yup.boolean())
+        .length(dataFormatSelected.length)
+        .test(
+          "dataformats-some-checked",
+          "Au moins un format de donnée doit être renseigné",
+          (value) => value.some((checked) => !!checked)
+        ),
+    }),
+    onSubmit: async (values) => {
+      const formats = [];
+      values.dataFormats.forEach((checked, index) => {
+        if (checked) {
+          formats.push(dataFormatChoices[index].value);
+        }
+      });
+      const payload = {
+        title: values.title,
+        description: values.description,
+        formats,
+      };
+      return await postData(payload);
+    },
+  });
+
+  const hasError = (error: string | string[]) => {
+    return typeof error === "string" && Boolean(error);
+  };
+
+  const handleDataformatChange = (event, index: number) => {
+    const { checked } = event.target;
+    dataFormatSelected[index] = checked;
+    updateValidateField("dataFormats", dataFormatSelected);
+  };
 </script>
 
 <svelte:head>
@@ -47,10 +88,7 @@
   <form on:submit={handleSubmit} data-bitwarden-watching="1">
     <fieldset class="fr-fieldset fr-my-4w">
       <div
-        class="fr-input-group {errorClassname(
-          $errors.title,
-          'fr-input-group--error'
-        )}"
+        class="fr-input-group {$errors.title ? 'fr-input-group--error' : ''}"
       >
         <label class="fr-label mandatory" for="title">
           Nom de la donnée
@@ -60,7 +98,7 @@
           </span>
         </label>
         <input
-          class="fr-input {errorClassname($errors.title, 'fr-input--error')}"
+          class="fr-input {$errors.title ? 'fr-input--error' : ''}"
           aria-describedby={$errors.title ? "title-desc-error" : null}
           type="text"
           id="title"
@@ -77,10 +115,9 @@
       </div>
 
       <div
-        class="fr-input-group {errorClassname(
-          $errors.description,
-          'fr-input-group--error'
-        )}"
+        class="fr-input-group {$errors.description
+          ? 'fr-input-group--error'
+          : ''}"
       >
         <label class="fr-label mandatory" for="description">
           Description des données
@@ -91,10 +128,7 @@
           </span>
         </label>
         <textarea
-          class="fr-input {errorClassname(
-            $errors.description,
-            'fr-input--error'
-          )}"
+          class="fr-input {$errors.description ? 'fr-input--error' : ''}"
           aria-describedby={$errors.description
             ? "description-desc-error"
             : null}
@@ -110,6 +144,47 @@
           </p>
         {/if}
       </div>
+    </fieldset>
+
+    <fieldset
+      class="fr-fieldset {hasError($errors.dataFormats)
+        ? 'fr-fieldset--error'
+        : ''}"
+      aria-describedby={hasError($errors.dataFormats)
+        ? "dataformats-desc-error"
+        : null}
+      role="group"
+    >
+      <legend class="fr-fieldset__legend fr-text--regular" id="dataformats-hint-legend">
+        Format(s) des données
+        <span class="fr-hint-text" id="select-hint-dataformats-hint">
+          Sélectionnez ici les différents formats de données qu'un réutilisateur
+          potentiel pourrait exploiter.
+        </span>
+      </legend>
+      <div class="fr-fieldset__content">
+        {#each dataFormatChoices as { value, label }, index (value)}
+          {@const id = `dataformats-${index}`}
+          <div class="fr-checkbox-group">
+            <input
+              type="checkbox"
+              {id}
+              name="dataformats"
+              {value}
+              on:blur={(event) => handleDataformatChange(event, index)}
+              on:change={(event) => handleDataformatChange(event, index)}
+            />
+            <label for={id}>
+              {label}
+            </label>
+          </div>
+        {/each}
+      </div>
+      {#if hasError($errors.dataFormats)}
+        <p id="dataformats-desc-error" class="fr-error-text">
+          {$errors.dataFormats}
+        </p>
+      {/if}
     </fieldset>
 
     <div class="fr-input-group fr-my-4w">

--- a/client/src/tests/e2e/contribuer.spec.js
+++ b/client/src/tests/e2e/contribuer.spec.js
@@ -15,6 +15,10 @@ test.describe("Basic form submission", () => {
     await description.fill(descriptionText);
     expect(await description.inputValue()).toBe(descriptionText);
 
+    const apiFormat = page.locator("label[for=dataformats-api]");
+    await apiFormat.check();
+    expect(await page.isChecked("input[value=api]")).toBeTruthy();
+
     const button = page.locator("button[type='submit']");
     const [request, response, _] = await Promise.all([
       page.waitForRequest("**/datasets/"),
@@ -26,6 +30,7 @@ test.describe("Basic form submission", () => {
     const json = await response.json();
     expect(json.title).toBe(titleText);
     expect(json.description).toBe(descriptionText);
+    expect(json.formats).toStrictEqual(["api"]);
     expect(json).toHaveProperty("id");
   });
 });

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -46,6 +46,7 @@ async def create_dataset(data: DatasetCreate) -> Dataset:
     command = CreateDataset(
         title=data.title,
         description=data.description,
+        formats=data.formats,
     )
 
     id = await bus.execute(command)
@@ -62,6 +63,7 @@ async def update_dataset(id: ID, data: DatasetUpdate) -> Dataset:
         id=id,
         title=data.title,
         description=data.description,
+        formats=data.formats,
     )
     try:
         await bus.execute(command)

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -1,22 +1,34 @@
+from typing import List
+
 from pydantic import BaseModel, validator
 
 from server.domain.common.types import ID
+from server.domain.datasets.entities import DataFormat
 
 
 class DatasetRead(BaseModel):
     id: ID
     title: str
     description: str
+    formats: List[DataFormat]
 
 
 class DatasetCreate(BaseModel):
     title: str
     description: str
+    formats: List[DataFormat]
+
+    @validator("formats")
+    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
+        if not value:
+            raise ValueError("formats must contain at least one item")
+        return value
 
 
 class DatasetUpdate(BaseModel):
     title: str
     description: str
+    formats: List[DataFormat]
 
     @validator("title")
     def check_title_not_empty(cls, value: str) -> str:
@@ -28,4 +40,10 @@ class DatasetUpdate(BaseModel):
     def check_description_not_empty(cls, value: str) -> str:
         if not value:
             raise ValueError("description must not be empty")
+        return value
+
+    @validator("formats")
+    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
+        if not value:
+            raise ValueError("formats must contain at least one item")
         return value

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -1,16 +1,21 @@
+from typing import List
+
 from server.domain.common.types import ID
+from server.domain.datasets.entities import DataFormat
 from server.seedwork.application.commands import Command
 
 
 class CreateDataset(Command[ID]):
     title: str
     description: str
+    formats: List[DataFormat]
 
 
 class UpdateDataset(Command[None]):
     id: ID
     title: str
     description: str
+    formats: List[DataFormat]
 
 
 class DeleteDataset(Command[None]):

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -16,6 +16,7 @@ async def create_dataset(command: CreateDataset) -> ID:
         id=repository.make_id(),
         title=command.title,
         description=command.description,
+        formats=command.formats,
     )
     return await repository.insert(dataset)
 
@@ -28,7 +29,11 @@ async def update_dataset(command: UpdateDataset) -> None:
     if dataset is None:
         raise DatasetDoesNotExist(pk)
 
-    dataset.update(title=command.title, description=command.description)
+    dataset.update(
+        title=command.title,
+        description=command.description,
+        formats=command.formats,
+    )
 
     await repository.update(dataset)
 

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -1,16 +1,30 @@
+import enum
+from typing import List
+
 from server.seedwork.domain.entities import Entity
 
 from ..common.types import ID
+
+
+class DataFormat(enum.Enum):
+    TABULAR_FILE = "file_tabular"
+    GIS_FILE = "file_gis"
+    API = "api"
+    DATABASE = "database"
+    WEBSITE = "website"
+    OTHER = "other"
 
 
 class Dataset(Entity):
     id: ID
     title: str
     description: str
+    formats: List[DataFormat]
 
     class Config:
         orm_mode = True
 
-    def update(self, title: str, description: str) -> None:
+    def update(self, title: str, description: str, formats: List[DataFormat]) -> None:
         self.title = title
         self.description = description
+        self.formats = formats

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -7,8 +7,8 @@ from ..common.types import ID
 
 
 class DataFormat(enum.Enum):
-    TABULAR_FILE = "file_tabular"
-    GIS_FILE = "file_gis"
+    FILE_TABULAR = "file_tabular"
+    FILE_GIS = "file_gis"
     API = "api"
     DATABASE = "database"
     WEBSITE = "website"

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -1,15 +1,38 @@
 import uuid
 from typing import List, Optional
 
-from sqlalchemy import Column, String, delete, insert, select, update
+from sqlalchemy import Column, Enum, ForeignKey, Integer, String, Table, select
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import relationship, selectinload
 
 from server.domain.common.types import ID
-from server.domain.datasets.entities import Dataset
+from server.domain.datasets.entities import DataFormat, Dataset
 from server.domain.datasets.repositories import DatasetRepository
 
 from ..database import Base, Database
+
+# Association table
+# See: https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#many-to-many
+dataset_dataformat = Table(
+    "dataset_dataformat",
+    Base.metadata,
+    Column("dataset_id", ForeignKey("dataset.id"), primary_key=True),
+    Column("dataformat_id", ForeignKey("dataformat.id"), primary_key=True),
+)
+
+
+class DataFormatModel(Base):
+    __tablename__ = "dataformat"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(Enum(DataFormat, name="dataformat_enum"), nullable=False, unique=True)
+    datasets: List["DatasetModel"] = relationship(
+        "DatasetModel",
+        back_populates="formats",
+        secondary=dataset_dataformat,
+    )
 
 
 class DatasetModel(Base):
@@ -18,6 +41,37 @@ class DatasetModel(Base):
     id: uuid.UUID = Column(UUID(as_uuid=True), primary_key=True)
     title = Column(String, nullable=False)
     description = Column(String, nullable=False)
+    formats: List[DataFormatModel] = relationship(
+        "DataFormatModel",
+        back_populates="datasets",
+        secondary=dataset_dataformat,
+    )
+
+
+def make_entity(instance: DatasetModel) -> Dataset:
+    return Dataset(
+        id=instance.id,
+        title=instance.title,
+        description=instance.description,
+        formats=[fmt.name for fmt in instance.formats],
+    )
+
+
+def make_instance(entity: Dataset, formats: List[DataFormatModel]) -> DatasetModel:
+    return DatasetModel(
+        id=entity.id,
+        title=entity.title,
+        description=entity.description,
+        formats=formats,
+    )
+
+
+def update_instance(
+    instance: DatasetModel, entity: Dataset, formats: List[DataFormatModel]
+) -> None:
+    instance.title = entity.title
+    instance.description = entity.description
+    instance.formats = formats
 
 
 class SqlDatasetRepository(DatasetRepository):
@@ -26,43 +80,73 @@ class SqlDatasetRepository(DatasetRepository):
 
     async def get_all(self) -> List[Dataset]:
         async with self._db.session() as session:
-            stmt = select(DatasetModel)
+            stmt = select(DatasetModel).options(selectinload(DatasetModel.formats))
             result = await session.execute(stmt)
-            objs = result.scalars().all()
-            return [Dataset.from_orm(obj) for obj in objs]
+            instances = result.scalars().all()
+            return [make_entity(instance) for instance in instances]
+
+    async def _get_format_instances(
+        self, session: AsyncSession, formats: List[DataFormat]
+    ) -> List[DataFormatModel]:
+        stmt = select(DataFormatModel).where(DataFormatModel.name.in_(formats))
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    async def _maybe_get_by_id(
+        self, session: AsyncSession, id: ID
+    ) -> Optional[DatasetModel]:
+        stmt = (
+            select(DatasetModel)
+            .where(DatasetModel.id == id)
+            .options(selectinload(DatasetModel.formats))
+        )
+        result = await session.execute(stmt)
+
+        try:
+            return result.scalar_one()
+        except NoResultFound:
+            return None
 
     async def get_by_id(self, id: ID) -> Optional[Dataset]:
         async with self._db.session() as session:
-            stmt = select(DatasetModel).where(DatasetModel.id == id)
-            result = await session.execute(stmt)
-            try:
-                obj = result.scalar_one()
-            except NoResultFound:
+            instance = await self._maybe_get_by_id(session, id)
+
+            if instance is None:
                 return None
-            else:
-                return Dataset.from_orm(obj)
+
+            return make_entity(instance)
 
     async def insert(self, entity: Dataset) -> ID:
         async with self._db.session() as session:
-            stmt = (
-                insert(DatasetModel).values(**entity.dict()).returning(DatasetModel.id)
-            )
-            result = await session.execute(stmt)
+            formats = await self._get_format_instances(session, entity.formats)
+            instance = make_instance(entity, formats)
+
+            session.add(instance)
+
             await session.commit()
-            return result.scalar_one()
+            await session.refresh(instance)
+
+            return ID(instance.id)
 
     async def update(self, entity: Dataset) -> None:
         async with self._db.session() as session:
-            stmt = (
-                update(DatasetModel)
-                .where(DatasetModel.id == entity.id)
-                .values(**entity.dict(exclude={"id"}))
-            )
-            await session.execute(stmt)
+            instance = await self._maybe_get_by_id(session, entity.id)
+
+            if instance is None:
+                return
+
+            formats = await self._get_format_instances(session, entity.formats)
+            update_instance(instance, entity, formats)
+
             await session.commit()
 
     async def delete(self, id: ID) -> None:
         async with self._db.session() as session:
-            stmt = delete(DatasetModel).where(DatasetModel.id == id)
-            await session.execute(stmt)
+            instance = await self._maybe_get_by_id(session, id)
+
+            if instance is None:
+                return
+
+            await session.delete(instance)
+
             await session.commit()

--- a/server/migrations/versions/1bef6a411f5c_dataset_add_formats.py
+++ b/server/migrations/versions/1bef6a411f5c_dataset_add_formats.py
@@ -16,8 +16,8 @@ branch_labels = None
 depends_on = None
 
 dataformat_values = (
-    "TABULAR_FILE",
-    "GIS_FILE",
+    "FILE_TABULAR",
+    "FILE_GIS",
     "API",
     "DATABASE",
     "WEBSITE",

--- a/server/migrations/versions/1bef6a411f5c_dataset_add_formats.py
+++ b/server/migrations/versions/1bef6a411f5c_dataset_add_formats.py
@@ -1,0 +1,60 @@
+"""dataset-add-formats
+
+Revision ID: 1bef6a411f5c
+Revises: 7b3e0dc2a28e
+Create Date: 2022-02-16 15:31:29.685734
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "1bef6a411f5c"
+down_revision = "7b3e0dc2a28e"
+branch_labels = None
+depends_on = None
+
+dataformat_values = (
+    "TABULAR_FILE",
+    "GIS_FILE",
+    "API",
+    "DATABASE",
+    "WEBSITE",
+    "OTHER",
+)
+
+dataformat_enum = sa.Enum(*dataformat_values, name="dataformat_enum")
+
+
+def upgrade():
+    dataformat_table = op.create_table(
+        "dataformat",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", dataformat_enum, nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "dataset_dataformat",
+        sa.Column("dataformat_id", sa.Integer(), nullable=False),
+        sa.Column("dataset_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["dataformat_id"],
+            ["dataformat.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["dataset_id"],
+            ["dataset.id"],
+        ),
+        sa.PrimaryKeyConstraint("dataformat_id", "dataset_id"),
+    )
+
+    # Add one row per data format
+    op.bulk_insert(dataformat_table, [{"name": value} for value in dataformat_values])
+
+
+def downgrade():
+    op.drop_table("dataset_dataformat")
+    op.drop_table("dataformat")

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -23,6 +23,16 @@ from server.seedwork.application.messages import MessageBus
             ],
             id="missing-fields",
         ),
+        pytest.param(
+            {"title": "Title", "description": "Description", "formats": []},
+            [
+                {
+                    "loc": ["body", "formats"],
+                    "msg": "formats must contain at least one item",
+                }
+            ],
+            id="formats-empty",
+        ),
     ],
 )
 async def test_create_dataset_invalid(

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -5,6 +5,7 @@ from server.application.datasets.commands import CreateDataset
 from server.application.datasets.queries import GetDatasetByID
 from server.config.di import resolve
 from server.domain.common.types import id_factory
+from server.domain.datasets.entities import DataFormat
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
@@ -18,6 +19,7 @@ from server.seedwork.application.messages import MessageBus
             [
                 {"loc": ["body", "title"], "type": "value_error.missing"},
                 {"loc": ["body", "description"], "type": "value_error.missing"},
+                {"loc": ["body", "formats"], "type": "value_error.missing"},
             ],
             id="missing-fields",
         ),
@@ -38,12 +40,13 @@ async def test_create_dataset_invalid(
 
 
 @pytest.mark.asyncio
-async def test_create_dataset(client: httpx.AsyncClient) -> None:
+async def test_dataset_crud(client: httpx.AsyncClient) -> None:
     response = await client.post(
         "/datasets/",
         json={
             "title": "Example",
             "description": "Some example items",
+            "formats": ["website"],
         },
     )
     assert response.status_code == 201
@@ -54,6 +57,7 @@ async def test_create_dataset(client: httpx.AsyncClient) -> None:
         "id": pk,
         "title": "Example",
         "description": "Some example items",
+        "formats": ["website"],
     }
 
     non_existing_id = id_factory()
@@ -80,7 +84,9 @@ async def test_create_dataset(client: httpx.AsyncClient) -> None:
 
 
 CREATE_EXAMPLE_DATASET = CreateDataset(
-    title="Example title", description="Example description"
+    title="Example title",
+    description="Example description",
+    formats=["website", "api"],
 )
 
 
@@ -89,7 +95,11 @@ class TestDatasetUpdate:
     async def test_not_found(self, client: httpx.AsyncClient) -> None:
         response = await client.put(
             f"/datasets/{id_factory()}/",
-            json={"title": "Title", "description": "Description"},
+            json={
+                "title": "Title",
+                "description": "Description",
+                "formats": ["website"],
+            },
         )
         assert response.status_code == 404
 
@@ -100,22 +110,25 @@ class TestDatasetUpdate:
         # Apply PUT semantics, which expect a full entity.
         response = await client.put(f"/datasets/{dataset_id}/", json={})
         assert response.status_code == 422
-        err_title, err_description = response.json()["detail"]
+        err_title, err_description, err_formats = response.json()["detail"]
         assert err_title["loc"] == ["body", "title"]
         assert err_title["type"] == "value_error.missing"
         assert err_description["loc"] == ["body", "description"]
         assert err_description["type"] == "value_error.missing"
+        assert err_formats["loc"] == ["body", "formats"]
+        assert err_formats["type"] == "value_error.missing"
 
     async def test_fields_empty_invalid(self, client: httpx.AsyncClient) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_EXAMPLE_DATASET)
 
         response = await client.put(
-            f"/datasets/{dataset_id}/", json={"title": "", "description": ""}
+            f"/datasets/{dataset_id}/",
+            json={"title": "", "description": "", "formats": []},
         )
         assert response.status_code == 422
 
-        err_title, err_description = response.json()["detail"]
+        err_title, err_description, err_formats = response.json()["detail"]
 
         assert err_title["loc"] == ["body", "title"]
         assert "empty" in err_title["msg"]
@@ -123,13 +136,20 @@ class TestDatasetUpdate:
         assert err_description["loc"] == ["body", "description"]
         assert "empty" in err_description["msg"]
 
+        assert err_formats["loc"] == ["body", "formats"]
+        assert "at least one" in err_formats["msg"].lower()
+
     async def test_update(self, client: httpx.AsyncClient) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_EXAMPLE_DATASET)
 
         response = await client.put(
             f"/datasets/{dataset_id}/",
-            json={"title": "Other title", "description": "Other description"},
+            json={
+                "title": "Other title",
+                "description": "Other description",
+                "formats": ["database"],
+            },
         )
         assert response.status_code == 200
 
@@ -138,6 +158,7 @@ class TestDatasetUpdate:
             "id": str(dataset_id),
             "title": "Other title",
             "description": "Other description",
+            "formats": ["database"],
         }
 
         # Entity was indeed updated
@@ -145,6 +166,40 @@ class TestDatasetUpdate:
         dataset = await bus.execute(query)
         assert dataset.title == "Other title"
         assert dataset.description == "Other description"
+        assert dataset.formats == [DataFormat.DATABASE]
+
+
+@pytest.mark.asyncio
+class TestFormats:
+    async def test_formats_add(self, client: httpx.AsyncClient) -> None:
+        bus = resolve(MessageBus)
+        dataset_id = await bus.execute(CREATE_EXAMPLE_DATASET)
+
+        response = await client.put(
+            f"/datasets/{dataset_id}/",
+            json={
+                **CREATE_EXAMPLE_DATASET.dict(exclude={"formats"}),
+                "formats": ["website", "api", "file_gis"],
+            },
+        )
+
+        assert response.status_code == 200
+        assert sorted(response.json()["formats"]) == ["api", "file_gis", "website"]
+
+    async def test_formats_remove(self, client: httpx.AsyncClient) -> None:
+        bus = resolve(MessageBus)
+        dataset_id = await bus.execute(CREATE_EXAMPLE_DATASET)
+
+        response = await client.put(
+            f"/datasets/{dataset_id}/",
+            json={
+                **CREATE_EXAMPLE_DATASET.dict(exclude={"formats"}),
+                "formats": ["website"],
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["formats"] == ["website"]
 
 
 @pytest.mark.asyncio

--- a/tests/domain/test_datasets.py
+++ b/tests/domain/test_datasets.py
@@ -5,7 +5,7 @@ import pytest
 from server.application.datasets.queries import GetAllDatasets
 from server.config.di import override, resolve
 from server.domain.common.types import id_factory
-from server.domain.datasets.entities import Dataset
+from server.domain.datasets.entities import DataFormat, Dataset
 from server.domain.datasets.repositories import DatasetRepository
 from server.seedwork.application.messages import MessageBus
 
@@ -20,9 +20,24 @@ async def test_datasets_get_all() -> None:
             return self.items
 
     mock_datasets = [
-        Dataset(id=id_factory(), title="mock0", description="mock0-desc"),
-        Dataset(id=id_factory(), title="mock1", description="mock1-desc"),
-        Dataset(id=id_factory(), title="mock2", description="mock2-desc"),
+        Dataset(
+            id=id_factory(),
+            title="mock0",
+            description="mock0-desc",
+            formats=[DataFormat.WEBSITE],
+        ),
+        Dataset(
+            id=id_factory(),
+            title="mock1",
+            description="mock1-desc",
+            formats=[DataFormat.WEBSITE],
+        ),
+        Dataset(
+            id=id_factory(),
+            title="mock2",
+            description="mock2-desc",
+            formats=[DataFormat.WEBSITE],
+        ),
     ]
 
     with override() as container:


### PR DESCRIPTION
Closes #70 

* API :
  * Champ `formats` pouvant contenir des valeurs parmi les valeurs attendues.
  * Implémentation sous la forme d'un _many-to-many_ (plutôt qu'un array d'enum) pour permettre les requêtes (pour le coup, il faut anticiper les filtres).
* Front :+1: 
  * Ajout champ `formats` dans le formulaire de contribution, sous forme de checkboxes
  * Branchement sur la liste du catalogue : les formats sont maintenant dynamiques

TODO :

- [x] Mettre à jour tests frontend

N.B. :

- Le champ "Autre" est pour l'instant une option comme une autre. La possibilité de spécifier une valeur libre reste en TODO (pour une autre PR)

Ressources :

- Doc DSFR utilisée pour la liste de checkboxes : https://gouvfr.atlassian.net/wiki/spaces/DB/pages/217251933/Case+cocher+-+Checkbox#Liste-avec-texte-d%E2%80%99aide

## Aperçus

![contribuer](https://user-images.githubusercontent.com/15911462/154332629-c50f1dce-23e2-4342-8f74-89bbea27d83b.png) (63 kB)

![error](https://user-images.githubusercontent.com/15911462/154332646-d2b78adc-3450-453c-843d-397bc3dd4781.png)  (34 kB)

![catalogue](https://user-images.githubusercontent.com/15911462/154332740-a7b1302d-3500-45dd-ac7b-ccb9a054762d.png) (52 kB)