### PR TITLE
Add complete Docker Compose local setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+venv/
+.mypy_cache/
+.pytest_cache/
+**/node_modules/
+**/.vagrant/
+.vscode/
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ serve-dist: #- Serve both the server and the built client in parallel
 serve-dist-client: #- Run the built client 
 	./tools/colorize_prefix.sh [client] 33 "cd client && npm start"
 
-up: #- Start Docker Compose setup
+compose-up: #- Start Docker Compose setup
 	docker-compose up --build -d
 
-down: #- Stop and teardown Docker Compose setup
+compose-down: #- Stop and teardown Docker Compose setup
 	docker-compose down
 
 migrate: #- Apply pending migrations

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ serve-dist-client: #- Run the built client
 
 compose-up: #- Start Docker Compose setup
 	docker-compose up --build -d
+	docker-compose run migrate
 
 compose-down: #- Stop and teardown Docker Compose setup
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ serve-dist: #- Serve both the server and the built client in parallel
 serve-dist-client: #- Run the built client 
 	./tools/colorize_prefix.sh [client] 33 "cd client && npm start"
 
+up: #- Start Docker Compose setup
+	docker-compose up --build -d
+
+down: #- Stop and teardown Docker Compose setup
+	docker-compose down
+
 migrate: #- Apply pending migrations
 	${bin}alembic upgrade head
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      VITE_API_BROWSER_URL: "http://localhost:3000"
+      VITE_API_BROWSER_URL: "http://localhost:3579"
       VITE_API_SSR_URL: "http://server:3579"
     volumes:
       - "./client/src:/app/client/src"
@@ -31,13 +31,21 @@ services:
     build:
       context: .
       dockerfile: ./docker/server.Dockerfile
+    image: catalogage-server
     container_name: catalogage-server
     ports:
       - "3579:3579"
     environment:
       APP_HOST: "0.0.0.0"
-      APP_DATABASE_URL: "postgresql+asyncpg://user:pass@db/catalogage"
+      APP_DATABASE_URL: "postgresql+asyncpg://user:pass@db:5432/catalogage"
     restart: always
+
+  migrate:
+    image: catalogage-server
+    profiles: ["cli"]
+    command: ./tools/wait-for-it.sh db:5432 -- make migrate
+    environment:
+      APP_DATABASE_URL: "postgresql+asyncpg://user:pass@db:5432/catalogage"
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3'
-
+version: "3"
 
 services:
-  postgresql:
+  db:
     image: postgres:12
-    container_name: catalogage-pg
+    container_name: catalogage-db
     ports:
       - "5432:5432"
     environment:
@@ -12,7 +11,33 @@ services:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=pass
     volumes:
-      - pgdata:/var/lib/postgresql/data/ # persist data even if container shuts down
+      - pgdata:/var/lib/postgresql/data/
+
+  client:
+    build:
+      context: .
+      dockerfile: ./docker/client.Dockerfile
+    container_name: catalogage-client
+    ports:
+      - "3000:3000"
+    environment:
+      VITE_API_BROWSER_URL: "http://localhost:3000"
+      VITE_API_SSR_URL: "http://server:3579"
+    volumes:
+      - "./client/src:/app/client/src"
+    restart: always
+
+  server:
+    build:
+      context: .
+      dockerfile: ./docker/server.Dockerfile
+    container_name: catalogage-server
+    ports:
+      - "3579:3579"
+    environment:
+      APP_HOST: "0.0.0.0"
+      APP_DATABASE_URL: "postgresql+asyncpg://user:pass@db/catalogage"
+    restart: always
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:12
     container_name: catalogage-db
     ports:
-      - "5432:5432"
+      - "6432:5432"
     environment:
       - POSTGRES_DB=catalogage
       - POSTGRES_USER=user

--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16 AS base
+WORKDIR /app/
+COPY ./client/package.json ./client/package-lock.json ./client/
+
+FROM base AS dependencies
+RUN cd client && npm ci
+
+FROM base AS release
+COPY --from=dependencies /app/client/node_modules ./client/node_modules
+COPY . .
+EXPOSE 3000
+WORKDIR /app/client
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8 AS base
+WORKDIR /app/
+
+FROM base AS dependencies
+COPY ./requirements.txt ./
+RUN python3 -m venv venv && \
+    venv/bin/pip install -U pip wheel setuptools && \
+    venv/bin/pip install -r requirements.txt
+
+FROM base AS release
+COPY --from=dependencies /app/venv ./venv
+COPY . .
+EXPOSE 3579
+CMD ["venv/bin/python", "-m", "server.main"]

--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -2,6 +2,47 @@
 
 Cette page indique les quelques étapes qui vous permettront d'avoir un projet fonctionnel à partir duquel travailler.
 
+* 👉 Je suis une personne non-technique et je souhaite rapidement lancer le projet : jetez un oeil à [Raccourci : usage Docker](#raccourci--usage-docker)
+* 👉 Je suis une personne technique et je souhaite participer au développement détaillé : suivez le guide !
+
+**Table des matières**
+
+* [Usage Docker](#raccourci--usage-docker)
+* [Prérequis](#pr%C3%A9requis)
+* [Interagir avec le projet](#interagir-avec-le-projet)
+* [Configuration](#configuration)
+
+---
+
+## Usage Docker
+
+Pour faciliter un démarrage rapide du projet, une configuration `docker-compose` est disponible, comprenant le serveur, le client, et une base de données.
+
+Installez d'abord les outils nécessaires :
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+Puis lancez :
+
+```
+make up
+```
+
+Le client (application web) sera alors disponible sur http://localhost:3000.
+
+Le client se rechargera automatiquement après des modifications dans le dossier `client/src/`, ce qui vous permettra d'y faire des modifications et de voir rapidement le résultat.
+
+Pour toute autre modification, il faudra relancer Docker Compose : `make down` puis `make up`.
+
+Pour arrêter le Docker Compose :
+
+```
+make down
+```
+
+---
+
 ## Prérequis
 
 Selon que vous vouliez contribuer au serveur ou au client, vous allez avoir besoin de :
@@ -26,13 +67,22 @@ Si vous avez un [serveur PostgreSQL](https://www.postgresql.org/download/linux/)
 createdb catalogage
 ```
 
-Sinon, vous pouvez utiliser [Docker Compose](https://docs.docker.com/compose/install/) :
+Sinon, vous pouvez utiliser la configuration `docker-compose` (voir [Raccourci : usage Docker](#raccourci--usage-docker)) :
 
 ```bash
-docker-compose up
+docker-compose up -d -- db
 ```
 
-Assurez-vous de [configurer](#configuration) votre `APP_DATABASE_URL` en conséquence.
+[Configurez](#configuration) ensuite votre `APP_DATABASE_URL` :
+
+```
+cp .env.example .env
+```
+
+```bash
+# .env
+APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/${DB:-catalogage}"
+```
 
 ## Interagir avec le projet
 
@@ -97,35 +147,29 @@ make check
 
 ## Configuration
 
-Le serveur d'API est configurable à l'aide des variables d'environnement suivantes.
+Le projet est configurable à l'aide des variables d'environnement suivantes.
 
 | Variable | Description | Valeur par défaut |
 |---|---|---|
-| `APP_SERVER_MODE` | Un mode d'opération qui configure Uvicorn en conséquence : <br> - `local` : pour le développement local (_hot reload_ activé, etc) <br> - `live` : pour tout déploiement tel que défini via Ansible (voir [Opérations](./ops.md)) | `local` |
 | `APP_DATABASE_URL` | URL vers la base de données PostgreSQL | `postgresql+asyncpg://localhost:5432/catalogage` |
-| `APP_PORT` | Port du server d'API | `3579` |
-| `VITE_API_BROWSER_URL` | (1) URL utilisée par le navigateur lors de requêtes d'API | `http://localhost:3579` |
-| `VITE_API_SSR_URL` | (1) URL utilisée par le serveur frontend lors de requêtes d'API | `http://localhost:3579` |
 
-> Notes : 
->
-> * (1) Ces options n'existent que pour la configuration de production, où le service est déployé via Nginx. Elles ne doivent typiquement pas être modifiées lors du développement local.
+Définissez les valeurs spécifiques à votre situation dans un fichier `.env` placé à la racine du projet, que vous pouvez créer à partir du modèle `.env.example` :
 
-Définissez les valeurs spécifiques à votre situation dans un fichier `.env` placé à la racine du projet, que vous pouvez créer à partir du modèle `.env.example`.
+```
+cp .env .env.example
+```
 
 Les variables peuvent aussi être passées en arguments, elles sont alors utilisées en priorité par rapport au `.env`. Par exemple :
 
 ```bash
-APP_DATABASE_URL="..." make serve
+APP_DATABASE_URL="postgresql+asyncpg://..." make serve
 ```
 
-## Tests
+Des paramètres avancés (principalement dédiés au déploiement - voir [Opérations](./ops.md)) sont également disponibles :
 
-### Tests unitaires - Client
-
-Les tests unitaires côté client utilisent [`svelte-testing-library`](https://github.com/testing-library/svelte-testing-library).
-
-Autres ressources pour démarrer :
-
-- [Svelte Testing Library: Example](https://testing-library.com/docs/svelte-testing-library/example)
-- [Unit Testing Svelte Components](https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component/)
+| Variable | Description | Valeur par défaut |
+|---|---|---|
+| `APP_SERVER_MODE` | Un mode d'opération qui configure Uvicorn en conséquence : <br> - `local` : pour le développement local (_hot reload_ activé, etc) <br> - `live` : pour tout déploiement tel que défini via Ansible | `local` |
+| `APP_PORT` | Port du server d'API | `3579` |
+| `VITE_API_BROWSER_URL` | URL utilisée par le navigateur lors de requêtes d'API. En mode `live`, indiquer le chemin vers l'API configuré sur Nginx : `/api`. | `http://localhost:3579` |
+| `VITE_API_SSR_URL` | URL utilisée par le serveur frontend lors de requêtes d'API | `http://localhost:3579` |

--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -2,12 +2,12 @@
 
 Cette page indique les quelques étapes qui vous permettront d'avoir un projet fonctionnel à partir duquel travailler.
 
-* 👉 Je suis une personne non-technique et je souhaite rapidement lancer le projet : jetez un oeil à [Raccourci : usage Docker](#raccourci--usage-docker)
+* 👉 Je suis une personne non-technique et je souhaite rapidement lancer le projet : jetez un oeil à [Usage Docker](#usage-docker)
 * 👉 Je suis une personne technique et je souhaite participer au développement détaillé : suivez le guide !
 
 **Table des matières**
 
-* [Usage Docker](#raccourci--usage-docker)
+* [Usage Docker](#usage-docker)
 * [Prérequis](#pr%C3%A9requis)
 * [Interagir avec le projet](#interagir-avec-le-projet)
 * [Configuration](#configuration)
@@ -67,7 +67,7 @@ Si vous avez un [serveur PostgreSQL](https://www.postgresql.org/download/linux/)
 createdb catalogage
 ```
 
-Sinon, vous pouvez utiliser la configuration `docker-compose` (voir [Raccourci : usage Docker](#raccourci--usage-docker)) :
+Sinon, vous pouvez utiliser la configuration `docker-compose` (voir [Usage Docker](#usage-docker)) :
 
 ```bash
 docker-compose up -d -- db

--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -26,19 +26,19 @@ Installez d'abord les outils nécessaires :
 Puis lancez :
 
 ```
-make up
+make compose-up
 ```
 
 Le client (application web) sera alors disponible sur http://localhost:3000.
 
 Le client se rechargera automatiquement après des modifications dans le dossier `client/src/`, ce qui vous permettra d'y faire des modifications et de voir rapidement le résultat.
 
-Pour toute autre modification, il faudra relancer Docker Compose : `make down` puis `make up`.
+Pour toute autre modification, il faudra relancer Docker Compose : `make compose-down` puis `make compose-up`.
 
 Pour arrêter le Docker Compose :
 
 ```
-make down
+make compose-down
 ```
 
 ---

--- a/docs/fr/outils.md
+++ b/docs/fr/outils.md
@@ -44,12 +44,23 @@ Ce projet est équipé du _type checking_ avec [`mypy`](https://mypy.readthedocs
 
 La vérification se fait avec une exécution standard de `$ mypy` lors de `make check`.
 
-## Playwright
+## Tests
+
+### Tests E2E
 
 Les tests _end-to-end_ sont lancés avec [`Playwright`](https://playwright.dev/).
 Il sont soit exécutés en mode _ci_ (continuous integration, par exemple dans
 notre cas avec github actions), et donc en _headless_, soit de manière
 interactive (en dev).
+
+### Tests unitaires - Client
+
+Les tests unitaires côté client utilisent [`svelte-testing-library`](https://github.com/testing-library/svelte-testing-library).
+
+Autres ressources pour démarrer :
+
+- [Svelte Testing Library: Example](https://testing-library.com/docs/svelte-testing-library/example)
+- [Unit Testing Svelte Components](https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component/)
 
 ## DSFR
 

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -3,7 +3,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from server.config import Settings
 from server.config.di import resolve
-from server.infrastructure.database import Database
 
 from .routes import router
 
@@ -13,11 +12,9 @@ origins = [
 
 
 def create_app() -> FastAPI:
-    db = resolve(Database)
     settings = resolve(Settings)
 
     app = FastAPI(
-        on_startup=[db.create_all],
         docs_url=settings.docs_url,
     )
     app.add_middleware(

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
 
     server_mode: ServerMode = "local"
     database_url: str = "postgresql+asyncpg://localhost:5432/catalogage"
+    host: str = "localhost"
     port: int = 3579
     docs_url: str = "/docs"
     testing: bool = False

--- a/server/infrastructure/database.py
+++ b/server/infrastructure/database.py
@@ -13,9 +13,5 @@ class Database:
             self._engine, autocommit=False, autoflush=False, class_=AsyncSession
         )
 
-    async def create_all(self) -> None:
-        async with self._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-
     def session(self) -> AsyncSession:
         return self._session_cls()

--- a/server/main.py
+++ b/server/main.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     settings = resolve(Settings)
 
     kwargs: dict = {
-        "host": "127.0.0.1",
+        "host": settings.host,
         "port": settings.port,
     }
 

--- a/tools/wait-for-it.sh
+++ b/tools/wait-for-it.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Copied from: https://github.com/vishnubob/wait-for-it
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
Closes #68 

J'avais déjà commencé qqc, je l'ai terminé :

* Mise à jour du `docker-compose.yml` pour qu'il lance aussi server + client
* Mise à jour de la doc
* Petits modifs au serveur : `host` configurable (doit être `0.0.0.0` dans Docker), retrait de `db.create_all()` (outil SQLAlchemy sensé créer automatiquement les tables "on startup", mais en fait on le fait explicitement avec `make migrate`, et ça entrait en conflit avec un `make migrate` juste après le démarrage du container : "tables already exist")

Fonctionnalités :

* Démarrage de la stack complète avec `make compose-up`
* Le client se recharge automatiquement en cas de modifs dans `client/src/`

@DaFrenchFrog Tu veux tester ? :)

```
git fetch
git checkout fm/compose
make compose-up
```