### PR TITLE
Bump backend deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,27 @@
 # App
 argon2-cffi==21.3.0
 asyncpg==0.25.0
-alembic==1.7.5
-fastapi==0.70.0
+alembic==1.7.7
+fastapi==0.75.2
 gunicorn==20.1.0
-punq==0.5
-pydantic[email]==1.8.2
-uvicorn[standard]==0.16.0
-sqlalchemy[asyncio,mypy]==1.4.27
+punq==0.6.2
+pydantic[email]==1.9.0
+uvicorn[standard]==0.17.6
+sqlalchemy[asyncio,mypy]==1.4.35
 
 # Tooling
 asgi-lifespan==1.0.1
-black==21.12b0
-click==8.0.4
+black==22.3.0
+click==8.1.2
 flake8==4.0.1
-httpx==0.21.1
+httpx==0.22.0
 isort==5.10.1
-mypy==0.910
+mypy==0.942
 psycopg2-binary==2.9.2
-pytest==6.2.5
-pytest-asyncio==0.16.0
+pytest==7.1.2
+pytest-asyncio==0.18.3
 pytest-cov==3.0.0
 pyyaml==6.0
-sqlalchemy-utils==0.37.9
+sqlalchemy-utils==0.38.2
 svg-path-transform==1.2.1
-types-pyyaml==6.0.4
+types-pyyaml==6.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,4 @@ addopts =
     --cov-fail-under=90
 filterwarnings =
     ignore:Calling URL\(\) directly is deprecated:DeprecationWarning
+asyncio_mode = strict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import AsyncIterator, Iterator
 
 import httpx
 import pytest
+import pytest_asyncio
 from alembic import command
 from alembic.config import Config
 from asgi_lifespan import LifespanManager
@@ -40,7 +41,7 @@ def test_database() -> Iterator[None]:
         drop_database(url)
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def transaction() -> AsyncIterator[None]:
     db = resolve(Database)
 
@@ -49,7 +50,7 @@ async def transaction() -> AsyncIterator[None]:
         await tx.rollback()
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest_asyncio.fixture(scope="session", autouse=True)
 async def warmup_db() -> None:
     # Run a database query to warmup tables. Otherwise this warmup would
     # occur during tests and interfere with time measurements.
@@ -67,7 +68,7 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
         loop.close()
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def client() -> AsyncIterator[httpx.AsyncClient]:
     from server.api.app import create_app
 
@@ -78,11 +79,11 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
             yield client
 
 
-@pytest.fixture(name="temp_user")
+@pytest_asyncio.fixture(name="temp_user")
 async def fixture_temp_user() -> TestUser:
     return await create_test_user(UserRole.USER)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def admin_user() -> TestUser:
     return await create_test_user(UserRole.ADMIN)


### PR DESCRIPTION
Mise à jour manuelle des dépendances backend aux versions les + récentes

Tâches subsidiaires :

- Passer `pytest-asyncio` en [mode `auto`](https://github.com/pytest-dev/pytest-asyncio#auto-mode), ce qui permettra de retirer les `@pytest.mark.asyncio` et d'utiliser à nouveau `@pytest.fixture` pour les fixtures async