### PR TITLE
Add bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,36 @@
+---
+name: Bug
+about: Signaler un problème détecté dans l'application
+labels: bug
+---
+
+## Description du bug
+
+<!-- Décrire le bug de façon concise, en une ou deux phrases -->
+
+## Comportement attendu
+
+<!-- Décrire ce qui devrait se passer -->
+
+## Comportement réel
+
+<!-- Décrire ce qu'il se passe réellement, en décalage avec le comportement attendu -->
+
+## Pour reproduire
+
+<!--
+Décrire les étapes nécessaires et suffisantes pour reproduire le bug
+
+- Ouvrir telle URL
+- Effectuer telle action
+- Constater telle chose
+- etc
+-->
+
+## Pistes de résolution
+
+<!-- Le cas échéant, esquisser ce qui pourrait permettre de résoudre le bug -->
+
+## Contexte supplémentaire
+
+<!-- D'autres informations utiles pour comprendre le bug : changements récents, etc -->


### PR DESCRIPTION
Je propose dans cette PR d'ajouter une _issue template_ pour les signalements de bugs

Basé sur le format "Problème / attendu / réel / reproduire / pistes" que j'ai déjà employé par exemple dans #110, qui est classique et fonctionne très bien pour cadrer la réflexion

Je vais merge directement quand la CI passe, cette PR a seulement une vocation de traçabilité