### PR TITLE
Fix URL building for search endpoint

### DIFF
--- a/client/src/lib/repositories/datasets.spec.ts
+++ b/client/src/lib/repositories/datasets.spec.ts
@@ -14,7 +14,7 @@ test("The datasets endpoint behaves as expected", async () => {
 
   const fakeFetch: Fetch = async (request) => {
     expect(request.method).toBe("GET");
-    expect(new URL(request.url).pathname).toBe("/datasets/");
+    expect(new URL(request.url, "http://test").pathname).toBe("/datasets/");
 
     const body = JSON.stringify(fakeDatasets);
     const headers = { "Content-Type": "application/json" };

--- a/client/src/lib/repositories/datasets.ts
+++ b/client/src/lib/repositories/datasets.ts
@@ -19,9 +19,9 @@ export const getDatasetByID: GetDatasetByID = async ({ fetch, id }) => {
 type GetDatasets = (opts: { fetch: Fetch; q?: string }) => Promise<Dataset[]>;
 
 export const getDatasets: GetDatasets = async ({ fetch, q }) => {
-  const url = new URL(`${getApiUrl()}/datasets/`);
-  url.search = toQueryString([["q", q]]);
-  const request = new Request(url.toString());
+  const queryString = toQueryString([["q", q]]);
+  const url = `${getApiUrl()}/datasets/${queryString}`;
+  const request = new Request(url);
   const response = await fetch(request);
   return await response.json();
 };

--- a/client/src/lib/util.spec.ts
+++ b/client/src/lib/util.spec.ts
@@ -1,0 +1,16 @@
+import { toQueryString } from "./util";
+
+describe("toQueryString", () => {
+  const cases: [[string, string][], string][] = [
+    [[], ""],
+    [[["q", undefined]], ""],
+    [[["q", null]], ""],
+    [[["q", ""]], "?q="],
+    [[["q", "value"]], "?q=value"],
+    [[["a", "1"], ["b", "2"]], "?a=1&b=2"],
+  ];
+
+  test.each(cases)("When items is '%s'", (items, expected) => {
+    expect(toQueryString(items)).toBe(expected);
+  });
+});

--- a/client/src/lib/util.ts
+++ b/client/src/lib/util.ts
@@ -10,11 +10,12 @@ export const pluralize = (
 };
 
 /**
- * Create an URL query string, dropping any null or undefined values.
+ * Create an URL query string, including a leading "?" if needed, dropping any null or undefined values.
  */
 export const toQueryString = (items: [string, string | null | undefined][]) => {
   const definedItems = items.filter(([_, value]) => typeof value === "string");
   const params = new URLSearchParams();
   definedItems.forEach(([name, value]) => params.append(name, value));
-  return params.toString();
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
 };

--- a/client/src/routes/fiches/search.svelte
+++ b/client/src/routes/fiches/search.svelte
@@ -27,7 +27,7 @@
   const updateSearch = (event: CustomEvent<string>) => {
     const q = event.detail;
     const queryString = toQueryString([["q", q]]);
-    const href = `?${queryString}`;
+    const href = `${queryString}`; // Same page, update query string only
     goto(href);
   };
 </script>

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -24,7 +24,7 @@
   const submitSearch = (event: CustomEvent<string>) => {
     const q = event.detail;
     const queryString = toQueryString([["q", q]]);
-    const href = `/fiches/search?${queryString}`;
+    const href = `/fiches/search${queryString}`;
     goto(href);
   };
 </script>


### PR DESCRIPTION
Fixes #112 

TL;DR : `new URL("/etc")` ne fonctionne pas ("URL invalide", limite de cette Web API), or en prod on a besoin que la base URL soit un chemin (en l'occurrence `/api`) pour bien passer par la redirection Nginx. On ne peut donc pas l'utiliser comme un "parseur d'URL" général.

En l'occurrence pour ajouter la query string à l'appel de recherche, il faut le faire à la mano.

J'en profite pour ajouter des tests unitaires blindés.