### PR TITLE
Add web security headers

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,8 +13,8 @@
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
     "test": "vitest run",
     "start-server": "cd .. && make serve",
-    "test-e2e": "playwright test",
-    "test-e2e:ci": "start-server-and-test start-server '3579/docs|3000' test-e2e",
+    "test-e2e": "E2E=1 playwright test",
+    "test-e2e:ci": "E2E=1 start-server-and-test start-server '3579/docs|3000' test-e2e",
     "test:watch": "vitest watch",
     "test:coverage": "npm run test -- --coverage"
   },

--- a/client/src/app.html
+++ b/client/src/app.html
@@ -16,12 +16,4 @@
   <body>
     <div id="svelte">%svelte.body%</div>
   </body>
-
-  <script>
-    // Options disponibles à l'initialisation du DSFR
-    window.dsfr = {
-      verbose: false,
-      mode: "loaded",
-    };
-  </script>
 </html>

--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -3,6 +3,8 @@ import preprocess from "svelte-preprocess";
 
 import vite from "./vite.config.js";
 
+const isE2E = !!process.env.E2E;
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   // Consult https://github.com/sveltejs/svelte-preprocess
@@ -17,19 +19,21 @@ const config = {
       allowed: ["PATCH", "DELETE"],
     },
 
-    csp: {
-      directives: {
-        "default-src": ["self"],
-        "font-src": [
-          "self",
-          "data:", // E.g. inline icon fonts (us or DSFR)
-        ],
-        "img-src": [
-          "self",
-          "data:", // E.g. DSFR inline images
-        ],
-      },
-    },
+    csp: isE2E
+      ? undefined
+      : {
+          directives: {
+            "default-src": ["self"],
+            "font-src": [
+              "self",
+              "data:", // E.g. inline icon fonts (us or DSFR)
+            ],
+            "img-src": [
+              "self",
+              "data:", // E.g. DSFR inline images
+            ],
+          },
+        },
 
     vite,
   },

--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -17,6 +17,20 @@ const config = {
       allowed: ["PATCH", "DELETE"],
     },
 
+    csp: {
+      directives: {
+        "default-src": ["self"],
+        "font-src": [
+          "self",
+          "data:", // E.g. inline icon fonts (us or DSFR)
+        ],
+        "img-src": [
+          "self",
+          "data:", // E.g. DSFR inline images
+        ],
+      },
+    },
+
     vite,
   },
   onwarn: (warning, handler) => {

--- a/ops/ansible/roles/web/templates/nginx-catalogage.conf.j2
+++ b/ops/ansible/roles/web/templates/nginx-catalogage.conf.j2
@@ -1,3 +1,7 @@
+add_header X-Frame-Options "DENY";
+add_header X-Content-Type-Options "nosniff";
+add_header X-XSS-Protection "1; mode=block";
+
 upstream client {
     server 127.0.0.1:{{ client_port }};
 }


### PR DESCRIPTION
Closes #133 

Configurer les headers suivants :

- `X-Frame-Options: DENY` (protection clickjacking)
- `X-Content-Type-Options: nosniff` (protection XSS)
- `Content-Security-Policy` (via [csp](https://kit.svelte.dev/docs/configuration#csp) dans SvelteKit) (protection XSS)
- `X-XSS-Protection: 1; mode=block` (protection XSS pour les ancies navigateurs IE / Safari ne supportant pas CSP)

Petit contournement nécessaire côté Playwright - visiblement il enfreint la CSP que l'on utilise en prod (pas clair pourquoi : un iframe ?), et [`bypassCSP`](https://playwright.dev/docs/api/class-testoptions#test-options-bypass-csp) ne semble pas avoir d'effet dans le `globalSetup`.