### PR TITLE
Show migrate task as changed only if migrations effectively applied

### DIFF
--- a/ops/ansible/roles/web/tasks/db.yml
+++ b/ops/ansible/roles/web/tasks/db.yml
@@ -9,3 +9,5 @@
   shell:
     cmd: make migrate
     chdir: "{{ workdir }}"
+  register: migrate
+  changed_when: "'Running upgrade' in migrate.stderr"


### PR DESCRIPTION
Petite amélioration "expérience dev" du setup Ansible

## Motivation

Actuellement lorsqu'on déploie, la tâche de migrations est toujours marquée comme "changed" :

```console
TASK [web : Ensure migrations are up to date] ***************************************
changed: [localhost]
```

Et ce même si aucune migration n'a été lancée car elles seraient déjà à jour, avec ce genre d'output :

```console
$ make migrate
venv/bin/alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
```

Ce qui ne contribue pas à un retour fidèle

## Description

Cette PR ajoute une option `changed_when` pour ne marquer la tâche comme "changed" que si une migration a effectivement été appliquée, avec ce genre d'output :

```console
$ make migrate
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade d694d065978d -> 67a6c2bf0696, add-dataset-contact-emails
```

Ça permet juste d'avoir un retour plus fidèle des changements appliqués lors du déploiement.

## Test

Testé sur la VM de test : 

- Lancer `venv/bin/alembic downgrade head-1` pour avoir une migration à appliquer
- Lancer le déploiement `make deploy env=test`
- La tâche migrate est `changed`
- Lancer le déploiement à nouveau
- La tâche migrate est `ok`

## Autres

N.B. : D'autres tâches sont toujours marquées comme changed, je les note pour référence. 1/ `Node dependencies` est toujours `changed` mais c'est une limite du module `ansible.community.npm`. 2/ `make build` est toujours `changed`, en théorie on devrait pouvoir se baser sur le commit hash.