### PR TITLE
Make SQL debug logs configurable

### DIFF
--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -152,6 +152,7 @@ Le projet est configurable à l'aide des variables d'environnement suivantes.
 | Variable | Description | Valeur par défaut |
 |---|---|---|
 | `APP_DATABASE_URL` | URL vers la base de données PostgreSQL | `postgresql+asyncpg://localhost:5432/catalogage` |
+| `APP_SQL_DEBUG` | Active les journeaux de débogage (_debug logs_) des requêtes SQL effectuées par le serveur | `False` |
 
 Définissez les valeurs spécifiques à votre situation dans un fichier `.env` placé à la racine du projet, que vous pouvez créer à partir du modèle `.env.example` :
 
@@ -159,10 +160,12 @@ Définissez les valeurs spécifiques à votre situation dans un fichier `.env` p
 cp .env .env.example
 ```
 
-Les variables peuvent aussi être passées en arguments, elles sont alors utilisées en priorité par rapport au `.env`. Par exemple :
+Les variables peuvent aussi être passées en arguments, elles sont alors utilisées en priorité par rapport au `.env`.
+
+Par exemple :
 
 ```bash
-APP_DATABASE_URL="postgresql+asyncpg://..." make serve
+APP_SQL_DEBUG=1 make serve
 ```
 
 Des paramètres avancés (principalement dédiés au déploiement - voir [Opérations](./ops.md)) sont également disponibles :

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -133,7 +133,10 @@ def create_container() -> punq.Container:
 
     # Databases
 
-    container.register(Database, instance=Database(url=settings.env_database_url))
+    container.register(
+        Database,
+        instance=Database(url=settings.env_database_url, debug=settings.sql_debug),
+    )
 
     # Repositories
 

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     host: str = "localhost"
     port: int = 3579
     docs_url: str = "/docs"
+    sql_debug: bool = False
     testing: bool = False
 
     class Config:

--- a/server/infrastructure/database.py
+++ b/server/infrastructure/database.py
@@ -7,8 +7,8 @@ Base = declarative_base()
 
 
 class Database:
-    def __init__(self, url: str) -> None:
-        self._engine = create_async_engine(url, echo=True, json_serializer=json.dumps)
+    def __init__(self, url: str, debug: bool = False) -> None:
+        self._engine = create_async_engine(url, echo=debug, json_serializer=json.dumps)
         self._session_cls = sessionmaker(
             self._engine, autocommit=False, autoflush=False, class_=AsyncSession
         )


### PR DESCRIPTION
Closes #89 

Les debug logs SQL ne sont maintenant affichés que si l'on passe une valeur "truthy" (1, true, True, etc) à `APP_SQL_DEBUG` lors du lancement du serveur.

L'idée est que l'on activerait ces logs que pour de l'optimisation de la BDD ou du débogage.