### PR TITLE
Fix transformers and form handling for lastUpdatedAt and updateFrequency

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -20,7 +20,7 @@ export const DATA_FORMAT_SHORT_NAMES: { [K in DataFormat]: string } = {
   other: "Autre",
 };
 
-export const UPDATE_FREQUENCY: { [K in UpdateFrequency]: string } = {
+export const UPDATE_FREQUENCY_LABELS: { [K in UpdateFrequency]: string } = {
   never: "Aucune (contribution ponctuelle)",
   realtime: "Permanente (temps réel)",
   daily: "Quotidienne (ou plusieures fois par jour)",

--- a/client/src/definitions/datasets.d.ts
+++ b/client/src/definitions/datasets.d.ts
@@ -30,8 +30,8 @@ export type Dataset = {
   entrypointEmail: string;
   contactEmails: string[];
   service: string;
-  updateFrequency: string;
-  lastUpdatedAt: string;
+  lastUpdatedAt: Date | null;
+  updateFrequency: UpdateFrequency | null;
 };
 
 export type DatasetFormData = Omit<Dataset, "id" | "createdAt" | "headlines">;

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -125,7 +125,7 @@ describe("Test the dataset form", () => {
     expect(updateFrequency.value).toBe("never");
   });
 
-  test("Nullable fields are handled correctly", async () => {
+  test("Null fields are correctly handled in HTML and submitted as null", async () => {
     const initial: DatasetFormData = {
       title: "Titre initial",
       description: "Description initiale",

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -3,7 +3,6 @@ import "@testing-library/jest-dom";
 import DatasetForm from "./DatasetForm.svelte";
 import { render, fireEvent, waitFor } from "@testing-library/svelte";
 import type { DataFormat, DatasetFormData } from "src/definitions/datasets";
-import { UPDATE_FREQUENCY } from "src/constants";
 
 describe("Test the dataset form", () => {
   test('The "title" field is present', () => {

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -7,7 +7,7 @@
     DatasetFormData,
     UpdateFrequency,
   } from "src/definitions/datasets";
-  import { DATA_FORMAT_LABELS, UPDATE_FREQUENCY } from "src/constants";
+  import { DATA_FORMAT_LABELS, UPDATE_FREQUENCY_LABELS } from "src/constants";
   import { formatHTMLDate } from "$lib/util/format";
   import RequiredMarker from "../RequiredMarker/RequiredMarker.svelte";
   import { user } from "src/lib/stores/auth";
@@ -123,23 +123,34 @@
     updateValidateField("dataFormats", dataFormatsValue);
   };
 
-  const handleLastUpdatedAtChange = (
+  const handleLastUpdatedAtChange = async (
     event: Event & { currentTarget: EventTarget & HTMLInputElement }
   ) => {
-    return event.currentTarget.value ? handleChange(event) : null;
+    if (!event.currentTarget.value /* Empty date */) {
+      // Needs manual handling, otherwise yup would call e.g. new Date("") which is invalid.
+      updateValidateField("lastUpdatedAt", null);
+    } else {
+      await handleChange(event);
+    }
   };
 
-  const handleUpdateFrequencyChange = (
+  const handleUpdateFrequencyChange = async (
     event: Event & { currentTarget: EventTarget & HTMLSelectElement }
   ) => {
-    return event.currentTarget.value === "null" ? null : handleChange(event);
+    if (event.currentTarget.value === "null" /* Empty option selected */) {
+      // Needs manual handling to ensure a `null` initial value and the empty
+      // option all correspond to `null`.
+      updateValidateField("updateFrequency", null);
+    } else {
+      await handleChange(event);
+    }
   };
 </script>
 
 <form
   on:submit={handleSubmit}
   data-bitwarden-watching="1"
-  aria-label="Formulaire de contribution"
+  aria-label="Informations sur le jeu de données"
 >
   <h2 class="fr-mt-6w">Informations générales</h2>
 
@@ -381,9 +392,11 @@
       on:change={handleUpdateFrequencyChange}
       on:blur={handleUpdateFrequencyChange}
     >
-      <option value={null} selected hidden>Sélectionner une option</option>
-      {#each Object.keys(UPDATE_FREQUENCY) as frequency}
-        <option value={frequency}>{UPDATE_FREQUENCY[frequency]}</option>
+      <option value={null} selected disabled hidden
+        >Sélectionner une option</option
+      >
+      {#each Object.keys(UPDATE_FREQUENCY_LABELS) as frequency}
+        <option value={frequency}>{UPDATE_FREQUENCY_LABELS[frequency]}</option>
       {/each}
     </select>
 

--- a/client/src/lib/transformers/dataset.spec.ts
+++ b/client/src/lib/transformers/dataset.spec.ts
@@ -7,13 +7,13 @@ import {
 } from "./dataset";
 
 describe("transformers -- dataset", () => {
-  describe("transformKeysToUnderscoreCase", () => {
+  test("transformKeysToUnderscoreCase", () => {
     const text = "helloWorld";
     const result = camelToUnderscore(text);
     expect(result).toBe("hello_world");
   });
 
-  describe("transformKeysToUnderscoreCase", () => {
+  test("transformKeysToUnderscoreCase", () => {
     const input = {
       helloWorld: "hello",
       fooBaz: "hello",
@@ -23,7 +23,7 @@ describe("transformers -- dataset", () => {
     expect(Object.keys(result).every((key) => key.includes("_"))).toBe(true);
   });
 
-  describe("toPayload", () => {
+  test("toPayload", () => {
     const dataset = getFakeDataset();
     const result = toPayload(dataset);
     expect(Object.keys(result).every((key) => key === key.toLowerCase())).toBe(
@@ -31,7 +31,7 @@ describe("transformers -- dataset", () => {
     );
   });
 
-  describe("toDataset", () => {
+  test("toDataset", () => {
     const dataset = toPayload(getFakeDataset());
     const result = toDataset(dataset);
     expect(Object.keys(result).every((key) => key === key.toLowerCase())).toBe(

--- a/client/src/lib/transformers/dataset.ts
+++ b/client/src/lib/transformers/dataset.ts
@@ -1,4 +1,3 @@
-import format from "date-fns/format";
 import type { Dataset } from "src/definitions/datasets";
 
 export const camelToUnderscore = (key: string): string => {
@@ -41,6 +40,6 @@ export const toDataset = (item: any): Dataset => {
     entrypointEmail: entrypoint_email,
     contactEmails: contact_emails,
     updateFrequency: update_frequency,
-    lastUpdatedAt: format(new Date(last_updated_at), "yyyy-MM-dd"),
+    lastUpdatedAt: last_updated_at ? new Date(last_updated_at) : null,
   };
 };

--- a/client/src/lib/transformers/dataset.ts
+++ b/client/src/lib/transformers/dataset.ts
@@ -18,11 +18,7 @@ export const transformKeysToUnderscoreCase = (object: {
 export const toPayload = (
   data: Partial<Record<keyof Dataset, any>>
 ): { [K: string]: unknown } => {
-  const transformed = transformKeysToUnderscoreCase(data);
-  return {
-    ...transformed,
-    last_updated_at: new Date(data.lastUpdatedAt).toISOString(),
-  };
+  return transformKeysToUnderscoreCase(data);
 };
 
 export const toDataset = (item: any): Dataset => {

--- a/client/src/lib/util/format.ts
+++ b/client/src/lib/util/format.ts
@@ -15,6 +15,10 @@ export const capitalize = (text: string): string => {
   return text.charAt(0).toUpperCase() + text.slice(1);
 };
 
+export const formatHTMLDate = (date: Date): string => {
+  return datefns.format(date, "yyyy-MM-dd");
+};
+
 export const formatDaysMonthsOrYearsToNow = (date: Date): string => {
   const now = new Date();
 

--- a/client/src/tests/e2e/contribuer.spec.ts
+++ b/client/src/tests/e2e/contribuer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { UPDATE_FREQUENCY } from "src/constants";
+import { UPDATE_FREQUENCY_LABELS } from "src/constants";
 import { STATE_AUTHENTICATED } from "./constants";
 
 test.describe("Basic form submission", () => {
@@ -56,7 +56,9 @@ test.describe("Basic form submission", () => {
     expect(await lastUpdatedAt.inputValue()).toBe(lastUpdatedAtDate);
 
     const updateFrequency = page.locator("form [name=updateFrequency]");
-    await updateFrequency.selectOption({ label: UPDATE_FREQUENCY.daily });
+    await updateFrequency.selectOption({
+      label: UPDATE_FREQUENCY_LABELS.daily,
+    });
 
     const button = page.locator("button[type='submit']");
     const [request, response] = await Promise.all([

--- a/client/src/tests/factories/dataset.ts
+++ b/client/src/tests/factories/dataset.ts
@@ -1,4 +1,3 @@
-import { UPDATE_FREQUENCY } from "src/constants";
 import type { Dataset, DatasetFormData } from "src/definitions/datasets";
 
 export const getFakeDataset = (dataset: Partial<Dataset> = {}): Dataset => {
@@ -11,8 +10,8 @@ export const getFakeDataset = (dataset: Partial<Dataset> = {}): Dataset => {
     entrypointEmail: dataset.entrypointEmail || "jane.doe@beta.gouv.fr",
     contactEmails: dataset.contactEmails || ["contact@beta.gouv.fr"],
     service: dataset.service || "La Drac",
-    updateFrequency: dataset.updateFrequency || UPDATE_FREQUENCY.daily,
-    lastUpdatedAt: dataset.lastUpdatedAt || new Date().toISOString(),
+    updateFrequency: dataset.updateFrequency || "daily",
+    lastUpdatedAt: dataset.lastUpdatedAt || new Date(),
   };
 };
 
@@ -26,7 +25,7 @@ export const getFakeDataSetFormData = (
     entrypointEmail: datasetFormData.entrypointEmail || "jane.doe@beta.gouv.fr",
     contactEmails: datasetFormData.contactEmails || ["contact@beta.gouv.fr"],
     service: datasetFormData.service || "La Drac",
-    updateFrequency: datasetFormData.updateFrequency || UPDATE_FREQUENCY.daily,
-    lastUpdatedAt: datasetFormData.lastUpdatedAt || new Date().toISOString(),
+    updateFrequency: datasetFormData.updateFrequency || "daily",
+    lastUpdatedAt: datasetFormData.lastUpdatedAt || new Date(),
   };
 };


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/157#discussion_r849339366

Il y avait plusieurs bugs subtils liés à ce qui suit :

* `last_updated_at` et `update_frequency` sont en réalité optionnels (cf maquette et API)
* Le type de ces champs "en interne". Par ex `lastUpdatedAt` doit bien être ingéré comme un `Date | null`, et non comme une string déjà formatée.
* L'interaction de leurs types respectifs avec HTML. Exemple : `lastUpdatedAt` est un `Date | null`, mais un `<input type="date">` a une `value` qui est toujours un `string`, y compris `""` si aucune date n'est sélectionnée => il faut s'assurer de convertir cela en `null`, sinon yup calculera `new Date("")` ce qui est une `Invalid Date`, et affichera une erreur. Idem pour le `updateFrequency` dans le cas où aucune valeur n'est sélectionnée

Cette PR les corrige et ajoute des tests unitaires

Par ailleurs les TU des `transformers/datasets` n'étaient pas exécuté (describe au lieu de test)