### PR TITLE
Treat password variables as secret

### DIFF
--- a/server/api/auth/schemas.py
+++ b/server/api/auth/schemas.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, SecretStr
 
 from server.domain.auth.entities import UserRole
 from server.domain.common.types import ID
@@ -20,12 +20,12 @@ class UserAuthenticatedRead(BaseModel):
 
 class UserCreate(BaseModel):
     email: EmailStr
-    password: str
+    password: SecretStr
 
 
 class UserLogin(BaseModel):
     email: EmailStr
-    password: str
+    password: SecretStr
 
 
 class CheckAuthResponse(BaseModel):

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -1,10 +1,12 @@
+from pydantic import SecretStr
+
 from server.domain.common.types import ID
 from server.seedwork.application.commands import Command
 
 
 class CreateUser(Command[ID]):
     email: str
-    password: str
+    password: SecretStr
 
 
 class DeleteUser(Command[None]):

--- a/server/application/auth/passwords.py
+++ b/server/application/auth/passwords.py
@@ -1,11 +1,13 @@
 import secrets
 
+from pydantic import SecretStr
+
 
 class PasswordEncoder:
-    def hash(self, value: str) -> str:
+    def hash(self, password: SecretStr) -> str:
         raise NotImplementedError  # pragma: no cover
 
-    def verify(self, password: str, hash: str) -> bool:
+    def verify(self, password: SecretStr, hash: str) -> bool:
         raise NotImplementedError  # pragma: no cover
 
 

--- a/server/application/auth/queries.py
+++ b/server/application/auth/queries.py
@@ -1,10 +1,12 @@
+from pydantic import SecretStr
+
 from server.domain.auth.entities import User
 from server.seedwork.application.queries import Query
 
 
 class Login(Query[User]):
     email: str
-    password: str
+    password: SecretStr
 
 
 class GetUserByEmail(Query[User]):

--- a/server/infrastructure/auth/passwords.py
+++ b/server/infrastructure/auth/passwords.py
@@ -1,4 +1,5 @@
 import argon2
+from pydantic import SecretStr
 
 from server.application.auth.passwords import PasswordEncoder
 
@@ -7,12 +8,12 @@ class Argon2PasswordEncoder(PasswordEncoder):
     def __init__(self) -> None:
         self._hasher = argon2.PasswordHasher()
 
-    def hash(self, value: str) -> str:
-        return self._hasher.hash(value)
+    def hash(self, password: SecretStr) -> str:
+        return self._hasher.hash(password.get_secret_value())
 
-    def verify(self, password: str, hash: str) -> bool:
+    def verify(self, password: SecretStr, hash: str) -> bool:
         try:
-            return self._hasher.verify(hash, password)
+            return self._hasher.verify(hash, password.get_secret_value())
         except argon2.exceptions.VerificationError:
             return False
         except argon2.exceptions.InvalidHash:

--- a/tests/unit/test_passwords.py
+++ b/tests/unit/test_passwords.py
@@ -1,3 +1,5 @@
+from pydantic import SecretStr
+
 from server.application.auth.passwords import generate_api_token
 from server.infrastructure.auth.passwords import Argon2PasswordEncoder
 
@@ -9,8 +11,9 @@ def test_generate_api_token() -> None:
 
 
 def test_argon2_password_encoder() -> None:
+    password = SecretStr("s3kr3t")
     encoder = Argon2PasswordEncoder()
-    hash_ = encoder.hash("s3kr3t")
-    assert encoder.verify("s3kr3t", hash_)
-    assert not encoder.verify("other", hash_)
-    assert not encoder.verify("s3kr3t", "invalidhash")
+    hash_ = encoder.hash(password)
+    assert encoder.verify(password, hash_)
+    assert not encoder.verify(SecretStr("other"), hash_)
+    assert not encoder.verify(password, "invalidhash")


### PR DESCRIPTION
Closes #172 

Toute l'app utilise désormais des mots de passe encapsulés dans un `SecretStr` (la valeur ne peut être qu'obtenue explicitement par `.get_secret_value()`)

`make initdata` affiche désormais:

```console
created: CreateUser(email='admin@catalogue.data.gouv.fr', password=SecretStr('**********'))
```