### PR TITLE
Add tests for initdata tool

### DIFF
--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from server.application.datasets.commands import UpdateDataset
+from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
+from server.config.di import resolve
+from server.seedwork.application.messages import MessageBus
+from tools import initdata
+
+
+@pytest.mark.asyncio
+async def test_initdata_empty(tmp_path: Path) -> None:
+    bus = resolve(MessageBus)
+
+    spec: dict = {"users": [], "datasets": []}
+    path = tmp_path / "initdata.yml"
+    path.write_text(yaml.dump(spec))
+
+    await initdata.main(path)
+
+    assert await bus.execute(GetAllDatasets()) == []
+
+
+@pytest.mark.asyncio
+async def test_initdata(capsys: pytest.CaptureFixture) -> None:
+    bus = resolve(MessageBus)
+    path = Path("tools", "initdata.yml")
+
+    # Initial run creates data items.
+    await initdata.main(path)
+    captured = capsys.readouterr()
+    assert captured.out.count("created") == 4
+
+    pk = "16b398af-f8c7-48b9-898a-18ad3404f528"
+    dataset = await bus.execute(GetDatasetByID(id=pk))
+    assert dataset.title == "Données brutes de l'inventaire forestier"
+
+    # Run a second time, without changes.
+    await initdata.main(path)
+    captured = capsys.readouterr()
+    assert captured.out.count("ok") == 4
+
+    # Make a change.
+    command = UpdateDataset(**dataset.dict(exclude={"title"}), title="Changed")
+    await bus.execute(command)
+    dataset = await bus.execute(GetDatasetByID(id=pk))
+    assert dataset.title == "Changed"
+
+    # No reset: dataset left unchanged
+    await initdata.main(path)
+    captured = capsys.readouterr()
+    assert captured.out.count("ok") == 4
+    dataset = await bus.execute(GetDatasetByID(id=pk))
+    assert dataset.title == "Changed"
+
+    # Reset: dataset goes back to initial state defined in yml file
+    await initdata.main(path, reset=True)
+    captured = capsys.readouterr()
+    assert captured.out.count("ok") == 3, captured.out
+    assert captured.out.count("reset") == 1
+    dataset = await bus.execute(GetDatasetByID(id=pk))
+    assert dataset.title == "Données brutes de l'inventaire forestier"
+
+    # Reset: dataset left in initial state
+    await initdata.main(path, reset=True)
+    captured = capsys.readouterr()
+    assert captured.out.count("ok") == 4
+    dataset = await bus.execute(GetDatasetByID(id=pk))
+    assert dataset.title == "Données brutes de l'inventaire forestier"

--- a/tools/initdata.py
+++ b/tools/initdata.py
@@ -57,9 +57,8 @@ async def handle_dataset(item: dict, reset: bool = False) -> None:
             print(f"{warn('reset')}: {command!r}")
             return
 
-        result = "unchanged" if reset else "ok"
         dataset_repr = f"Dataset(id={id_!r}, title={item['params']['title']!r}, ...)"
-        print(f"{info(result)}: {dataset_repr}")
+        print(f"{info('ok')}: {dataset_repr}")
         return
 
     command = CreateDataset(**item["params"])

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -15,6 +15,7 @@ datasets:
       formats:
         - website
       entrypoint_email: service@example.org
+      contact_emails: []
 
   -  # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
@@ -25,6 +26,7 @@ datasets:
       formats:
         - file_tabular
       entrypoint_email: service@example.org
+      contact_emails: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
@@ -35,3 +37,4 @@ datasets:
       formats:
         - other
       entrypoint_email: service@example.org
+      contact_emails: []


### PR DESCRIPTION
Cette PR ajoute des tests pour l'outil `make initdata(reset)` (cf #118).

Corrige aussi un bug présent sur `master` : champ `contact_emails` manquant dans le fichier YAML.