### PR TITLE
Tweak and enable TLS certs on demo and staging

### DIFF
--- a/docs/fr/ops.md
+++ b/docs/fr/ops.md
@@ -274,6 +274,67 @@ Il y a probablement soit un problème de configuration de la connexion entre Ngi
 ~/catalogage $ git log
 ```
 
+### Nginx ne redémarre pas
+
+Il est probable que la configuration Nginx soit corrompue (ex: : accès à une ressource qui n'existe pas ou plus), y compris en raison d'une faiblesse dans le setup Ansible.
+
+* Inspecter les logs d'erreurs / avertissements de Nginx :
+
+```
+~/catalogage $ nginx -t
+```
+
+### Certificats
+
+**_(Avancé)_**
+
+Les certificats TLS sont stockés par Certbot dans `/etc/letsencrypt` sur l'instance de chaque environnement.
+
+Pour vérifier le cronjob de renouvellement des certificats :
+
+```
+crontab -l
+```
+
+Le résultat doit contenir :
+
+```
+#Ansible: certs_renewal
+@weekly certbot renew -q
+```
+
+Pour lister les certificats, se connecter en SSH puis lancer :
+
+```
+$ certbot certificates
+root@catalogage-dev:~# certbot certificates
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Found the following certs:
+  Certificate Name: staging.catalogue.multi.coop
+    Serial Number: 44fdad5f55bedd1be22e249bc9928b1977f
+    Key Type: RSA
+    Domains: staging.catalogue.multi.coop
+    Expiry Date: 2022-06-26 14:59:19+00:00 (VALID: 89 days)
+    Certificate Path: /etc/letsencrypt/live/staging.catalogue.multi.coop/fullchain.pem
+    Private Key Path: /etc/letsencrypt/live/staging.catalogue.multi.coop/privkey.pem
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+```
+
+Pour régénérer manuellement les certificats pour un environnement :
+
+1. Se connecter en SSH.
+2. Révoquer le certificat :
+
+    ```
+    certbot revoke --cert-name <env>.catalogue.multi.coop
+    ```
+
+3. Redéployer : un nouveau certificat sera créé et configuré.
+
+> N.B. : LetsEncrypt applique du _rate limiting_ à la délivrance de certificats. Voir [Let's Encrypt: Rate Limits](https://letsencrypt.org/docs/rate-limits/).
+
 ## Versions
 
 ## OS

--- a/ops/ansible/environments/demo/group_vars/web.yml
+++ b/ops/ansible/environments/demo/group_vars/web.yml
@@ -1,3 +1,3 @@
 git_version: master
 
-tls_enabled: false
+tls_enabled: true

--- a/ops/ansible/environments/staging/group_vars/web.yml
+++ b/ops/ansible/environments/staging/group_vars/web.yml
@@ -1,3 +1,3 @@
 git_version: master
 
-tls_enabled: false
+tls_enabled: true

--- a/ops/ansible/roles/web/tasks/nginx.yml
+++ b/ops/ansible/roles/web/tasks/nginx.yml
@@ -23,6 +23,12 @@
       state: directory
     become: true
 
+  - name: Ensure app Nginx site is disabled while certs get configured
+    file:
+      name: /etc/nginx/sites-enabled/catalogage.conf
+      state: absent
+    become: true
+
   - name: Ensure LetsEncrypt Nginx site is configured
     template:
       src: nginx-letsencrypt.conf.j2
@@ -45,7 +51,7 @@
     notify: reload nginx
 
   - name: Create certificates
-    shell: certbot certonly -n --webroot -w /var/www/letsencrypt --must-staple --agree-tos --email "{{ letsencrypt_email }}" -d "{{ domain_name }}"
+    shell: certbot certonly -n --webroot -w /var/www/letsencrypt --agree-tos --email "{{ letsencrypt_email }}" -d "{{ domain_name }}"
     args:
       creates: "/etc/letsencrypt/live/{{ domain_name }}"
     become: true

--- a/ops/ansible/roles/web/templates/nginx-catalogage.conf.j2
+++ b/ops/ansible/roles/web/templates/nginx-catalogage.conf.j2
@@ -29,11 +29,6 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
-
-    # OSCP stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/{{ domain_name }}/chain.pem;
     {% else %}
     listen 80 default_server;
     server_name {{ domain_name }};


### PR DESCRIPTION
Refs #135 

* Réactive les certificats TLS maintenant que les rate limits de Let's Encrypt sont passées.
* Must-Staple est retiré car il ne semblait pas implémenté sous Firefox (TLS_MISSING_FEATURE).
* J'en profite pour ajouter un peu de doc supplémentaire.

https://staging.catalogue.multi.coop/