### PR TITLE
Use statically defined links

### DIFF
--- a/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
+++ b/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Dataset } from "src/definitions/datasets";
   import { DATA_FORMAT_SHORT_NAMES } from "src/constants";
+  import paths from "$lib/paths";
 
   export let dataset: Dataset;
 
@@ -40,7 +41,7 @@
         <div class="fr-grid-row fr-grid-row--right">
           <p class="fr-text--sm fr-text-mention--grey">Il y a 3 jours</p>
           <a
-            href={`/fiches/${dataset.id}`}
+            href={paths.datasetDetail({ id: dataset.id })}
             class="fr-link fr-fi-arrow-right-line fr-link--icon-right"
             title="Consulter cette fiche de données"
           >

--- a/client/src/lib/components/Footer/Footer.svelte
+++ b/client/src/lib/components/Footer/Footer.svelte
@@ -1,8 +1,12 @@
+<script lang="ts">
+  import paths from "$lib/paths";
+</script>
+
 <footer class="fr-footer" role="contentinfo" id="footer">
   <div class="fr-container">
     <div class="fr-footer__body">
       <div class="fr-footer__brand fr-enlarge-link">
-        <a href="/" title="Retour à l’accueil">
+        <a href={paths.home} title="Retour à l’accueil">
           <p class="fr-logo" title="république française">
             Catalogage
             <br />des

--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -2,6 +2,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { isLoggedIn, logout, user } from "$lib/stores/auth";
+  import paths from "$lib/paths";
 
   type NavItem = {
     label: string;
@@ -11,11 +12,11 @@
   const navigationItems: NavItem[] = [
     {
       label: "Rechercher",
-      href: "/fiches/search",
+      href: paths.datasetSearch,
     },
     {
       label: "Contribuer",
-      href: "/contribuer",
+      href: paths.contribute,
     },
     {
       label: "Mon espace",
@@ -58,7 +59,7 @@
             </div>
           </div>
           <div class="fr-header__service">
-            <a href="/" title="Accueil - Catalogage des données">
+            <a href={paths.home} title="Accueil - Catalogage des données">
               <p class="fr-header__service-title">Catalogage des données</p>
             </a>
             <p class="fr-header__service-tagline">
@@ -75,7 +76,11 @@
               </p>
               <ul class="fr-links-group">
                 <li>
-                  <a href="/" class="fr-link" title="Accéder aux réglages">
+                  <a
+                    href={paths.home}
+                    class="fr-link"
+                    title="Accéder aux réglages"
+                  >
                     Réglages
                   </a>
                 </li>
@@ -88,7 +93,7 @@
             {:else}
               <ul class="fr-links-group">
                 <li>
-                  <a href="/login" class="fr-link" title="Se connecter">
+                  <a href={paths.login} class="fr-link" title="Se connecter">
                     Se connecter
                   </a>
                 </li>

--- a/client/src/lib/paths.ts
+++ b/client/src/lib/paths.ts
@@ -1,0 +1,10 @@
+import { path } from "./util/paths";
+
+export default {
+  home: "/",
+  login: "/login",
+  contribute: "/contribuer",
+  datasetDetail: path("/fiches/:id"),
+  datasetSearch: "/fiches/search",
+  datasetEdit: path("/fiches/:id/edit"),
+};

--- a/client/src/lib/util/paths.spec.ts
+++ b/client/src/lib/util/paths.spec.ts
@@ -1,0 +1,15 @@
+import { path } from "./paths";
+
+test("path", () => {
+  expect(path("/")({})).toBe("/");
+  expect(path("/login")({})).toBe("/login");
+  expect(path("/:itemId")({ itemId: "abc" })).toBe("/abc");
+  expect(path("/items/:itemId")({ itemId: "abc" })).toBe("/items/abc");
+  expect(
+    path("/items/:itemId/objects/:objectId/")({
+      itemId: "abc",
+      objectId: "123",
+    })
+  ).toBe("/items/abc/objects/123/");
+  expect(() => path("/items/:itemId")({} as any)).toThrow();
+});

--- a/client/src/lib/util/paths.ts
+++ b/client/src/lib/util/paths.ts
@@ -1,0 +1,90 @@
+// Simplified implementation of: https://github.com/garybernhardt/static-path
+// Credits: https://www.youtube.com/watch?v=KRMJIiGE0ds
+
+/**
+ * In:  '/items/:itemId/objects/:objectId'
+ * Out: 'itemId' | 'lessonId'
+ */
+type PathParamNames<Pattern extends string> =
+  // prettier-ignore
+  Pattern extends `:${infer Param}/${infer Rest}` ? Param | PathParamNames<Rest>
+  : Pattern extends `:${infer Param}` ? Param
+  : Pattern extends `${infer _Prefix}:${infer Rest}` ? PathParamNames<`:${Rest}`>
+  : never;
+
+/**
+ * In:  '/items/:itemId'
+ * Out: { itemId: string }
+ */
+type Params<Pattern extends string> =
+  // prettier-ignore
+  string extends Pattern ? never
+  : { [K in PathParamNames<Pattern>]: string };
+
+type Part<Pattern extends string> =
+  | { type: "constant"; value: string }
+  | { type: "param"; paramName: PathParamNames<Pattern> };
+
+export type Path<Pattern extends string> = (params: Params<Pattern>) => string;
+
+/**
+ * Represent a path in a type-safe manner.
+ *
+ * Usage:
+ *
+ * const itemDetail = path('/items/:itemId');
+ * const href = itemDetail({ itemId: '...' });
+ */
+export const path = <Pattern extends string>(
+  pattern: Pattern
+): Path<Pattern> => {
+  const parts = makePatternParts(pattern);
+
+  return (params: Params<Pattern>) => {
+    const pathValues = parts
+      .map((part) => {
+        if (part.type === "param") {
+          return getParamValue(params, part.paramName);
+        }
+        return part.value;
+      })
+      .filter(
+        // Drop any leading empty part,
+        // since we add the leading / manually on the next line
+        (value, index) => (index === 0 ? value !== "" : true)
+      );
+    return `/${pathValues.join("/")}`;
+  };
+};
+
+/**
+ * Split a pattern into structured parts.
+ */
+const makePatternParts = <Pattern extends string>(
+  pattern: Pattern
+): Part<Pattern>[] => {
+  return pattern.split("/").map((value) => {
+    if (value.startsWith(":")) {
+      return {
+        type: "param",
+        paramName: value.replace(/^:/, "") as PathParamNames<Pattern>,
+      };
+    }
+    return { type: "constant", value };
+  });
+};
+
+const getParamValue = <Pattern extends string>(
+  params: Params<Pattern>,
+  paramName: keyof Params<Pattern>
+): string => {
+  const value = params[paramName];
+  if (typeof value !== "string") {
+    const formattedParam = JSON.stringify({ paramName });
+    throw new Error(
+      `When generating a path, param ${formattedParam} did not exist on params object. ` +
+        "Types should have prevented this, so either you bypassed type checks, or there is a bug!"
+    );
+  }
+  return value;
+};

--- a/client/src/routes/fiches/[id]/edit.svelte
+++ b/client/src/routes/fiches/[id]/edit.svelte
@@ -17,6 +17,7 @@
   import { page } from "$app/stores";
   import type { Dataset, DatasetFormData } from "src/definitions/datasets";
   import DatasetForm from "$lib/components/DatasetForm/DatasetForm.svelte";
+  import paths from "$lib/paths";
 
   export let dataset: Dataset;
 
@@ -27,7 +28,7 @@
     try {
       loading = true;
       await updateDataset({ fetch, id, data: event.detail });
-      await goto(`/fiches/${id}`);
+      await goto(paths.datasetDetail({ id }));
     } finally {
       loading = false;
     }

--- a/client/src/routes/fiches/[id]/index.svelte
+++ b/client/src/routes/fiches/[id]/index.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import paths from "$lib/paths";
 
   const id = $page.params.id;
 
-  const editUrl = `/fiches/${id}/edit`;
+  const editUrl = paths.datasetEdit({ id });
 </script>
 
 <section class="fr-container fr-mt-9w">

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -18,13 +18,14 @@
   import { toQueryString } from "$lib/util";
   import DatasetList from "$lib/components/DatasetList/DatasetList.svelte";
   import SearchForm from "$lib/components/SearchForm/SearchForm.svelte";
+  import paths from "$lib/paths";
 
   export let datasets: Dataset[];
 
   const submitSearch = (event: CustomEvent<string>) => {
     const q = event.detail;
     const queryString = toQueryString([["q", q]]);
-    const href = `/fiches/search${queryString}`;
+    const href = `${paths.datasetSearch}${queryString}`;
     goto(href);
   };
 </script>


### PR DESCRIPTION
Closes #100 

Refactor pour s'assurer qu'en cas de modification des chemins internes, les liens y faisant référence soient automatiquement mis à jour (par référence aux variables dans `paths`), ou bien détectés comme erronnés (via TypeScript).

Bref, réduit le risque de liens morts à l'avenir.

cc @magopian (pour info, si tu es curieux du résultat ^^)