### PR TITLE
Add geographical_coverage and technical_source to API + form fields in the UI

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,8 @@
-import type { DataFormat, UpdateFrequency } from "./definitions/datasets";
+import type {
+  DataFormat,
+  UpdateFrequency,
+  GeographicalCoverage,
+} from "./definitions/datasets";
 
 export const PUBLIC_PAGES = ["/login"];
 
@@ -27,4 +31,17 @@ export const UPDATE_FREQUENCY_LABELS: { [K in UpdateFrequency]: string } = {
   weekly: "Hebdomadaire (ou plusieures fois par semaine)",
   monthly: "Mensuelle (ou plusieures fois pas mois)",
   yearly: "Annuel (ou plusieures fois par an)",
+};
+
+export const GEOGRAPHICAL_COVERAGE_LABELS: {
+  [K in GeographicalCoverage]: string;
+} = {
+  municipality: "Communale",
+  epci: "EPCI",
+  department: "Départementale",
+  region: "Régionale",
+  national: "Nationale (métropole)",
+  national_full_territory: "Nationale (terr Outre-mer inclus)",
+  europe: "Européenne",
+  world: "Monde",
 };

--- a/client/src/definitions/datasets.ts
+++ b/client/src/definitions/datasets.ts
@@ -1,5 +1,5 @@
 // Matches enum on the backend.
-type DataFormat =
+export type DataFormat =
   | "file_tabular"
   | "file_gis"
   | "api"
@@ -7,13 +7,23 @@ type DataFormat =
   | "website"
   | "other";
 
-type UpdateFrequency =
+export type UpdateFrequency =
   | "never"
   | "realtime"
   | "daily"
   | "weekly"
   | "monthly"
   | "yearly";
+
+export type GeographicalCoverage =
+  | "municipality"
+  | "epci"
+  | "department"
+  | "region"
+  | "national"
+  | "national_full_territory"
+  | "europe"
+  | "world";
 
 export interface DatasetHeadlines {
   title: string;
@@ -32,6 +42,8 @@ export type Dataset = {
   service: string;
   lastUpdatedAt: Date | null;
   updateFrequency: UpdateFrequency | null;
+  geographicalCoverage: GeographicalCoverage;
+  technicalSource: string | null;
 };
 
 export type DatasetFormData = Omit<Dataset, "id" | "createdAt" | "headlines">;

--- a/client/src/definitions/form.ts
+++ b/client/src/definitions/form.ts
@@ -1,0 +1,4 @@
+export type SelectOption = {
+  label: string;
+  value: string;
+};

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -7,7 +7,7 @@ import type { DataFormat, DatasetFormData } from "src/definitions/datasets";
 describe("Test the dataset form", () => {
   test('The "title" field is present', () => {
     const { getByLabelText } = render(DatasetForm);
-    const title = getByLabelText("Nom", { exact: false });
+    const title = getByLabelText("Nom du jeu de la donnée", { exact: false });
     expect(title).toBeInTheDocument();
     expect(title).toBeRequired();
   });
@@ -23,6 +23,24 @@ describe("Test the dataset form", () => {
     const { getAllByRole } = render(DatasetForm);
     const checkboxes = getAllByRole("checkbox");
     expect(checkboxes.length).toBeGreaterThan(0);
+  });
+
+  test('The "geographicalCoverage" field is present', async () => {
+    const { getByLabelText } = render(DatasetForm);
+    const geographicalCoverage = getByLabelText("Couverture géographique", {
+      exact: false,
+    });
+    expect(geographicalCoverage).toBeInTheDocument();
+    expect(geographicalCoverage).toBeRequired();
+  });
+
+  test('The "technicalSource" field is present', async () => {
+    const { getByLabelText } = render(DatasetForm);
+    const technicalSource = getByLabelText("Système d’information source", {
+      exact: false,
+    });
+    expect(technicalSource).toBeInTheDocument();
+    expect(technicalSource).not.toBeRequired();
   });
 
   test("At least one format is required", async () => {
@@ -80,6 +98,8 @@ describe("Test the dataset form", () => {
       service: "A nice service",
       lastUpdatedAt: new Date("2022-02-01"),
       updateFrequency: "never",
+      geographicalCoverage: "europe",
+      technicalSource: "foo/bar",
     };
     const props = { initial };
 
@@ -88,7 +108,9 @@ describe("Test the dataset form", () => {
       { props }
     );
 
-    const title = getByLabelText("Nom", { exact: false }) as HTMLInputElement;
+    const title = getByLabelText("Nom du jeu de la donnée", {
+      exact: false,
+    }) as HTMLInputElement;
     expect(title.value).toBe("Titre initial");
 
     const description = getByLabelText("Description", {
@@ -123,6 +145,11 @@ describe("Test the dataset form", () => {
       exact: false,
     }) as HTMLSelectElement;
     expect(updateFrequency.value).toBe("never");
+
+    const technicalSource = getByLabelText("Système d’information source", {
+      exact: false,
+    }) as HTMLSelectElement;
+    expect(technicalSource.value).toBe("foo/bar");
   });
 
   test("Null fields are correctly handled in HTML and submitted as null", async () => {
@@ -135,6 +162,8 @@ describe("Test the dataset form", () => {
       service: "A nice service",
       lastUpdatedAt: null,
       updateFrequency: null,
+      geographicalCoverage: "europe",
+      technicalSource: "foo/bar",
     };
     const props = { initial };
     const { getByLabelText, getByRole, component } = render(DatasetForm, {
@@ -149,7 +178,6 @@ describe("Test the dataset form", () => {
     const updateFrequency = getByLabelText("Fréquence de mise à jour", {
       exact: false,
     }) as HTMLSelectElement;
-    expect(updateFrequency.value).toBe("null");
 
     // Simulate touching the fields. This sends HTML values such as "" (empty date or select value)
     // which should be handled as null.

--- a/client/src/lib/components/Select/Select.spec.ts
+++ b/client/src/lib/components/Select/Select.spec.ts
@@ -1,0 +1,135 @@
+import { fireEvent } from "@testing-library/dom";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/svelte";
+import type { SelectOption } from "src/definitions/form";
+import Select from "./Select.svelte";
+
+describe("Test the select component", () => {
+  test("should display a select input with 3 options", () => {
+    const options: SelectOption[] = [
+      {
+        label: "label-1",
+        value: "value-1",
+      },
+      {
+        label: "label-2",
+        value: "value-2",
+      },
+      {
+        label: "label-3",
+        value: "value-3",
+      },
+    ];
+
+    const props = {
+      options,
+      label: "My Nice Select",
+      id: "myId",
+      name: "mySelect",
+    };
+
+    const { getAllByRole } = render(Select, { props });
+
+    expect(getAllByRole("option").length).toBe(3);
+  });
+
+  test("should have a placeholder value", () => {
+    const options: SelectOption[] = [];
+
+    const placeholder = "My brand new select";
+
+    const props = {
+      options,
+      placeholder,
+      label: "My Nice Select",
+      id: "myId",
+      name: "mySelect",
+    };
+
+    const { getByRole } = render(Select, { props });
+
+    expect(
+      (getByRole("option", { name: placeholder }) as HTMLOptionElement).selected
+    ).toBeFalsy();
+  });
+
+  test("should be marked as required", () => {
+    const options: SelectOption[] = [
+      {
+        value: "foo",
+        label: "tata",
+      },
+    ];
+
+    const label = "label";
+
+    const props = {
+      options,
+      label,
+      id: "myId",
+      name: "mySelect",
+      required: true,
+    };
+
+    const { getByLabelText } = render(Select, { props });
+
+    const labelInput = getByLabelText(label, {
+      exact: false,
+    });
+    expect(labelInput).toBeDefined();
+    expect(labelInput.children).toHaveLength(1);
+  });
+
+  test("on:change should be triggered", () => {
+    const options: SelectOption[] = [
+      {
+        label: "label",
+        value: "my-name",
+      },
+    ];
+    const label = "label";
+
+    const props = {
+      options,
+      label,
+      id: "myId",
+      name: "mySelect",
+    };
+
+    const { getByRole, component } = render(Select, { props });
+
+    let count = 0;
+
+    const mock = () => (count += 1);
+
+    const option = getByRole("option", { name: "label" }) as HTMLOptionElement;
+
+    component.$on("change", mock);
+    fireEvent.change(option);
+
+    expect(count).toBe(1);
+  });
+
+  test("should display a error message", () => {
+    const options: SelectOption[] = [];
+    const label = "label";
+
+    const props = {
+      options,
+      label,
+      id: "myId",
+      name: "mySelect",
+      error: "a nice error message",
+    };
+
+    const { getByText } = render(Select, { props });
+
+    const errorMessage = getByText("a nice error message", {
+      exact: false,
+    });
+
+    expect(errorMessage).toBeDefined();
+    expect(errorMessage).toHaveClass("fr-error-text");
+    expect(errorMessage).toHaveAttribute("id", "mySelect-desc-error");
+  });
+});

--- a/client/src/lib/components/Select/Select.svelte
+++ b/client/src/lib/components/Select/Select.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { SelectOption } from "src/definitions/form";
+
+  import RequiredMarker from "../RequiredMarker/RequiredMarker.svelte";
+  export let label: string;
+  export let id: string;
+  export let name: string;
+  export let options: SelectOption[];
+
+  export let placeholder = "";
+  export let hintText = "";
+  export let required = false;
+  export let error = "";
+  export let value = "";
+</script>
+
+<div class="fr-select-group" class:fr-select-group--error={error}>
+  <label class="fr-label" for={id}>
+    {label}
+    {#if required}
+      <RequiredMarker />
+    {/if}
+
+    {#if hintText}
+      <span class="fr-hint-text" id="{name}-desc-hint">
+        {hintText}
+      </span>
+    {/if}
+  </label>
+  <select
+    aria-describedby={error ? `{name}-desc-error` : ""}
+    class="fr-select"
+    class:fr-select--error={error}
+    {required}
+    {value}
+    {id}
+    {name}
+    on:change
+    on:blur
+  >
+    {#if placeholder}
+      <option value={null} disabled>{placeholder}</option>
+    {/if}
+
+    {#each options as { value, label }}
+      <option {value}>{label}</option>
+    {/each}
+  </select>
+
+  {#if error}
+    <p id="{name}-desc-error" class="fr-error-text">
+      {error}
+    </p>
+  {/if}
+</div>

--- a/client/src/lib/transformers/dataset.ts
+++ b/client/src/lib/transformers/dataset.ts
@@ -28,6 +28,8 @@ export const toDataset = (item: any): Dataset => {
     contact_emails,
     update_frequency,
     last_updated_at,
+    geographical_coverage,
+    technical_source,
     ...rest
   } = item;
   return {
@@ -36,6 +38,8 @@ export const toDataset = (item: any): Dataset => {
     entrypointEmail: entrypoint_email,
     contactEmails: contact_emails,
     updateFrequency: update_frequency,
+    geographicalCoverage: geographical_coverage,
+    technicalSource: technical_source,
     lastUpdatedAt: last_updated_at ? new Date(last_updated_at) : null,
   };
 };

--- a/client/src/lib/transformers/form.spec.ts
+++ b/client/src/lib/transformers/form.spec.ts
@@ -1,0 +1,23 @@
+import { toSelectOptions } from "./form";
+
+describe("transformers -- form", () => {
+  describe("toSelectOptions", () => {
+    it("should transform an object to SelectOption", () => {
+      const source = {
+        foo: "bar",
+        baz: "taz",
+      };
+
+      expect(toSelectOptions(source)).toEqual([
+        {
+          value: "foo",
+          label: "bar",
+        },
+        {
+          value: "baz",
+          label: "taz",
+        },
+      ]);
+    });
+  });
+});

--- a/client/src/lib/transformers/form.ts
+++ b/client/src/lib/transformers/form.ts
@@ -1,0 +1,12 @@
+import type { SelectOption } from "src/definitions/form";
+
+export const toSelectOptions = (labelsMap: {
+  [key: string]: string;
+}): Array<SelectOption> => {
+  return Object.keys(labelsMap).map(
+    (item): SelectOption => ({
+      label: labelsMap[item],
+      value: item,
+    })
+  );
+};

--- a/client/src/lib/util/form.ts
+++ b/client/src/lib/util/form.ts
@@ -1,0 +1,18 @@
+export const handleSelectChange = async <Inf>(
+  fieldname: keyof Inf,
+  event: Event,
+  handleChange: (event: Event) => Promise<void>,
+  updateValidateField: (fieldname: keyof Inf, event: Event) => void
+): Promise<void> => {
+  const target = event.currentTarget as EventTarget & HTMLSelectElement;
+
+  if (target.value === "null" || !target.value) {
+    // Empty option selected.
+    // Needs manual handling to ensure a `null` initial value and the empty
+    // option all correspond to `null`.
+    updateValidateField(fieldname, null);
+    return;
+  }
+
+  await handleChange(event);
+};

--- a/client/src/tests/e2e/contribuer.spec.ts
+++ b/client/src/tests/e2e/contribuer.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
-import { UPDATE_FREQUENCY_LABELS } from "src/constants";
+import {
+  UPDATE_FREQUENCY_LABELS,
+  GEOGRAPHICAL_COVERAGE_LABELS,
+} from "src/constants";
 import { STATE_AUTHENTICATED } from "./constants";
 
 test.describe("Basic form submission", () => {
@@ -13,6 +16,7 @@ test.describe("Basic form submission", () => {
     const contactEmail2Text = "contact2@example.org";
     const lastUpdatedAtDate = "2000-05-05";
     const serviceText = "Ministère de l'écologie";
+    const technicalSourceText = "foo/bar";
 
     await page.goto("/contribuer");
 
@@ -26,9 +30,20 @@ test.describe("Basic form submission", () => {
     await description.fill(descriptionText);
     expect(await description.inputValue()).toBe(descriptionText);
 
+    const geographicalCoverage = page.locator(
+      "form [name=geographicalCoverage]"
+    );
+    await geographicalCoverage.selectOption({
+      label: GEOGRAPHICAL_COVERAGE_LABELS.europe,
+    });
+
     const apiFormat = page.locator("label[for=dataformats-api]");
     await apiFormat.check();
     expect(await page.isChecked("input[value=api]")).toBeTruthy();
+
+    const technicalSource = page.locator("form [name=technicalSource]");
+    await technicalSource.fill(technicalSourceText);
+    expect(await technicalSource.inputValue()).toBe(technicalSourceText);
 
     // "Contacts" section
 
@@ -71,10 +86,12 @@ test.describe("Basic form submission", () => {
     const json = await response.json();
     expect(json.title).toBe(titleText);
     expect(json.description).toBe(descriptionText);
+    expect(json.geographical_coverage).toBe("europe");
     expect(json.formats).toStrictEqual(["api"]);
     expect(json.entrypoint_email).toBe(entrypointEmailText);
     expect(json.contact_emails).toEqual([contactEmail1Text, contactEmail2Text]);
     expect(json).toHaveProperty("id");
+    expect(json.technical_source).toBe(technicalSourceText);
     expect(json.update_frequency).toBe("daily");
     expect(json.last_updated_at).toEqual("2000-05-05T00:00:00+00:00");
     expect(json.service).toBe(serviceText);

--- a/client/src/tests/e2e/fixtures.ts
+++ b/client/src/tests/e2e/fixtures.ts
@@ -50,6 +50,8 @@ export const test = base.extend<AppTestArgs>({
       description: "Sample description",
       updateFrequency: "never",
       formats: ["api"],
+      technicalSource: "foo/baz",
+      geographicalCoverage: "world",
     });
     let response = await apiContext.post("/datasets/", {
       data: toPayload(data),

--- a/client/src/tests/factories/dataset.ts
+++ b/client/src/tests/factories/dataset.ts
@@ -10,8 +10,10 @@ export const getFakeDataset = (dataset: Partial<Dataset> = {}): Dataset => {
     entrypointEmail: dataset.entrypointEmail || "jane.doe@beta.gouv.fr",
     contactEmails: dataset.contactEmails || ["contact@beta.gouv.fr"],
     service: dataset.service || "La Drac",
+    technicalSource: dataset.technicalSource || null,
     updateFrequency: dataset.updateFrequency || "daily",
     lastUpdatedAt: dataset.lastUpdatedAt || new Date(),
+    geographicalCoverage: dataset.geographicalCoverage || "europe",
   };
 };
 
@@ -25,7 +27,9 @@ export const getFakeDataSetFormData = (
     entrypointEmail: datasetFormData.entrypointEmail || "jane.doe@beta.gouv.fr",
     contactEmails: datasetFormData.contactEmails || ["contact@beta.gouv.fr"],
     service: datasetFormData.service || "La Drac",
+    technicalSource: datasetFormData.technicalSource || null,
     updateFrequency: datasetFormData.updateFrequency || "daily",
     lastUpdatedAt: datasetFormData.lastUpdatedAt || new Date(),
+    geographicalCoverage: datasetFormData.geographicalCoverage || "europe",
   };
 };

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -3,14 +3,20 @@ from typing import List, Optional
 
 from pydantic import BaseModel, EmailStr, Field, validator
 
-from server.domain.datasets.entities import DataFormat, UpdateFrequency
+from server.domain.datasets.entities import (
+    DataFormat,
+    GeographicalCoverage,
+    UpdateFrequency,
+)
 
 
 class DatasetCreate(BaseModel):
     title: str
     description: str
-    formats: List[DataFormat]
     service: str
+    geographical_coverage: GeographicalCoverage
+    formats: List[DataFormat]
+    technical_source: Optional[str] = None
     entrypoint_email: EmailStr
     contact_emails: List[EmailStr] = Field(default_factory=list)
     update_frequency: Optional[UpdateFrequency] = None
@@ -26,8 +32,10 @@ class DatasetCreate(BaseModel):
 class DatasetUpdate(BaseModel):
     title: str
     description: str
-    formats: List[DataFormat]
     service: str
+    geographical_coverage: GeographicalCoverage
+    formats: List[DataFormat]
+    technical_source: Optional[str] = Field(...)
     entrypoint_email: EmailStr
     contact_emails: List[EmailStr]
     update_frequency: Optional[UpdateFrequency] = Field(...)
@@ -45,14 +53,14 @@ class DatasetUpdate(BaseModel):
             raise ValueError("description must not be empty")
         return value
 
-    @validator("formats")
-    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
-        if not value:
-            raise ValueError("formats must contain at least one item")
-        return value
-
     @validator("service")
     def check_service_not_empty(cls, value: str) -> str:
         if not value:
             raise ValueError("service must not be empty")
+        return value
+
+    @validator("formats")
+    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
+        if not value:
+            raise ValueError("formats must contain at least one item")
         return value

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -4,15 +4,21 @@ from typing import List, Optional
 from pydantic import Field
 
 from server.domain.common.types import ID
-from server.domain.datasets.entities import DataFormat, UpdateFrequency
+from server.domain.datasets.entities import (
+    DataFormat,
+    GeographicalCoverage,
+    UpdateFrequency,
+)
 from server.seedwork.application.commands import Command
 
 
 class CreateDataset(Command[ID]):
     title: str
     description: str
-    formats: List[DataFormat]
     service: str
+    geographical_coverage: GeographicalCoverage
+    formats: List[DataFormat]
+    technical_source: Optional[str] = None
     entrypoint_email: str
     contact_emails: List[str] = Field(default_factory=list)
     update_frequency: Optional[UpdateFrequency] = None
@@ -23,8 +29,10 @@ class UpdateDataset(Command[None]):
     id: ID
     title: str
     description: str
-    formats: List[DataFormat]
     service: str
+    geographical_coverage: GeographicalCoverage
+    formats: List[DataFormat]
+    technical_source: Optional[str] = Field(...)
     entrypoint_email: str
     contact_emails: List[str]
     update_frequency: Optional[UpdateFrequency] = Field(...)

--- a/server/application/datasets/views.py
+++ b/server/application/datasets/views.py
@@ -4,7 +4,11 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from server.domain.common.types import ID
-from server.domain.datasets.entities import DataFormat, UpdateFrequency
+from server.domain.datasets.entities import (
+    DataFormat,
+    GeographicalCoverage,
+    UpdateFrequency,
+)
 from server.domain.datasets.repositories import DatasetHeadlines
 
 
@@ -13,8 +17,10 @@ class DatasetView(BaseModel):
     created_at: dt.datetime
     title: str
     description: str
-    formats: List[DataFormat]
     service: str
+    geographical_coverage: GeographicalCoverage
+    formats: List[DataFormat]
+    technical_source: Optional[str]
     entrypoint_email: str
     contact_emails: List[str]
     update_frequency: Optional[UpdateFrequency]

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -12,7 +12,7 @@ from ..common.types import ID
 
 class GeographicalCoverage(enum.Enum):
     MUNICIPALITY = "municipality"
-    EPCI = "EPCI"
+    EPCI = "epci"
     DEPARTMENT = "department"
     REGION = "region"
     NATIONAL = "national"

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -10,6 +10,17 @@ from ..common import datetime as dtutil
 from ..common.types import ID
 
 
+class GeographicalCoverage(enum.Enum):
+    MUNICIPALITY = "municipality"
+    EPCI = "EPCI"
+    DEPARTMENT = "department"
+    REGION = "region"
+    NATIONAL = "national"
+    NATIONAL_FULL_TERRITORY = "national_full_territory"
+    EUROPE = "europe"
+    WORLD = "world"
+
+
 class DataFormat(enum.Enum):
     FILE_TABULAR = "file_tabular"
     FILE_GIS = "file_gis"
@@ -33,8 +44,10 @@ class Dataset(Entity):
     created_at: dt.datetime = Field(default_factory=dtutil.now)
     title: str
     description: str
-    formats: List[DataFormat]
     service: str
+    geographical_coverage: GeographicalCoverage
+    formats: List[DataFormat]
+    technical_source: Optional[str]
     entrypoint_email: str
     contact_emails: List[str] = Field(default_factory=list)
     update_frequency: Optional[UpdateFrequency] = None
@@ -47,8 +60,10 @@ class Dataset(Entity):
         self,
         title: str,
         description: str,
-        formats: List[DataFormat],
         service: str,
+        geographical_coverage: GeographicalCoverage,
+        formats: List[DataFormat],
+        technical_source: Optional[str],
         entrypoint_email: str,
         contact_emails: List[str],
         update_frequency: Optional[UpdateFrequency],
@@ -56,8 +71,10 @@ class Dataset(Entity):
     ) -> None:
         self.title = title
         self.description = description
-        self.formats = formats
         self.service = service
+        self.geographical_coverage = geographical_coverage
+        self.formats = formats
+        self.technical_source = technical_source
         self.entrypoint_email = entrypoint_email
         self.contact_emails = contact_emails
         self.update_frequency = update_frequency

--- a/server/migrations/versions/f92d0ee57d88_add_dataset_geographical_coverage_.py
+++ b/server/migrations/versions/f92d0ee57d88_add_dataset_geographical_coverage_.py
@@ -1,0 +1,49 @@
+"""add-dataset-geographical_coverage-technical_source
+
+Revision ID: f92d0ee57d88
+Revises: 6fd05f9d4158
+Create Date: 2022-04-14 11:53:39.708368
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f92d0ee57d88"
+down_revision = "6fd05f9d4158"
+branch_labels = None
+depends_on = None
+
+
+geographical_coverage_enum = sa.Enum(
+    "MUNICIPALITY",
+    "EPCI",
+    "DEPARTMENT",
+    "REGION",
+    "NATIONAL",
+    "NATIONAL_FULL_TERRITORY",
+    "EUROPE",
+    "WORLD",
+    name="geographical_coverage_enum",
+)
+
+
+def upgrade():
+    geographical_coverage_enum.create(op.get_bind())
+    op.add_column(
+        "dataset",
+        sa.Column(
+            "geographical_coverage",
+            geographical_coverage_enum,
+            nullable=False,
+            server_default="NATIONAL",
+        ),
+    )
+    op.alter_column("dataset", "geographical_coverage", server_default=None)
+    op.add_column("dataset", sa.Column("technical_source", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("dataset", "technical_source")
+    op.drop_column("dataset", "geographical_coverage")
+    geographical_coverage_enum.drop(op.get_bind())

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -11,7 +11,7 @@ from server.application.datasets.commands import (
 )
 from server.application.datasets.queries import GetDatasetByID
 from server.config.di import resolve
-from server.domain.datasets.entities import DataFormat
+from server.domain.datasets.entities import DataFormat, GeographicalCoverage
 from server.seedwork.application.messages import MessageBus
 
 DEFAULT_CORPUS_ITEMS = [
@@ -31,8 +31,9 @@ async def add_corpus(items: List[Tuple[str, str]] = None) -> None:
         command = CreateDataset(
             title=title,
             description=description,
-            formats=[DataFormat.FILE_TABULAR],
             service="Service",
+            geographical_coverage=GeographicalCoverage.NATIONAL,
+            formats=[DataFormat.FILE_TABULAR],
             entrypoint_email="service@example.org",
         )
         pk = await bus.execute(command)
@@ -156,8 +157,9 @@ async def test_search_results_change_when_data_changes(
     command = CreateDataset(
         title="Titre",
         description="Description",
-        formats=[DataFormat.OTHER],
         service="Service",
+        geographical_coverage=GeographicalCoverage.DEPARTMENT,
+        formats=[DataFormat.OTHER],
         entrypoint_email="service@example.org",
     )
     pk = await bus.execute(command)
@@ -172,8 +174,10 @@ async def test_search_results_change_when_data_changes(
         id=pk,
         title="Modifié",
         description="Description",
-        formats=[DataFormat.OTHER],
         service="Service",
+        geographical_coverage=GeographicalCoverage.DEPARTMENT,
+        formats=[DataFormat.OTHER],
+        technical_source=None,
         entrypoint_email="service@example.org",
         contact_emails=[],
         update_frequency=None,
@@ -191,8 +195,10 @@ async def test_search_results_change_when_data_changes(
         id=pk,
         title="Modifié",
         description="Jeu de données spécial",
-        formats=[DataFormat.OTHER],
         service="Service",
+        geographical_coverage=GeographicalCoverage.DEPARTMENT,
+        formats=[DataFormat.OTHER],
+        technical_source=None,
         entrypoint_email="service@example.org",
         contact_emails=[],
         update_frequency=None,

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -18,9 +18,11 @@ datasets:
       description: |
         Les données brutes de l'inventaire forestier correspondent à l'ensemble des données collectées en forêt (y compris en peupleraie) sur le territoire métropolitain par les agents forestiers de terrain de l'IGN. Ces données portent sur les caractéristiques des placettes d'inventaire (6000 par an), les mesures et observations sur les arbres (60 000 par an), les données éco-floristiques.
         Les coordonnées géographiques des placettes sont fournies au kilomètre près.
+      service: Service cartographie
+      geographical_coverage: national
       formats:
         - website
-      service: Service cartographie
+      technical_source: SIG national de l'IGN
       entrypoint_email: service@example.org
       contact_emails: []
       update_frequency: null
@@ -32,9 +34,11 @@ datasets:
       title: Ensemble des lieux de restauration des CROUS
       description: |
         Les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
+      service: Direction des données du CROUS
+      geographical_coverage: national
       formats:
         - file_tabular
-      service: Direction des données du CROUS
+      technical_source: Système d'information central du CROUS
       entrypoint_email: service@example.org
       contact_emails: []
       update_frequency: null
@@ -46,9 +50,11 @@ datasets:
       title: Catalogue des enquêtes réalisées par la DARES
       description: |
         Présentation sous forme de fiches répertoriées par thèmes des enquêtes menées par la DARES avec reprise des objectifs, de la périodicité, de la taille de l'échantillon, des publications.
+      service: Service enquêtes
+      geographical_coverage: national_full_territory
       formats:
         - other
-      service: Service enquêtes
+      technical_source: Catalogue des fiches de la DARES
       entrypoint_email: service@example.org
       contact_emails: []
       update_frequency: null


### PR DESCRIPTION
Refs #125 

Back pour #177 

- [x] Ajout champ `geographical_coverage` (enum)
- [x] Ajout champ `technical_source` (optional str)
- [x] Màj tests
- [x] Màj initdata