### PR TITLE
Add missing certs cron job

### DIFF
--- a/ops/ansible/roles/web/tasks/nginx.yml
+++ b/ops/ansible/roles/web/tasks/nginx.yml
@@ -33,3 +33,11 @@
   become: true
   when: tls_enabled
   notify: reload nginx
+
+- name: Ensure certs get renewed
+  cron:
+    name: certs_renewal
+    special_time: weekly
+    job: "certbot renew -q"
+    state: present
+  when: tls_enabled


### PR DESCRIPTION
Cleanup #132 

Le cron job de renouvellement des certificats n'est pas ajouté automatiquement, il faut donc le configurer avec Ansible

Avant :

```console
$ crontab -l
no crontab for root
```

Après :

```console
$ crontab -l
#Ansible: certs_renewal
@weekly certbot renew -q
```