### PR TITLE
Document how to deploy from a specific git ref

### DIFF
--- a/docs/fr/ops.md
+++ b/docs/fr/ops.md
@@ -90,6 +90,14 @@ Exemple :
 make deploy env=staging
 ```
 
+Si vous souhaitez déployer depuis une branche (dans le cadre d'une _pull request_, par exemple), utilisez :
+
+```
+make deploy env=<ENV> extra_opts="-e git_version=<BRANCH>"
+```
+
+> **Tip** : `git_version` accepte n'importe quelle [référence git](https://git-scm.com/book/fr/v2/Les-tripes-de-Git-R%C3%A9f%C3%A9rences-Git) (branche, tag...) ou commit hash.
+
 En cas de problème, voir [Débogage](#débogage).
 
 ### Ajouter un nouvel environnement


### PR DESCRIPTION
Suite de #174, la documentation sur comment déployer depuis une PR était manquante, or @Volubyl va le faire pour #157.