### PR TITLE
Upgrade DSFR to ^1.3.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.0.1",
       "dependencies": {
-        "@gouvfr/dsfr": "^1.3.0",
+        "@gouvfr/dsfr": "^1.3.1",
         "svelte-forms-lib": "^2.0.1",
         "yup": "^0.32.11"
       },
@@ -989,9 +989,9 @@
       }
     },
     "node_modules/@gouvfr/dsfr": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.3.0.tgz",
-      "integrity": "sha512-zwwMytV7/i35fSe9VT8K2A8hYDla8sfxzJcSxXSwclyk57JH5HBXBY7k4qt49ECTrvMy8GWAWKqJREg6FAdRgQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.3.1.tgz",
+      "integrity": "sha512-11TYlm2nqJVN7VezjManBNUy/O3o/nJ5X9F1N6wkstf0x0N6Ucmtys4yTCPdC036AHqQj7X3v/OwIuvSUDOx5A==",
       "engines": {
         "node": ">=14.18.0"
       }
@@ -7109,9 +7109,9 @@
       }
     },
     "@gouvfr/dsfr": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.3.0.tgz",
-      "integrity": "sha512-zwwMytV7/i35fSe9VT8K2A8hYDla8sfxzJcSxXSwclyk57JH5HBXBY7k4qt49ECTrvMy8GWAWKqJREg6FAdRgQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.3.1.tgz",
+      "integrity": "sha512-11TYlm2nqJVN7VezjManBNUy/O3o/nJ5X9F1N6wkstf0x0N6Ucmtys4yTCPdC036AHqQj7X3v/OwIuvSUDOx5A=="
     },
     "@hapi/hoek": {
       "version": "9.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@gouvfr/dsfr": "^1.3.0",
+    "@gouvfr/dsfr": "^1.3.1",
     "svelte-forms-lib": "^2.0.1",
     "yup": "^0.32.11"
   }


### PR DESCRIPTION
Cette PR met à jour le DSFR pour utiliser la version 1.3.1 et supérieure.

(Nous utilisions précédemment 1.3.0 et supérieure.)

Changelog: https://github.com/GouvernementFR/dsfr/releases/tag/v1.3.1

J'ai constaté qu'il y avait un problème avec l'affichage des icônes dans des groupes de boutons. Nous en avons besoin pour #82 (cf maquette). Cette nouvelle version corrige ce pb, vérifié en local en ajoutant ceci :

```html
<ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-right">
  <li>
    <button class="fr-btn fr-fi-checkbox-circle-line">
      Label bouton
    </button>
  </li>
</ul>
```