### PR TITLE
Various presentational improvements

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -3,3 +3,14 @@
 mark {
   background-color: var(--background-contrast-info);
 }
+
+:root {
+  /*
+  Breakpoints in DSFR. This is for reference only. The @media CSS spec does not
+  support using var(), so you'll need to use these values explicitly.
+  */
+  --bp-sm: 36em;
+  --bp-md: 48em;
+  --bp-lg: 62em;
+  --bp-xl: 78em;
+}

--- a/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
+++ b/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
@@ -13,72 +13,79 @@
   };
 </script>
 
-<li class="fr-p-2w">
+<li class="fr-p-3w">
+  <p class="fr-logo fr-logo--sm fr-p-0" title="république française">
+    {@html "Ministère<br />de la culture"}
+  </p>
+
   <div class="fr-container">
-    <div class="fr-grid-row">
-      <div class="fr-col-2">
-        <p class="fr-text--sm">Ministère de la culture</p>
-      </div>
-      <div class="fr-col">
-        <div class="fr-container">
-          <p class="fr-grid-row">
-            {#if dataset.headlines}
-              <strong data-testid="headlines-title">
-                {@html dataset.headlines.title}
-              </strong>
-            {:else}
-              <strong>
-                {dataset.title}
-              </strong>
-            {/if}
-          </p>
-          <p class="fr-grid-row fr-text--sm fr-text-mention--grey">
-            Bibliothèque nationale de France
-          </p>
-          <div class="fr-grid-row">
-            <span class="fr-col"> France </span>
-            <span class="fr-col"> 2010-2018 </span>
-            <span class="fr-col"> {formatFormats(dataset)} </span>
-            <span class="fr-col"> Qualité : haute </span>
-            <span class="fr-col"> Open data </span>
-          </div>
-          {#if dataset.headlines}
-            <div class="fr-grid-row fr-mt-1w">
-              <p class="fr-text--sm fr-text-mention--grey">
-                <em data-testid="headlines-description"
-                  >... {@html dataset.headlines.description} ...</em
-                >
-              </p>
-            </div>
-          {/if}
-        </div>
-      </div>
-      <div class="fr-col-2 fr-container fr-container--fluid">
-        <div
-          class="fr-grid-row fr-grid-row--right fr-text--sm fr-text-mention--grey dataset-created-at"
-        >
-          {capitalize(formatDaysMonthsOrYearsToNow(dataset.createdAt))}
-        </div>
-        <div class="fr-grid-row fr-grid-row--right">
-          <a
-            href={paths.datasetDetail({ id: dataset.id })}
-            class="fr-link fr-fi-arrow-right-line fr-link--icon-right"
-            title="Consulter cette fiche de données"
-          >
-            Voir
-          </a>
-        </div>
-      </div>
+    <p class="fr-m-0">
+      {#if dataset.headlines}
+        <strong data-testid="headlines-title">
+          {@html dataset.headlines.title}
+        </strong>
+      {:else}
+        <strong>
+          {dataset.title}
+        </strong>
+      {/if}
+    </p>
+    <p class="fr-m-0 fr-text--sm fr-text-mention--grey">
+      Bibliothèque nationale de France
+    </p>
+    <div class="metadata-items">
+      <span> France </span>
+      <span> 2010-2018 </span>
+      <span> {formatFormats(dataset)} </span>
+      <span> Qualité : haute </span>
+      <span> Open data </span>
     </div>
+    {#if dataset.headlines}
+      <p class="fr-mb-0 fr-mt-1w fr-text--sm fr-text-mention--grey">
+        <em data-testid="headlines-description"
+          >... {@html dataset.headlines.description} ...</em
+        >
+      </p>
+    {/if}
+  </div>
+
+  <div class="actions">
+    <p class="fr-mb-2w fr-text--sm fr-text-mention--grey">
+      {capitalize(formatDaysMonthsOrYearsToNow(dataset.createdAt))}
+    </p>
+    <a
+      href={paths.datasetDetail({ id: dataset.id })}
+      class="fr-link fr-fi-arrow-right-line fr-link--icon-right"
+      title="Consulter cette fiche de données"
+    >
+      Voir
+    </a>
   </div>
 </li>
 
 <style>
+  li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    column-gap: 1em;
+  }
+
   li:not(:last-child) {
     border-bottom: 1px solid var(--border-default-grey);
   }
 
-  .dataset-created-at {
+  .metadata-items {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 -1em;
+  }
+
+  .metadata-items > * {
+    flex: 1 1 auto;
+    margin: 0 1em;
+  }
+
+  .actions {
     text-align: right;
   }
 </style>

--- a/client/src/routes/fiches/[id]/index.svelte
+++ b/client/src/routes/fiches/[id]/index.svelte
@@ -21,15 +21,13 @@
   const editUrl = paths.datasetEdit({ id: dataset.id });
 </script>
 
-<section class="fr-container fr-mt-6w">
-  <div class="fr-grid-row fr-grid-row--middle">
-    <div class="fr-col-2">
-      <p class="fr-logo" title="république française">
-        {@html "Ministère<br />de la culture"}
-      </p>
-    </div>
-    <div class="fr-col">
-      <p class="fr-mb-0 fr-text-mention--grey">Ministère de la culture</p>
+<section class="fr-container header">
+  <div class="header-headlines">
+    <p class="fr-logo" title="république française">
+      {@html "Ministère<br />de la culture"}
+    </p>
+    <div>
+      <p class="fr-m-0 fr-text-mention--grey">Ministère de la culture</p>
       <h1>
         {dataset.title}
       </h1>
@@ -37,7 +35,7 @@
   </div>
 
   <ul
-    class="fr-grid-row fr-grid-row--right fr-btns-group fr-btns-group--inline fr-btns-group--icon-right fr-mb-3w"
+    class="header-toolbar fr-grid-row fr-btns-group fr-btns-group--inline fr-btns-group--icon-right fr-mb-3w"
   >
     <li>
       <a
@@ -67,64 +65,61 @@
   </ul>
 </section>
 
-<aside
-  role="contentinfo"
-  aria-label="Métadonnées sur ce jeu de données"
-  class="fr-container"
->
-  <div class="fr-grid-row fr-grid-row--gutters">
-    <div class="fr-col-4">
-      <div class="aside-entry">
-        <span class="fr-fi--lg fr-fi-x-bank-line" aria-hidden="true" />
-        <p>
-          <span class="fr-text--xs">Producteur</span><br />
-          <span>DRAC Bretagne</span>
-        </p>
-      </div>
-      <div class="aside-entry">
-        <span class="fr-fi--lg fr-fi-x-map-2-line" aria-hidden="true" />
-        <p>
-          <span class="fr-text--xs">Couverture géographique</span><br />
-          <span>France métropolitaine</span>
-        </p>
-      </div>
-      <div class="aside-entry">
-        <span class="fr-fi--lg fr-fi-calendar-line" aria-hidden="true" />
-        <p>
-          <span class="fr-text--xs">Couverture temporelle</span><br />
-          <span>2015-2022</span>
-        </p>
-      </div>
-
-      <h6>Temporalité</h6>
-
-      <div class="aside-entry">
-        <span
-          class="fr-fi--lg fr-fi-x-calendar-check-line"
-          aria-hidden="true"
-        />
-        <p>
-          <span class="fr-text--xs">Date de dernière mise à jour</span><br />
-          <span>13 septembre 2021</span>
-        </p>
-      </div>
-      <div class="aside-entry">
-        <span class="fr-fi--lg fr-fi-refresh-line" aria-hidden="true" />
-        <p>
-          <span class="fr-text--xs">Fréquence de mise à jour</span><br />
-          <span>Mensuelle ou plusieurs fois par an</span>
-        </p>
-      </div>
-      <div class="aside-entry">
-        <span class="fr-fi--lg fr-fi-x-cake-2-line" aria-hidden="true" />
-        <p>
-          <span class="fr-text--xs">Date de première publication</span><br />
-          <span>15 décembre 2019</span>
-        </p>
-      </div>
+<section class="layout fr-container">
+  <aside
+    role="contentinfo"
+    aria-label="Métadonnées sur ce jeu de données"
+    class="fr-container"
+  >
+    <div class="aside-entry">
+      <span class="fr-fi--lg fr-fi-x-bank-line" aria-hidden="true" />
+      <p>
+        <span class="fr-text--xs">Producteur</span><br />
+        <span>DRAC Bretagne</span>
+      </p>
+    </div>
+    <div class="aside-entry">
+      <span class="fr-fi--lg fr-fi-x-map-2-line" aria-hidden="true" />
+      <p>
+        <span class="fr-text--xs">Couverture géographique</span><br />
+        <span>France métropolitaine</span>
+      </p>
+    </div>
+    <div class="aside-entry">
+      <span class="fr-fi--lg fr-fi-calendar-line" aria-hidden="true" />
+      <p>
+        <span class="fr-text--xs">Couverture temporelle</span><br />
+        <span>2015-2022</span>
+      </p>
     </div>
 
-    <div class="fr-col fr-tabs">
+    <h6>Temporalité</h6>
+
+    <div class="aside-entry">
+      <span class="fr-fi--lg fr-fi-x-calendar-check-line" aria-hidden="true" />
+      <p>
+        <span class="fr-text--xs">Date de dernière mise à jour</span><br />
+        <span>13 septembre 2021</span>
+      </p>
+    </div>
+    <div class="aside-entry">
+      <span class="fr-fi--lg fr-fi-refresh-line" aria-hidden="true" />
+      <p>
+        <span class="fr-text--xs">Fréquence de mise à jour</span><br />
+        <span>Mensuelle ou plusieurs fois par an</span>
+      </p>
+    </div>
+    <div class="aside-entry">
+      <span class="fr-fi--lg fr-fi-x-cake-2-line" aria-hidden="true" />
+      <p>
+        <span class="fr-text--xs">Date de première publication</span><br />
+        <span>15 décembre 2019</span>
+      </p>
+    </div>
+  </aside>
+
+  <section>
+    <div class="fr-tabs">
       <ul
         class="fr-tabs__list"
         role="tablist"
@@ -220,10 +215,43 @@
         À venir
       </div>
     </div>
-  </div>
-</aside>
+  </section>
+</section>
 
 <style>
+  .header {
+    margin-top: 1.5rem;
+  }
+
+  @media (min-width: 36em /* sm */) {
+    .header {
+      margin-top: 3rem;
+    }
+
+    .header-headlines {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: 1em;
+      align-items: center;
+    }
+  }
+
+  @media (min-width: 48em /* md */) {
+    .header-headlines {
+      column-gap: 3em;
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: 1em;
+    }
+
+    .header-toolbar {
+      justify-content: flex-end;
+    }
+  }
+
   .aside-entry {
     align-items: center;
     display: flex;

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -35,7 +35,7 @@
 </svelte:head>
 
 <section class="fr-background-alt--grey fr-mb-6w">
-  <div class="fr-container fr-grid-row fr-grid-row--center fr-p-6w">
+  <div class="fr-container fr-grid-row fr-grid-row--center fr-py-6w">
     <div class="fr-col-10">
       <h1>Recherchez un jeu de données</h1>
       <SearchForm


### PR DESCRIPTION
Cette PR ajoute diverses améliorations de présentation :

- Rendu sur mobile (responsive) - Champ de recherche, liste, page d'une fiche
- Simplification du HTML en écrivant du CSS sur mesure (les classes utilitaires du type `fr-grid-row fr-container` ont tendance à surcharger le HTML tout en ne facilitant pas un rendu responsive)
- Ajout du mini-logo FR aux list items (mockup en attendant un logo par organisation)

## Aperçu

![Screenshot 2022-03-29 at 15-09-50 Catalogue](https://user-images.githubusercontent.com/15911462/160618600-e78d035c-503d-485f-b5fc-2053a96f626d.png) (120 kB)

![Screenshot 2022-03-29 at 15-08-51 Catalogue](https://user-images.githubusercontent.com/15911462/160618690-d5d544cf-d211-45d8-a88b-3d50f550f0fa.png) (118 kB)
