### PR TITLE
Add basic plain text search

### DIFF
--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -8,7 +8,11 @@ from server.application.datasets.commands import (
     DeleteDataset,
     UpdateDataset,
 )
-from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
+from server.application.datasets.queries import (
+    GetAllDatasets,
+    GetDatasetByID,
+    SearchDatasets,
+)
 from server.config.di import resolve
 from server.domain.common.types import ID
 from server.domain.datasets.entities import Dataset
@@ -21,8 +25,12 @@ router = APIRouter(prefix="/datasets", tags=["datasets"])
 
 
 @router.get("/", response_model=List[DatasetRead])
-async def list_datasets() -> List[Dataset]:
+async def list_datasets(q: str = None) -> List[Dataset]:
     bus = resolve(MessageBus)
+
+    if q is not None:
+        query = SearchDatasets(q=q)
+        return await bus.execute(query)
 
     query = GetAllDatasets()
     return await bus.execute(query)

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -7,7 +7,7 @@ from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.repositories import DatasetRepository
 
 from .commands import CreateDataset, DeleteDataset, UpdateDataset
-from .queries import GetAllDatasets, GetDatasetByID
+from .queries import GetAllDatasets, GetDatasetByID, SearchDatasets
 
 
 async def create_dataset(command: CreateDataset) -> ID:
@@ -58,3 +58,8 @@ async def get_dataset_by_id(query: GetDatasetByID) -> Dataset:
         raise DatasetDoesNotExist(id)
 
     return dataset
+
+
+async def search_datasets(query: SearchDatasets) -> List[Dataset]:
+    repository = resolve(DatasetRepository)
+    return await repository.search(q=query.q)

--- a/server/application/datasets/queries.py
+++ b/server/application/datasets/queries.py
@@ -11,3 +11,7 @@ class GetAllDatasets(Query[List[Dataset]]):
 
 class GetDatasetByID(Query[Dataset]):
     id: ID
+
+
+class SearchDatasets(Query[List[Dataset]]):
+    q: str

--- a/server/domain/datasets/repositories.py
+++ b/server/domain/datasets/repositories.py
@@ -13,6 +13,9 @@ class DatasetRepository(Repository):
     async def get_all(self) -> List[Dataset]:
         raise NotImplementedError  # pragma: no cover
 
+    async def search(self, q: str) -> List[Dataset]:
+        raise NotImplementedError  # pragma: no cover
+
     async def get_by_id(self, id: ID) -> Optional[Dataset]:
         raise NotImplementedError  # pragma: no cover
 

--- a/server/infrastructure/datasets/module.py
+++ b/server/infrastructure/datasets/module.py
@@ -8,9 +8,14 @@ from server.application.datasets.handlers import (
     delete_dataset,
     get_all_datasets,
     get_dataset_by_id,
+    search_datasets,
     update_dataset,
 )
-from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
+from server.application.datasets.queries import (
+    GetAllDatasets,
+    GetDatasetByID,
+    SearchDatasets,
+)
 from server.seedwork.application.modules import Module
 
 
@@ -24,4 +29,5 @@ class DatasetsModule(Module):
     query_handlers = {
         GetAllDatasets: get_all_datasets,
         GetDatasetByID: get_dataset_by_id,
+        SearchDatasets: search_datasets,
     }

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from sqlalchemy import (
     Column,
@@ -15,14 +15,13 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import TSVECTOR, UUID
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, relationship, selectinload
+from sqlalchemy.orm import relationship, selectinload, Mapped
 
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, Dataset
 from server.domain.datasets.repositories import DatasetRepository
 
 from ..database import Base, Database
-from ..utils.sql import to_tsvector
 
 # Association table
 # See: https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#many-to-many
@@ -57,9 +56,9 @@ class DatasetModel(Base):
         back_populates="datasets",
         secondary=dataset_dataformat,
     )
-    search_tsv: Mapped[Any] = Column(
+    search_tsv: Mapped[str] = Column(
         TSVECTOR,
-        Computed(to_tsvector("title", "description", lang="french"), persisted=True),
+        Computed("to_tsvector('french', title || ' ' || description)", persisted=True),
     )
 
     __table_args__ = (

--- a/server/infrastructure/utils/sql.py
+++ b/server/infrastructure/utils/sql.py
@@ -1,3 +1,0 @@
-def to_tsvector(*columns: str, lang: str) -> str:
-    s = " || ' ' || ".join(columns)
-    return f"to_tsvector('{lang}', {s})"

--- a/server/infrastructure/utils/sql.py
+++ b/server/infrastructure/utils/sql.py
@@ -1,0 +1,3 @@
+def to_tsvector(*columns: str, lang: str) -> str:
+    s = " || ' ' || ".join(columns)
+    return f"to_tsvector('{lang}', {s})"

--- a/server/migrations/versions/cc869b534916_add_dataset_search_tsv.py
+++ b/server/migrations/versions/cc869b534916_add_dataset_search_tsv.py
@@ -1,0 +1,42 @@
+"""add-dataset-search-tsv
+
+Revision ID: cc869b534916
+Revises: 1bef6a411f5c
+Create Date: 2022-02-22 19:11:56.402112
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "cc869b534916"
+down_revision = "1bef6a411f5c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "dataset",
+        sa.Column(
+            "search_tsv",
+            postgresql.TSVECTOR(),
+            sa.Computed(
+                "to_tsvector('french', title || ' ' || description)", persisted=True
+            ),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_dataset_search_tsv",
+        "dataset",
+        ["search_tsv"],
+        unique=False,
+        postgresql_using="GIN",
+    )
+
+
+def downgrade():
+    op.drop_index("ix_dataset_search_tsv", table_name="dataset", postgresql_using="GIN")
+    op.drop_column("dataset", "search_tsv")

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -1,0 +1,82 @@
+from typing import AsyncIterator, List
+
+import httpx
+import pytest
+
+from server.application.datasets.commands import CreateDataset, DeleteDataset
+from server.application.datasets.queries import GetDatasetByID
+from server.config.di import resolve
+from server.domain.datasets.entities import DataFormat, Dataset
+from server.seedwork.application.messages import MessageBus
+
+CORPUS_ITEMS = [
+    ("Inventaire national forestier", "Ensemble des forêts de France"),
+    ("Base Carbone", "Inventaire des données climat de l'ADEME"),
+    ("Cadastre national", "Base de données du cadastre de la France"),
+]
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def corpus() -> AsyncIterator[None]:
+    bus = resolve(MessageBus)
+
+    datasets: List[Dataset] = []
+
+    for title, description in CORPUS_ITEMS:
+        command = CreateDataset(
+            title=title, description=description, formats=[DataFormat.FILE_TABULAR]
+        )
+        pk = await bus.execute(command)
+        query = GetDatasetByID(id=pk)
+        dataset = await bus.execute(query)
+        datasets.append(dataset)
+
+    try:
+        yield
+    finally:
+        for dataset in datasets:
+            command = DeleteDataset(id=dataset.id)
+            await bus.execute(command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "q, expected_titles",
+    [
+        pytest.param("", [], id="empty-search"),
+        pytest.param("tototitu", [], id="no-results"),
+        pytest.param(
+            "carbone",
+            ["Base Carbone"],
+            id="single-result-title",
+        ),
+        pytest.param(
+            "forêt",
+            ["Inventaire national forestier"],
+            id="single-result-description",
+        ),
+        pytest.param(
+            "national",
+            ["Inventaire national forestier", "Cadastre national"],
+            id="many-results-title",
+        ),
+        pytest.param(
+            "France",
+            ["Inventaire national forestier", "Cadastre national"],
+            id="many-results-description",
+        ),
+        pytest.param(
+            "base",
+            ["Base Carbone", "Cadastre national"],
+            id="many-results-title-description",
+        ),
+    ],
+)
+async def test_search_empty(
+    client: httpx.AsyncClient, q: str, expected_titles: List[str]
+) -> None:
+    response = await client.get("/datasets/", params={"q": q})
+    assert response.status_code == 200
+    data = response.json()
+    titles = [item["title"] for item in data]
+    assert titles == expected_titles


### PR DESCRIPTION
Refs #94 

_Backend seulement_

TODO :

* [x] Stockage d'un "text search vector" (tsv) en base, permettant à PostgreSQL d'indexer et faire les calculs
* [x] Endpoint de recherche : `GET /datasets/?q=...`
* [x] Tester requête de 1 mot, sans résultats / avec résultats parmi titre / description / les deux
* [x] Tester les requêtes de plusieurs mots : le comportement doit être un "ET" (tous les mots doivent être présents dans le document)
* [x] Tester les caractères spéciaux (notamment `&`, `|` qui sont les "ET" / "OU" de PostgreSQL) : ils doivent être échappés ou retirés de la requête envoyée à la BDD
* [x] Tester que des mots ou écritures proches donnent les bons résultats : `forêt` vs `forestier` (lexeme), `Base` vs `base` (casse).
* [x] Tester qu'un ajout de dataset se répercute sur les résultats de recherche
* [x] Tester qu'un update du `title` ou de la `description` se répercute sur les résultats de recherche
* [x] Tester qu'une suppression de dataset se répercute sur les résultats de recherche

## Pour plus tard

_(Pas obligé que ça soit dans cette PR qui sera déjà chargée et dont on a besoin pour #98)_

* Paramètre `limit` : dans une recherche, on n'affiche jamais l'ensemble des résultats, on se limite à un certain nb ou un certain seuil de pertinence
* Insensibilité aux accents (cf [unaccent](https://www.postgresql.org/docs/current/unaccent.html)), pour que `forêt` et `foret` soient traités de façon identique (? pas sûr que ce soit pertinent, d'où placement dans cette liste)
* Tri par pertinence : https://www.postgresql.org/docs/12/textsearch-controls.html#TEXTSEARCH-RANKING
* Assigner un poids supérieur au `title` qu'à la `description` ? https://www.postgresql.org/docs/14/textsearch-controls.html#TEXTSEARCH-RANKING
* Surbrillance des résultats : https://www.postgresql.org/docs/12/textsearch-controls.html#TEXTSEARCH-HEADLINE
