### PR TITLE
Add missing fr-container in edit page

### DIFF
--- a/client/src/routes/fiches/[id]/edit.svelte
+++ b/client/src/routes/fiches/[id]/edit.svelte
@@ -34,20 +34,22 @@
   };
 </script>
 
-<h1 class="fr-mt-9w">Modifier "{dataset.title}"</h1>
+<section class="fr-container">
+  <h1 class="fr-mt-9w">Modifier "{dataset.title}"</h1>
 
-<h2>Informations générales</h2>
+  <h2>Informations générales</h2>
 
-<section class="fr-col-lg-8">
-  <DatasetForm
-    initial={{
-      title: dataset.title,
-      description: dataset.description,
-      formats: dataset.formats,
-    }}
-    {loading}
-    submitLabel="Modifier ce jeu de données"
-    loadingLabel="Modification en cours..."
-    on:save={onSave}
-  />
+  <div class="fr-col-lg-8">
+    <DatasetForm
+      initial={{
+        title: dataset.title,
+        description: dataset.description,
+        formats: dataset.formats,
+      }}
+      {loading}
+      submitLabel="Modifier ce jeu de données"
+      loadingLabel="Modification en cours..."
+      on:save={onSave}
+    />
+  </div>
 </section>


### PR DESCRIPTION
Cleanup pour #98 

J'avais oublié d'ajouter le conteneur `fr-container` sur la page d'édition d'une fiche de données

Avant :sweat_smile: 

![before](https://user-images.githubusercontent.com/15911462/157021577-d83dc82f-5f54-4117-b33d-eed5094f51a7.png) (19kB)

Après

![after](https://user-images.githubusercontent.com/15911462/157021629-cb099538-5145-47ed-aecd-75fe8f9f4559.png) (20kB)