### PR TITLE
Fix login redirect flash

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,5 +1,7 @@
 import type { DataFormat } from "./definitions/datasets";
 
+export const PUBLIC_PAGES = ["/login"];
+
 export const DATA_FORMAT_LABELS: { [K in DataFormat]: string } = {
   file_tabular: "Fichier tabulaire (XLS, XLSX, CSV, ...)",
   file_gis: "Fichier SIG (Shapefile, ...)",

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,9 +1,18 @@
 import type { Handle } from "@sveltejs/kit";
 import { maybePatchDataUrl } from "$lib/fetch";
+import { PUBLIC_PAGES } from "./constants";
 
 // See: https://kit.svelte.dev/docs/hooks#handle
 export const handle: Handle = async ({ event, resolve }) => {
-  let response = await resolve(event);
+  let response = await resolve(event, {
+    // NOTE: SSR usage is aimed at improving SEO, so we focus on public pages.
+    // This also happens to simplify the e2e test setup, as auth state
+    // for private pages can then be exclusively managed in the browser.
+    // See: https://github.com/etalab/catalogage-donnees/pull/143
+    ssr: PUBLIC_PAGES.includes(event.url.pathname),
+  });
+
   response = await maybePatchDataUrl(response, event.url);
+
   return response;
 };

--- a/client/src/lib/auth/guard.ts
+++ b/client/src/lib/auth/guard.ts
@@ -1,6 +1,5 @@
 import { get } from "svelte/store";
 import type { LoadOutput } from "@sveltejs/kit";
-import { browser } from "$app/env";
 import { isLoggedIn } from "../stores/auth";
 
 const isPublicPage = (url: URL): boolean => {
@@ -13,10 +12,6 @@ const isPublicPage = (url: URL): boolean => {
  */
 export const authGuard = (url: URL): LoadOutput => {
   if (isPublicPage(url)) {
-    return {};
-  }
-
-  if (!browser) {
     return {};
   }
 

--- a/client/src/lib/auth/guard.ts
+++ b/client/src/lib/auth/guard.ts
@@ -1,17 +1,14 @@
 import { get } from "svelte/store";
 import type { LoadOutput } from "@sveltejs/kit";
 import { isLoggedIn } from "../stores/auth";
-
-const isPublicPage = (url: URL): boolean => {
-  return url.pathname === "/login";
-};
+import { PUBLIC_PAGES } from "src/constants";
 
 /**
  * Force-redirect to the login page if an unauthenticated user
  * is attempting to access a protected page.
  */
 export const authGuard = (url: URL): LoadOutput => {
-  if (isPublicPage(url)) {
+  if (PUBLIC_PAGES.includes(url.pathname)) {
     return {};
   }
 


### PR DESCRIPTION
Fixes #123, correctif suite à #109

Voire analyse dans l'issue

* Retrait du check `browser` dans le `guard`
* Désactivation du SSR hors pages publiques, évitant un pb de redirection systématique vers /login lors des tests e2e, le `storageState` Playwright n'étant pas applicable côté serveur SSR.