### PR TITLE
Add email/password/token authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # App
+argon2-cffi==21.3.0
 asyncpg==0.25.0
 alembic==1.7.5
 fastapi==0.70.0

--- a/server/api/auth/schemas.py
+++ b/server/api/auth/schemas.py
@@ -10,8 +10,20 @@ class UserRead(BaseModel):
     email: str
 
 
+class UserAuthenticatedRead(BaseModel):
+    id: ID
+    email: str
+    api_token: str
+
+
 class UserCreate(BaseModel):
     email: EmailStr
+    password: str
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
 
 
 class CheckAuthResponse(BaseModel):

--- a/server/api/security.py
+++ b/server/api/security.py
@@ -1,6 +1,3 @@
-from fastapi.security import APIKeyHeader
+from fastapi.security import HTTPBearer
 
-# XXX: Temporary password-less identification mechanism.
-# Must be replaced with a regular user-password authentication mechanism later on
-# (e.g. OAuth bearer, token auth, etc).
-email_security = APIKeyHeader(name="X-Email")
+bearer_security = HTTPBearer(auto_error=False)

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -4,6 +4,7 @@ from server.seedwork.application.commands import Command
 
 class CreateUser(Command[ID]):
     email: str
+    password: str
 
 
 class DeleteUser(Command[None]):

--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -1,15 +1,21 @@
 from server.config.di import resolve
 from server.domain.auth.entities import User
-from server.domain.auth.exceptions import EmailAlreadyExists, UserDoesNotExist
+from server.domain.auth.exceptions import (
+    EmailAlreadyExists,
+    LoginFailed,
+    UserDoesNotExist,
+)
 from server.domain.auth.repositories import UserRepository
 from server.domain.common.types import ID
 
 from .commands import CreateUser, DeleteUser
-from .queries import GetUserByEmail
+from .passwords import PasswordEncoder, generate_api_token
+from .queries import GetUserByAPIToken, GetUserByEmail, Login
 
 
 async def create_user(command: CreateUser) -> ID:
     repository = resolve(UserRepository)
+    password_encoder = resolve(PasswordEncoder)
 
     email = command.email
 
@@ -18,13 +24,40 @@ async def create_user(command: CreateUser) -> ID:
     if user is not None:
         raise EmailAlreadyExists(email)
 
-    user = User(id=repository.make_id(), email=email)
+    password_hash = password_encoder.hash(command.password)
+    api_token = generate_api_token()
+
+    user = User(
+        id=repository.make_id(),
+        email=email,
+        password_hash=password_hash,
+        api_token=api_token,
+    )
+
     return await repository.insert(user)
 
 
 async def delete_user(command: DeleteUser) -> None:
     repository = resolve(UserRepository)
     await repository.delete(command.id)
+
+
+async def login(query: Login) -> User:
+    repository = resolve(UserRepository)
+    password_encoder = resolve(PasswordEncoder)
+
+    email = query.email
+
+    user = await repository.get_by_email(email)
+
+    if user is None:
+        password_encoder.hash(query.password)  # Mitigate timing attacks.
+        raise LoginFailed("Invalid credentials")
+
+    if not password_encoder.verify(password=query.password, hash=user.password_hash):
+        raise LoginFailed("Invalid credentials")
+
+    return user
 
 
 async def get_user_by_email(query: GetUserByEmail) -> User:
@@ -36,5 +69,16 @@ async def get_user_by_email(query: GetUserByEmail) -> User:
 
     if user is None:
         raise UserDoesNotExist(email)
+
+    return user
+
+
+async def get_user_by_api_token(query: GetUserByAPIToken) -> User:
+    repository = resolve(UserRepository)
+
+    user = await repository.get_by_api_token(query.api_token)
+
+    if user is None:
+        raise UserDoesNotExist("__token__")
 
     return user

--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -46,9 +46,7 @@ async def login(query: Login) -> User:
     repository = resolve(UserRepository)
     password_encoder = resolve(PasswordEncoder)
 
-    email = query.email
-
-    user = await repository.get_by_email(email)
+    user = await repository.get_by_email(query.email)
 
     if user is None:
         password_encoder.hash(query.password)  # Mitigate timing attacks.

--- a/server/application/auth/passwords.py
+++ b/server/application/auth/passwords.py
@@ -1,7 +1,5 @@
 import secrets
 
-API_TOKEN_LENGTH = 64
-
 
 class PasswordEncoder:
     def hash(self, value: str) -> str:
@@ -11,7 +9,9 @@ class PasswordEncoder:
         raise NotADirectoryError  # pragma: no cover
 
 
+API_TOKEN_LENGTH = 64
+
+
 def generate_api_token() -> str:
-    assert API_TOKEN_LENGTH % 2 == 0
     nbytes = API_TOKEN_LENGTH // 2
     return secrets.token_hex(nbytes)

--- a/server/application/auth/passwords.py
+++ b/server/application/auth/passwords.py
@@ -1,0 +1,17 @@
+import secrets
+
+API_TOKEN_LENGTH = 64
+
+
+class PasswordEncoder:
+    def hash(self, value: str) -> str:
+        raise NotImplementedError  # pragma: no cover
+
+    def verify(self, password: str, hash: str) -> bool:
+        raise NotADirectoryError  # pragma: no cover
+
+
+def generate_api_token() -> str:
+    assert API_TOKEN_LENGTH % 2 == 0
+    nbytes = API_TOKEN_LENGTH // 2
+    return secrets.token_hex(nbytes)

--- a/server/application/auth/passwords.py
+++ b/server/application/auth/passwords.py
@@ -6,7 +6,7 @@ class PasswordEncoder:
         raise NotImplementedError  # pragma: no cover
 
     def verify(self, password: str, hash: str) -> bool:
-        raise NotADirectoryError  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
 
 API_TOKEN_LENGTH = 64

--- a/server/application/auth/queries.py
+++ b/server/application/auth/queries.py
@@ -2,5 +2,14 @@ from server.domain.auth.entities import User
 from server.seedwork.application.queries import Query
 
 
+class Login(Query[User]):
+    email: str
+    password: str
+
+
 class GetUserByEmail(Query[User]):
     email: str
+
+
+class GetUserByAPIToken(Query[User]):
+    api_token: str

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -67,9 +67,11 @@ from typing import Iterator, List, Type, TypeVar
 
 import punq
 
+from server.application.auth.passwords import PasswordEncoder
 from server.domain.auth.repositories import UserRepository
 from server.domain.datasets.repositories import DatasetRepository
 from server.infrastructure.adapters.messages import MessageBusAdapter
+from server.infrastructure.auth.passwords import Argon2PasswordEncoder
 from server.infrastructure.auth.repositories import SqlUserRepository
 from server.infrastructure.database import Database
 from server.infrastructure.datasets.repositories import SqlDatasetRepository
@@ -110,6 +112,10 @@ def create_container() -> punq.Container:
 
     settings = Settings()
     container.register(Settings, instance=settings)
+
+    # Common services
+
+    container.register(PasswordEncoder, instance=Argon2PasswordEncoder())
 
     # Event handling (Commands, queries, and the message bus)
 

--- a/server/domain/auth/entities.py
+++ b/server/domain/auth/entities.py
@@ -6,6 +6,8 @@ from ..common.types import ID
 class User(Entity):
     id: ID
     email: str
+    password_hash: str
+    api_token: str
 
     class Config:
         orm_mode = True

--- a/server/domain/auth/exceptions.py
+++ b/server/domain/auth/exceptions.py
@@ -8,3 +8,7 @@ class UserDoesNotExist(DoesNotExist):
 class EmailAlreadyExists(Exception):
     def __init__(self, email: str) -> None:
         super().__init__(f"Email already exists: {email!r}")
+
+
+class LoginFailed(Exception):
+    pass

--- a/server/infrastructure/auth/module.py
+++ b/server/infrastructure/auth/module.py
@@ -1,6 +1,12 @@
 from server.application.auth.commands import CreateUser, DeleteUser
-from server.application.auth.handlers import create_user, delete_user, get_user_by_email
-from server.application.auth.queries import GetUserByEmail
+from server.application.auth.handlers import (
+    create_user,
+    delete_user,
+    get_user_by_api_token,
+    get_user_by_email,
+    login,
+)
+from server.application.auth.queries import GetUserByAPIToken, GetUserByEmail, Login
 from server.seedwork.application.modules import Module
 
 
@@ -11,5 +17,7 @@ class AuthModule(Module):
     }
 
     query_handlers = {
+        Login: login,
         GetUserByEmail: get_user_by_email,
+        GetUserByAPIToken: get_user_by_api_token,
     }

--- a/server/infrastructure/auth/passwords.py
+++ b/server/infrastructure/auth/passwords.py
@@ -13,5 +13,7 @@ class Argon2PasswordEncoder(PasswordEncoder):
     def verify(self, password: str, hash: str) -> bool:
         try:
             return self._hasher.verify(hash, password)
-        except (argon2.exceptions.VerificationError, argon2.exceptions.InvalidHash):
+        except argon2.exceptions.VerificationError:
+            return False
+        except argon2.exceptions.InvalidHash:
             return False

--- a/server/infrastructure/auth/passwords.py
+++ b/server/infrastructure/auth/passwords.py
@@ -1,0 +1,17 @@
+import argon2
+
+from server.application.auth.passwords import PasswordEncoder
+
+
+class Argon2PasswordEncoder(PasswordEncoder):
+    def __init__(self) -> None:
+        self._hasher = argon2.PasswordHasher()
+
+    def hash(self, value: str) -> str:
+        return self._hasher.hash(value)
+
+    def verify(self, password: str, hash: str) -> bool:
+        try:
+            return self._hasher.verify(hash, password)
+        except (argon2.exceptions.VerificationError, argon2.exceptions.InvalidHash):
+            return False

--- a/server/infrastructure/auth/repositories.py
+++ b/server/infrastructure/auth/repositories.py
@@ -50,7 +50,6 @@ class SqlUserRepository(UserRepository):
 
     async def insert(self, entity: User) -> ID:
         async with self._db.session() as session:
-
             instance = UserModel(
                 id=entity.id,
                 email=entity.email,

--- a/server/infrastructure/auth/repositories.py
+++ b/server/infrastructure/auth/repositories.py
@@ -1,10 +1,11 @@
 import uuid
 from typing import Optional
 
-from sqlalchemy import Column, String, delete, insert, select
+from sqlalchemy import Column, String, delete, select
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import NoResultFound
 
+from server.application.auth.passwords import API_TOKEN_LENGTH
 from server.domain.auth.entities import User
 from server.domain.auth.repositories import UserRepository
 from server.domain.common.types import ID
@@ -17,6 +18,8 @@ class UserModel(Base):
 
     id: uuid.UUID = Column(UUID(as_uuid=True), primary_key=True)
     email = Column(String, nullable=False, unique=True, index=True)
+    password_hash = Column(String, nullable=False)
+    api_token = Column(String(API_TOKEN_LENGTH), nullable=False)
 
 
 class SqlUserRepository(UserRepository):
@@ -34,12 +37,33 @@ class SqlUserRepository(UserRepository):
             else:
                 return User.from_orm(obj)
 
+    async def get_by_api_token(self, api_token: str) -> Optional[User]:
+        async with self._db.session() as session:
+            stmt = select(UserModel).where(UserModel.api_token == api_token)
+            result = await session.execute(stmt)
+            try:
+                obj = result.scalar_one()
+            except NoResultFound:
+                return None
+            else:
+                return User.from_orm(obj)
+
     async def insert(self, entity: User) -> ID:
         async with self._db.session() as session:
-            stmt = insert(UserModel).values(**entity.dict()).returning(UserModel.id)
-            result = await session.execute(stmt)
+
+            instance = UserModel(
+                id=entity.id,
+                email=entity.email,
+                password_hash=entity.password_hash,
+                api_token=entity.api_token,
+            )
+
+            session.add(instance)
+
             await session.commit()
-            return result.scalar_one()
+            await session.refresh(instance)
+
+            return ID(instance.id)
 
     async def delete(self, id: ID) -> None:
         async with self._db.session() as session:

--- a/server/migrations/versions/30474ebed7a2_user_add_password_token.py
+++ b/server/migrations/versions/30474ebed7a2_user_add_password_token.py
@@ -1,0 +1,56 @@
+"""user-add-password-token
+
+Revision ID: 30474ebed7a2
+Revises: cc869b534916
+Create Date: 2022-03-01 16:24:53.881795
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "30474ebed7a2"
+down_revision = "cc869b534916"
+branch_labels = None
+depends_on = None
+
+API_TOKEN_LENGTH = 64
+
+
+def upgrade():
+    # Hash for "changeme"
+    default_password_hash = "$argon2id$v=19$m=65536,t=3,p=4$2/LvwQp6Bm5bbRvnFNTivQ$GtK4plgCCfrwVnSH7PdAJni9KeQ1qr0tmM88v2deo9A"  # noqa: E501
+
+    op.add_column(
+        "user",
+        sa.Column(
+            "password_hash",
+            sa.String(),
+            nullable=False,
+            server_default=default_password_hash,
+        ),
+    )
+
+    op.alter_column("user", "password_hash", server_default=None)
+
+    # Sample result for `secrets.token_hex(API_TOKEN_LENGTH // 2)`
+    default_api_token = (
+        "9cd0c1b46e11cef4c713815690e845186385faf0aaaf9495bd47027ecb378f79"  # noqa: E501
+    )
+
+    op.add_column(
+        "user",
+        sa.Column(
+            "api_token",
+            sa.String(API_TOKEN_LENGTH),
+            nullable=False,
+            server_default=default_api_token,
+        ),
+    )
+
+    op.alter_column("user", "api_token", server_default=None)
+
+
+def downgrade():
+    op.drop_column("user", "api_token")
+    op.drop_column("user", "password_hash")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 from server.config import Settings
 from server.config.di import bootstrap, resolve
 
+from .helpers import TestUser, temp_user
+
 os.environ["APP_TESTING"] = "True"
 
 bootstrap()
@@ -53,3 +55,9 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
     async with LifespanManager(app):
         async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
             yield client
+
+
+@pytest.fixture(name="temp_user")
+async def fixture_temp_user() -> AsyncIterator[TestUser]:
+    async with temp_user() as user:
+        yield user

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,46 @@
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from server.application.auth.commands import CreateUser, DeleteUser
+from server.application.auth.queries import GetUserByEmail
+from server.config.di import resolve
+from server.domain.auth.entities import User
+from server.seedwork.application.messages import MessageBus
+
+
+class _DisablePytestCollectionMixin:
+    """
+    Prevent a class named 'Test*' from being collected as a test case by pytest.
+
+    See: https://github.com/pytest-dev/pytest/issues/1879
+    """
+
+    __test__ = False
+
+
+class TestUser(_DisablePytestCollectionMixin, User):
+    """
+    A user that exposes the plaintext password for testing purposes.
+    """
+
+    password: str
+
+
+@asynccontextmanager
+async def temp_user() -> AsyncIterator[TestUser]:
+    bus = resolve(MessageBus)
+
+    email = "temp@example.org"
+    password = "s3kr3t"
+
+    command = CreateUser(email=email, password=password)
+    await bus.execute(command)
+
+    query = GetUserByEmail(email=email)
+    user = await bus.execute(query)
+
+    try:
+        yield TestUser(**user.dict(), password=password)
+    finally:
+        command = DeleteUser(id=user.id)
+        await bus.execute(command)

--- a/tests/unit/test_passwords.py
+++ b/tests/unit/test_passwords.py
@@ -1,0 +1,16 @@
+from server.application.auth.passwords import generate_api_token
+from server.infrastructure.auth.passwords import Argon2PasswordEncoder
+
+
+def test_generate_api_token() -> None:
+    api_token = generate_api_token()
+    assert len(api_token) == 64
+    assert api_token.isalnum()
+
+
+def test_argon2_password_encoder() -> None:
+    encoder = Argon2PasswordEncoder()
+    hsh = encoder.hash("s3kr3t")
+    assert encoder.verify("s3kr3t", hsh)
+    assert not encoder.verify("other", hsh)
+    assert not encoder.verify("s3kr3t", "invalidhash")

--- a/tests/unit/test_passwords.py
+++ b/tests/unit/test_passwords.py
@@ -10,7 +10,7 @@ def test_generate_api_token() -> None:
 
 def test_argon2_password_encoder() -> None:
     encoder = Argon2PasswordEncoder()
-    hsh = encoder.hash("s3kr3t")
-    assert encoder.verify("s3kr3t", hsh)
-    assert not encoder.verify("other", hsh)
+    hash_ = encoder.hash("s3kr3t")
+    assert encoder.verify("s3kr3t", hash_)
+    assert not encoder.verify("other", hash_)
     assert not encoder.verify("s3kr3t", "invalidhash")


### PR DESCRIPTION
Closes #106 

Cette PR modifie la stratégie d'authentification côté backend, pour utiliser une authentification par token.

Dans cette version minimale, chaque utilisateur a un token d'API qui lui est propre est créé lors de la création du compte. (Ceci pourra (_devra_) être amélioré par la suite, cf alternatives sur #106.)

Pour ce faire :

* Ajout de champs `password_hash` et `api_token` à la table `user`
* Utilisation de `argon2` pour le hachage des mots de passe
* Mise à jour de `POST /auth/users/` (création d'utilisateur)
* Ajout de`POST /auth/login/` (connexion)
* Mise à jour des tests

## Prochaines étapes

_À faire suite à cette PR, pour ne pas la surcharger_

* Protéger les endpoints derrière l'authentification

### Pour plus tard

_Idées de choses à faire, qui dépendront du futur usage de l'authentification, cf #12_

* Mise à jour d'un utilisateur (email) ?
* Modification / récupération de mot de passe ?
* Lien avec une organisation ?
* Profil utilisateur : prénom, nom... ?