### PR TITLE
Redirect to dataset detail page after creation

### DIFF
--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -5,6 +5,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import type { DatasetFormData } from "src/definitions/datasets";
+  import paths from "$lib/paths";
   import DatasetForm from "$lib/components/DatasetForm/DatasetForm.svelte";
   import { createDataset } from "$lib/repositories/datasets";
 
@@ -14,7 +15,7 @@
     try {
       loading = true;
       const dataset = await createDataset({ fetch, data: event.detail });
-      await goto(`/fiches/${dataset.id}`);
+      await goto(paths.datasetDetail({ id: dataset.id }));
     } finally {
       loading = false;
     }

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import type { DatasetFormData } from "src/definitions/datasets";
   import DatasetForm from "$lib/components/DatasetForm/DatasetForm.svelte";
   import { createDataset } from "$lib/repositories/datasets";
@@ -12,7 +13,8 @@
   const onSave = async (event: CustomEvent<DatasetFormData>) => {
     try {
       loading = true;
-      await createDataset({ fetch, data: event.detail });
+      const dataset = await createDataset({ fetch, data: event.detail });
+      await goto(`/fiches/${dataset.id}`);
     } finally {
       loading = false;
     }

--- a/client/src/tests/e2e/contribuer.spec.js
+++ b/client/src/tests/e2e/contribuer.spec.js
@@ -35,5 +35,7 @@ test.describe("Basic form submission", () => {
     expect(json.description).toBe(descriptionText);
     expect(json.formats).toStrictEqual(["api"]);
     expect(json).toHaveProperty("id");
+
+    await page.locator("text='Fiche de données'").waitFor();
   });
 });


### PR DESCRIPTION
Closes #102 

NB : solution temporaire (qui convient en l'état de l'outil), en attendant un parcours plus évolué (choix entre contribuer une nouvelle fiche, consulter la fiche, aller à l'accueil...).