### PR TITLE
Run backend tests in isolated DB transactions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,5 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
 
 
 @pytest.fixture(name="temp_user")
-async def fixture_temp_user() -> AsyncIterator[TestUser]:
-    async with temp_user() as user:
-        yield user
+async def fixture_temp_user() -> TestUser:
+    return await temp_user()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from server.config import Settings
 from server.config.di import bootstrap, resolve
+from server.infrastructure.database import Database
 
 from .helpers import TestUser, temp_user
 
@@ -34,6 +35,15 @@ def test_database() -> Iterator[None]:
         yield
     finally:
         drop_database(url)
+
+
+@pytest.fixture(autouse=True)
+async def transaction() -> AsyncIterator[None]:
+    db = resolve(Database)
+
+    async with db.transaction() as tx:
+        yield
+        await tx.rollback()
 
 
 @pytest.fixture(scope="session")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,4 @@
-from contextlib import asynccontextmanager
-from typing import AsyncIterator
-
-from server.application.auth.commands import CreateUser, DeleteUser
+from server.application.auth.commands import CreateUser
 from server.application.auth.queries import GetUserByEmail
 from server.config.di import resolve
 from server.domain.auth.entities import User
@@ -26,8 +23,7 @@ class TestUser(_DisablePytestCollectionMixin, User):
     password: str
 
 
-@asynccontextmanager
-async def temp_user() -> AsyncIterator[TestUser]:
+async def temp_user() -> TestUser:
     bus = resolve(MessageBus)
 
     email = "temp@example.org"
@@ -39,8 +35,4 @@ async def temp_user() -> AsyncIterator[TestUser]:
     query = GetUserByEmail(email=email)
     user = await bus.execute(query)
 
-    try:
-        yield TestUser(**user.dict(), password=password)
-    finally:
-        command = DeleteUser(id=user.id)
-        await bus.execute(command)
+    return TestUser(**user.dict(), password=password)


### PR DESCRIPTION
Closes #117 

Cette PR s'assure que chaque test est lancé dans une transaction qui est ensuite `ROLLBACK`, de sorte qu'aucune donnée ne "déborde" sur les tests suivants / précédents. En effet chaque test devrait être isolé.

Permet dès lors de simplifier un certain nb d'endroits où on prenait garde de "nettoyer" des entités créées en base pour le besoin des tests.