### PR TITLE
Fix TLS configuration

### DIFF
--- a/ops/ansible/environments/demo/group_vars/web.yml
+++ b/ops/ansible/environments/demo/group_vars/web.yml
@@ -1,3 +1,3 @@
 git_version: master
 
-tls_enabled: true
+tls_enabled: false

--- a/ops/ansible/environments/staging/group_vars/web.yml
+++ b/ops/ansible/environments/staging/group_vars/web.yml
@@ -1,3 +1,3 @@
 git_version: master
 
-tls_enabled: true
+tls_enabled: false

--- a/ops/ansible/roles/web/defaults/main.yml
+++ b/ops/ansible/roles/web/defaults/main.yml
@@ -1,0 +1,1 @@
+tls_enabled: false

--- a/ops/ansible/roles/web/tasks/nginx.yml
+++ b/ops/ansible/roles/web/tasks/nginx.yml
@@ -1,4 +1,10 @@
-- name: Add Nginx config
+- name: Ensure default Nginx site is removed
+  file:
+    name: /etc/nginx/sites-enabled/default
+    state: absent
+  become: true
+
+- name: Ensure Nginx config is present and up to date
   template:
     src: nginx.conf.j2
     dest: /etc/nginx/nginx.conf
@@ -8,36 +14,64 @@
   become: true
   notify: reload nginx
 
-- name: Add Nginx site
+- name: Configure certificates
+  when: tls_enabled
+  block:
+  - name: Ensure LetsEncrypt webroot is present
+    file:
+      name: /var/www/letsencrypt
+      state: directory
+    become: true
+
+  - name: Ensure LetsEncrypt Nginx site is configured
+    template:
+      src: nginx-letsencrypt.conf.j2
+      dest: /etc/nginx/sites-enabled/letsencrypt.conf
+      owner: root
+      group: root
+      mode: 0644
+    become: true
+    register: letsencrypt_site
+
+  - name: Ensure LetsEncrypt site is active
+    service: name=nginx state=reloaded
+    when: letsencrypt_site is changed
+
+  - name: Configure dhparams
+    shell: curl https://ssl-config.mozilla.org/ffdhe2048.txt > /etc/nginx/dhparams.pem
+    args:
+      creates: /etc/nginx/dhparams.pem
+    become: true
+    notify: reload nginx
+
+  - name: Create certificates
+    shell: certbot certonly -n --webroot -w /var/www/letsencrypt --must-staple --agree-tos --email "{{ letsencrypt_email }}" -d "{{ domain_name }}"
+    args:
+      creates: "/etc/letsencrypt/live/{{ domain_name }}"
+    become: true
+    notify: reload nginx
+
+  - name: Ensure certs get renewed
+    cron:
+      name: certs_renewal
+      special_time: weekly
+      job: "certbot renew -q"
+      state: present
+
+- name: Ensure LetsEncrypt is disabled
+  when: not tls_enabled
+  file:
+    name: /etc/nginx/sites-enabled/letsencrypt.conf
+    state: absent
+  become: true
+  notify: reload nginx
+
+- name: Ensure Nginx site is configured and up to date
   template:
     src: nginx-catalogage.conf.j2
-    dest: /etc/nginx/sites-available/catalogage.conf
+    dest: /etc/nginx/sites-enabled/catalogage.conf
     owner: root
     group: root
     mode: 0644
   become: true
   notify: reload nginx
-
-- name: Ensure Nginx site is default
-  file:
-    src: /etc/nginx/sites-available/catalogage.conf
-    dest: /etc/nginx/sites-enabled/default
-    state: link
-  become: true
-  notify: reload nginx
-
-- name: Create and install certificates
-  shell: certbot run -n --nginx --agree-tos --redirect --staple-ocsp --must-staple -d "{{ domain_name }}" --email "{{ letsencrypt_email }}"
-  args:
-    creates: "/etc/letsencrypt/live/{{ domain_name }}"
-  become: true
-  when: tls_enabled
-  notify: reload nginx
-
-- name: Ensure certs get renewed
-  cron:
-    name: certs_renewal
-    special_time: weekly
-    job: "certbot renew -q"
-    state: present
-  when: tls_enabled

--- a/ops/ansible/roles/web/templates/nginx-catalogage.conf.j2
+++ b/ops/ansible/roles/web/templates/nginx-catalogage.conf.j2
@@ -7,13 +7,33 @@ upstream api {
 }
 
 server {
-    listen 80 default_server;
+    {% if tls_enabled %}
+    {# Adapted from: https://ssl-config.mozilla.org/ #}
+    listen 443 ssl;
     server_name {{ domain_name }};
 
-    location /.well-known/acme-challenge {
-        root /var/www/html;
-        try_files $uri $uri/ =404;
-    }
+    ssl_certificate /etc/letsencrypt/live/{{ domain_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ domain_name }}/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+    ssl_session_tickets off;
+
+    # From: https://ssl-config.mozilla.org/ffdhe2048.txt
+    ssl_dhparam /etc/nginx/dhparams.pem;
+
+    # intermediate configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # OSCP stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/{{ domain_name }}/chain.pem;
+    {% else %}
+    listen 80 default_server;
+    server_name {{ domain_name }};
+    {% endif %}
 
     location /favicon.ico {
         access_log off;

--- a/ops/ansible/roles/web/templates/nginx-letsencrypt.conf.j2
+++ b/ops/ansible/roles/web/templates/nginx-letsencrypt.conf.j2
@@ -1,0 +1,13 @@
+server {
+    listen 80 default_server;
+    server_name {{ domain_name }};
+
+    location /.well-known/acme-challenge {
+        root /var/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}


### PR DESCRIPTION
Cleanup #132 

Dans #132, j'avais utilisé le plugin `--nginx` de certbot. Malheureusement, ça ne fonctionne pas bien avec Ansible car le principe du plugin est de modifier la config Nginx en place, ce qui n'est pas une opération "isomorphe". (Lors du 1er déploiement, les certificats sont créés -car ils n'existent pas encore-, et la config sera modifée. Lors du 2nd déploiement, les certificats existent déjà, donc `certbot` n'est pas lancé -- et donc la config Nginx de base ne sera pas modifiée, le site restant configuré uniquement en HTTP (port 80). Il est possible de dissocier `certbot certonly` et `certbot install --nginx`, mais cette dernière opération semble ne pas certains paramètres de sécurité, dont le OCSP Staple.)

Après diverses expérimentations, et pour la simplicité, la solution est de procéder manuellement, sans le plugin.

D'où :

* Utilisation de la stratégie [webroot](https://eff-certbot.readthedocs.io/en/stable/using.html?highlight=testing#webroot) : dans Nginx, on crée un `server` séparé que l'on active au préalable pour l'exécution du _challenge_ LetsEncrypt. Cela génère les certificats que l'on peut ensuite utiliser dans le site principal.
* Configuration TLS explicite (tirée de https://ssl-config.mozilla.org)

Malheureusement, suite à mes tests j'ai atteint les [rate limits](https://letsencrypt.org/docs/rate-limits/) de LetsEncrypt. Erreur : ` too many certificates (5) already issued for this exact set of domains in the last 168 hours: staging.catalogue.multi.coop`. J'aurais en effet dû utiliser l'[environnement staging](https://letsencrypt.org/docs/staging-environment/) pour faire mes tests. Il semble que la retombée des _rate limits_ puisse prendre jusqu'à une semaine...

D'où : 

* Désactive `tls_enabled` sur staging et demo pour l'instant. Ça permet de merge cette PR, déployer, et accéder aux instances en HTTP (il faudra nettoyer le cache, dans Firefox : Historique -> multi.coop -> "Forget about this site"). Lorsque les rate limits seront rétablies, on réactivera `tls_enabled` dans une PR dédiée.