### PR TITLE
Convert read schemas as views

### DIFF
--- a/server/api/auth/schemas.py
+++ b/server/api/auth/schemas.py
@@ -2,21 +2,6 @@ from typing import Literal
 
 from pydantic import BaseModel, EmailStr, SecretStr
 
-from server.domain.auth.entities import UserRole
-from server.domain.common.types import ID
-
-
-class UserRead(BaseModel):
-    id: ID
-    email: str
-
-
-class UserAuthenticatedRead(BaseModel):
-    id: ID
-    email: str
-    role: UserRole
-    api_token: str
-
 
 class UserCreate(BaseModel):
     email: EmailStr

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -15,36 +15,36 @@ from server.application.datasets.queries import (
     GetDatasetByID,
     SearchDatasets,
 )
+from server.application.datasets.views import DatasetView
 from server.config.di import resolve
 from server.domain.auth.entities import UserRole
 from server.domain.common.types import ID
-from server.domain.datasets.entities import Dataset
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
 from ..auth.dependencies import HasRole, IsAuthenticated
-from .schemas import DatasetCreate, DatasetRead, DatasetUpdate
+from .schemas import DatasetCreate, DatasetUpdate
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 
 
-@router.get("/", response_model=List[DatasetRead])
+@router.get("/", response_model=List[DatasetView])
 async def list_datasets(
     q: str = None, highlight: bool = False
-) -> Union[JSONResponse, List[Dataset]]:
+) -> Union[JSONResponse, List[DatasetView]]:
     bus = resolve(MessageBus)
 
     if q is not None:
         query = SearchDatasets(q=q, highlight=highlight)
-        items = await bus.execute(query)
-        return JSONResponse(jsonable_encoder(items))
+        views = await bus.execute(query)
+        return JSONResponse(jsonable_encoder(views))
 
     query = GetAllDatasets()
     return await bus.execute(query)
 
 
-@router.get("/{id}/", response_model=DatasetRead, responses={404: {}})
-async def get_dataset_by_id(id: ID) -> Dataset:
+@router.get("/{id}/", response_model=DatasetView, responses={404: {}})
+async def get_dataset_by_id(id: ID) -> DatasetView:
     bus = resolve(MessageBus)
 
     query = GetDatasetByID(id=id)
@@ -54,8 +54,8 @@ async def get_dataset_by_id(id: ID) -> Dataset:
         raise HTTPException(404)
 
 
-@router.post("/", response_model=DatasetRead, status_code=201)
-async def create_dataset(data: DatasetCreate) -> Dataset:
+@router.post("/", response_model=DatasetView, status_code=201)
+async def create_dataset(data: DatasetCreate) -> DatasetView:
     bus = resolve(MessageBus)
 
     command = CreateDataset(**data.dict())
@@ -66,8 +66,8 @@ async def create_dataset(data: DatasetCreate) -> Dataset:
     return await bus.execute(query)
 
 
-@router.put("/{id}/", response_model=DatasetRead, responses={404: {}})
-async def update_dataset(id: ID, data: DatasetUpdate) -> Dataset:
+@router.put("/{id}/", response_model=DatasetView, responses={404: {}})
+async def update_dataset(id: ID, data: DatasetUpdate) -> DatasetView:
     bus = resolve(MessageBus)
 
     command = UpdateDataset(id=id, **data.dict())

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -3,21 +3,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, EmailStr, Field, validator
 
-from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
-
-
-class DatasetRead(BaseModel):
-    id: ID
-    created_at: dt.datetime
-    title: str
-    description: str
-    formats: List[DataFormat]
-    service: str
-    entrypoint_email: str
-    contact_emails: List[str]
-    update_frequency: Optional[UpdateFrequency]
-    last_updated_at: Optional[dt.datetime]
 
 
 class DatasetCreate(BaseModel):

--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -1,3 +1,4 @@
+from server.application.auth.views import AuthenticatedUserView, UserView
 from server.config.di import resolve
 from server.domain.auth.entities import User, UserRole
 from server.domain.auth.exceptions import (
@@ -48,7 +49,7 @@ async def delete_user(command: DeleteUser) -> None:
     await repository.delete(command.id)
 
 
-async def login(query: Login) -> User:
+async def login(query: Login) -> AuthenticatedUserView:
     repository = resolve(UserRepository)
     password_encoder = resolve(PasswordEncoder)
 
@@ -61,10 +62,10 @@ async def login(query: Login) -> User:
     if not password_encoder.verify(password=query.password, hash=user.password_hash):
         raise LoginFailed("Invalid credentials")
 
-    return user
+    return AuthenticatedUserView(**user.dict())
 
 
-async def get_user_by_email(query: GetUserByEmail) -> User:
+async def get_user_by_email(query: GetUserByEmail) -> UserView:
     repository = resolve(UserRepository)
 
     email = query.email
@@ -74,10 +75,10 @@ async def get_user_by_email(query: GetUserByEmail) -> User:
     if user is None:
         raise UserDoesNotExist(email)
 
-    return user
+    return UserView(**user.dict())
 
 
-async def get_user_by_api_token(query: GetUserByAPIToken) -> User:
+async def get_user_by_api_token(query: GetUserByAPIToken) -> UserView:
     repository = resolve(UserRepository)
 
     user = await repository.get_by_api_token(query.api_token)
@@ -85,4 +86,4 @@ async def get_user_by_api_token(query: GetUserByAPIToken) -> User:
     if user is None:
         raise UserDoesNotExist("__token__")
 
-    return user
+    return UserView(**user.dict())

--- a/server/application/auth/queries.py
+++ b/server/application/auth/queries.py
@@ -1,17 +1,17 @@
 from pydantic import SecretStr
 
-from server.domain.auth.entities import User
+from server.application.auth.views import AuthenticatedUserView, UserView
 from server.seedwork.application.queries import Query
 
 
-class Login(Query[User]):
+class Login(Query[AuthenticatedUserView]):
     email: str
     password: SecretStr
 
 
-class GetUserByEmail(Query[User]):
+class GetUserByEmail(Query[UserView]):
     email: str
 
 
-class GetUserByAPIToken(Query[User]):
+class GetUserByAPIToken(Query[UserView]):
     api_token: str

--- a/server/application/auth/views.py
+++ b/server/application/auth/views.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+from server.domain.auth.entities import UserRole
+from server.domain.common.types import ID
+
+
+class UserView(BaseModel):
+    id: ID
+    email: str
+    role: UserRole
+
+
+class AuthenticatedUserView(BaseModel):
+    id: ID
+    email: str
+    role: UserRole
+    api_token: str

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -8,7 +8,7 @@ from server.domain.datasets.repositories import DatasetRepository
 
 from .commands import CreateDataset, DeleteDataset, UpdateDataset
 from .queries import GetAllDatasets, GetDatasetByID, SearchDatasets
-from .views import DatasetSearchView
+from .views import DatasetSearchView, DatasetView
 
 
 async def create_dataset(command: CreateDataset, *, id_: ID = None) -> ID:
@@ -40,12 +40,13 @@ async def delete_dataset(command: DeleteDataset) -> None:
     await repository.delete(command.id)
 
 
-async def get_all_datasets(query: GetAllDatasets) -> List[Dataset]:
+async def get_all_datasets(query: GetAllDatasets) -> List[DatasetView]:
     repository = resolve(DatasetRepository)
-    return await repository.get_all()
+    datasets = await repository.get_all()
+    return [DatasetView(**dataset.dict()) for dataset in datasets]
 
 
-async def get_dataset_by_id(query: GetDatasetByID) -> Dataset:
+async def get_dataset_by_id(query: GetDatasetByID) -> DatasetView:
     repository = resolve(DatasetRepository)
 
     id = query.id
@@ -54,7 +55,7 @@ async def get_dataset_by_id(query: GetDatasetByID) -> Dataset:
     if dataset is None:
         raise DatasetDoesNotExist(id)
 
-    return dataset
+    return DatasetView(**dataset.dict())
 
 
 async def search_datasets(query: SearchDatasets) -> List[DatasetSearchView]:

--- a/server/application/datasets/queries.py
+++ b/server/application/datasets/queries.py
@@ -1,17 +1,16 @@
 from typing import List
 
 from server.domain.common.types import ID
-from server.domain.datasets.entities import Dataset
 from server.seedwork.application.queries import Query
 
-from .views import DatasetSearchView
+from .views import DatasetSearchView, DatasetView
 
 
-class GetAllDatasets(Query[List[Dataset]]):
+class GetAllDatasets(Query[List[DatasetView]]):
     pass
 
 
-class GetDatasetByID(Query[Dataset]):
+class GetDatasetByID(Query[DatasetView]):
     id: ID
 
 

--- a/server/application/datasets/views.py
+++ b/server/application/datasets/views.py
@@ -1,8 +1,25 @@
-from typing import Optional
+import datetime as dt
+from typing import List, Optional
 
-from server.domain.datasets.entities import Dataset
+from pydantic import BaseModel
+
+from server.domain.common.types import ID
+from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.datasets.repositories import DatasetHeadlines
 
 
-class DatasetSearchView(Dataset):
+class DatasetView(BaseModel):
+    id: ID
+    created_at: dt.datetime
+    title: str
+    description: str
+    formats: List[DataFormat]
+    service: str
+    entrypoint_email: str
+    contact_emails: List[str]
+    update_frequency: Optional[UpdateFrequency]
+    last_updated_at: Optional[dt.datetime]
+
+
+class DatasetSearchView(DatasetView):
     headlines: Optional[DatasetHeadlines] = None

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -83,9 +83,9 @@ async def test_create_user(
     response = await client.post("/auth/users/", json=payload, auth=admin_user.auth)
     assert response.status_code == 201
     user = response.json()
-    pk = user.pop("id")
-    assert isinstance(pk, str)
-    assert user == {"email": "john@doe.com"}
+    id_ = user["id"]
+    assert isinstance(id_, str)
+    assert user == {"id": id_, "email": "john@doe.com", "role": "USER"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Jusqu'ici, les query handlers renvoyaient des entités directement (ex : `Dataset`), et l'API s'occupait de n'exposer que ce qui était souhaitable, via des _schemas_.

En réalité, du point de vue de l'archi hexa, il est préférable que ce soient les handlers qui s'occupent de n'exposer que ce qui est nécessaire à l'application, via des _vues_. On en a déjà un exemple avec `DatasetSearchView`.

Cette PR transforme donc les _schemas_ de lecture (UserRead, UserAuthenticatedRead, DatasetRead) en _vues_ (UserView, AuthenticatedUserView, DatasetView).

En conséquences, les fichiers `schemas.py` de l'API se concentrent exclusivement sur les _payloads_ d'entrée.

NB : dans les routes, `response_model` doit toujours être défini malgré le type de retour qui est maintenant quasi-tout le temps identique :

https://fastapi.tiangolo.com/tutorial/response-model/

> The response model is declared in this parameter instead of as a function return type annotation, because the path function may not actually return that response model but rather return a dict, database object or some other model, and then use the response_model to perform the field limiting and serialization.