### PR TITLE
Fix e2e test fixtures

### DIFF
--- a/client/src/tests/e2e/fixtures.js
+++ b/client/src/tests/e2e/fixtures.js
@@ -1,65 +1,59 @@
-/**
- * @typedef {import("@playwright/test").APIRequestContext} APIRequestContext
- * @typedef {import("src/definitions/datasets").Dataset} Dataset
- * @typedef {import("src/definitions/datasets").DatasetCreateData} DatasetCreateData
- */
 import { test as base, expect } from "@playwright/test";
 
-// See: https://playwright.dev/docs/test-fixtures
+/**
+ * These fixtures allow simplifying setup/teardown logic in tests,
+ * especially for preparing server-side state.
+ * See: https://playwright.dev/docs/test-fixtures
+ * See: https://playwright.dev/docs/test-api-testing#sending-api-requests-from-ui-tests
+ */
 
 /**
- * @type {import("@playwright/test").Fixtures<{
- *  page: any,
- *  sampleDataset: Dataset
- * }>}
+ * This is JSDoc annotations. We use them while waiting for Playwright TS setup to land.
+ * See: https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html
+ * See: https://github.com/etalab/catalogage-donnees/issues/87
+ *
+ * @typedef {{
+ *  apiContext: import("@playwright/test").APIRequestContext,
+ *  dataset: import("src/definitions/datasets").Dataset,
+ * }} AppTestArgs
+ *
+ * @typedef {{}} AppWorkerArgs
+ *
+ * @typedef {import("@playwright/test").PlaywrightTestArgs} PlaywrightTestArgs
+ * @typedef {import("@playwright/test").PlaywrightWorkerArgs} PlaywrightWorkerArgs
+ *
+ * @typedef {import("@playwright/test").Fixtures<
+ *  AppTestArgs, AppWorkerArgs, PlaywrightTestArgs, PlaywrightWorkerArgs
+ * >} AppFixtures
+ */
+
+/**
+ * @type AppFixtures
  */
 const fixtures = {
-  sampleDataset: async ({ page }, use) => {
-    const [dataset, disposeDataset] = await getSampleDataset();
+  apiContext: async ({ playwright }, use) => {
+    const baseURL = "http://localhost:3579";
+    const apiContext = await playwright.request.newContext({ baseURL });
+    await use(apiContext);
+    await apiContext.dispose();
+  },
+
+  dataset: async ({ apiContext }, use) => {
+    /** @type {import("src/definitions/datasets").DatasetCreateData} */
+    const data = {
+      title: "Sample title",
+      description: "Sample description",
+      formats: ["api"],
+    };
+    let response = await apiContext.post("/datasets/", { data });
+    expect(response.ok()).toBeTruthy();
+    const dataset = await response.json();
+
     await use(dataset);
-    await disposeDataset();
+
+    response = await apiContext.delete(`/datasets/${dataset.id}/`);
+    expect(response.ok()).toBeTruthy();
   },
 };
 
 export const test = base.extend(fixtures);
-
-// See: https://playwright.dev/docs/test-api-testing#sending-api-requests-from-ui-tests
-
-/** @type {APIRequestContext} */
-let apiContext;
-
-test.beforeAll(async ({ playwright }) => {
-  apiContext = await playwright.request.newContext({
-    baseURL: "http://localhost:3579",
-  });
-});
-
-test.afterAll(async () => {
-  await apiContext.dispose();
-});
-
-/**
- *
- * @returns {Promise<[Dataset, () => Promise<void>]>}
- */
-const getSampleDataset = async () => {
-  /** @type {DatasetCreateData} */
-  const data = {
-    title: "Sample title",
-    description: "Sample description",
-    formats: ["api"],
-  };
-
-  let response = await apiContext.post("/datasets/", { data });
-  expect(response.ok()).toBeTruthy();
-
-  /** @type {Dataset} */
-  const dataset = await response.json();
-
-  const disposeDataset = async () => {
-    response = await apiContext.delete(`/datasets/${dataset.id}/`);
-    expect(response.ok()).toBeTruthy();
-  };
-
-  return [dataset, disposeDataset];
-};

--- a/client/src/tests/e2e/home.spec.js
+++ b/client/src/tests/e2e/home.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "./fixtures.js";
 
 test.describe("Catalog list", () => {
-  test("Visits the home page", async ({ page, sampleDataset }) => {
+  test("Visits the home page", async ({ page, dataset }) => {
     await page.goto("/");
 
     await expect(page).toHaveTitle("Catalogue");


### PR DESCRIPTION
Correctif suite à la tentative d'inclure #90 dans #88.

Je n'avais pas bien compris le typage des fixtures, ni que malgré ce qu'indique la doc de Playwright, il était préférable de créer une fixture pour le `apiContext` aussi (sinon en l'état, la valeur globale était malmenée par les tests lancés en //).