### PR TITLE
Add basic error page

### DIFF
--- a/client/src/routes/__error.svelte
+++ b/client/src/routes/__error.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" context="module">
+  import type { ErrorLoad } from "@sveltejs/kit";
+
+  export const load: ErrorLoad = ({ error, status }) => {
+    return {
+      props: {
+        title: `${status}: ${error.message}`
+      }
+    };
+  };
+</script>
+
+<script lang="ts">
+  export let title: string;
+</script>
+
+<section class="fr-container fr-mt-9w">
+  <h1>{title}</h1>
+</section>

--- a/client/src/routes/__error.svelte
+++ b/client/src/routes/__error.svelte
@@ -4,8 +4,8 @@
   export const load: ErrorLoad = ({ error, status }) => {
     return {
       props: {
-        title: `${status}: ${error.message}`
-      }
+        title: `${status}: ${error.message}`,
+      },
     };
   };
 </script>


### PR DESCRIPTION
Ajout d'une page d'erreur basique, en remplacement de la page par défaut de SvelteKit. Essentiellement pour créer ce fichier et se rappeler dans le futur que cette page sera à affiner.