### PR TITLE
Protect datasets API endpoints behind auth

### DIFF
--- a/client/src/lib/repositories/datasets.ts
+++ b/client/src/lib/repositories/datasets.ts
@@ -8,25 +8,41 @@ import { getHeaders, getApiUrl } from "$lib/fetch";
 import { toQueryString } from "$lib/util/urls";
 import { toDataset, toPayload } from "$lib/transformers/dataset";
 
-type GetDatasetByID = (opts: { fetch: Fetch; id: string }) => Promise<Dataset>;
+type GetDatasetByID = (opts: {
+  fetch: Fetch;
+  apiToken: string;
+  id: string;
+}) => Promise<Dataset>;
 
-export const getDatasetByID: GetDatasetByID = async ({ fetch, id }) => {
+export const getDatasetByID: GetDatasetByID = async ({
+  fetch,
+  apiToken,
+  id,
+}) => {
   const url = `${getApiUrl()}/datasets/${id}/`;
-  const request = new Request(url);
+  const request = new Request(url, {
+    headers: new Headers(getHeaders(apiToken)),
+  });
   const response = await fetch(request);
   return toDataset(await response.json());
 };
 
-type GetDatasets = (opts: { fetch: Fetch; q?: string }) => Promise<Dataset[]>;
+type GetDatasets = (opts: {
+  fetch: Fetch;
+  apiToken: string;
+  q?: string;
+}) => Promise<Dataset[]>;
 
-export const getDatasets: GetDatasets = async ({ fetch, q }) => {
+export const getDatasets: GetDatasets = async ({ fetch, apiToken, q }) => {
   const queryItems = [];
   if (typeof q === "string") {
     queryItems.push(["q", q], ["highlight", "true"]);
   }
   const queryString = toQueryString(queryItems);
   const url = `${getApiUrl()}/datasets/${queryString}`;
-  const request = new Request(url);
+  const request = new Request(url, {
+    headers: new Headers(getHeaders(apiToken)),
+  });
   const response = await fetch(request);
   const items: any[] = await response.json();
   return items.map((item) => toDataset(item));
@@ -34,15 +50,23 @@ export const getDatasets: GetDatasets = async ({ fetch, q }) => {
 
 type CreateDataset = (opts: {
   fetch: Fetch;
+  apiToken: string;
   data: DatasetCreateData;
 }) => Promise<Dataset>;
 
-export const createDataset: CreateDataset = async ({ fetch, data }) => {
+export const createDataset: CreateDataset = async ({
+  fetch,
+  apiToken,
+  data,
+}) => {
   const body = JSON.stringify(toPayload(data));
   const url = `${getApiUrl()}/datasets/`;
   const request = new Request(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: new Headers([
+      ["Content-Type", "application/json"],
+      ...getHeaders(apiToken),
+    ]),
     body,
   });
   const response = await fetch(request);
@@ -51,16 +75,25 @@ export const createDataset: CreateDataset = async ({ fetch, data }) => {
 
 type UpdateDataset = (opts: {
   fetch: Fetch;
+  apiToken: string;
   id: string;
   data: DatasetUpdateData;
 }) => Promise<Dataset>;
 
-export const updateDataset: UpdateDataset = async ({ fetch, id, data }) => {
+export const updateDataset: UpdateDataset = async ({
+  fetch,
+  apiToken,
+  id,
+  data,
+}) => {
   const body = JSON.stringify(toPayload(data));
   const url = `${getApiUrl()}/datasets/${id}/`;
   const request = new Request(url, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: new Headers([
+      ["Content-Type", "application/json"],
+      ...getHeaders(apiToken),
+    ]),
     body,
   });
   const response = await fetch(request);

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -6,6 +6,7 @@
   import { goto } from "$app/navigation";
   import type { DatasetFormData } from "src/definitions/datasets";
   import paths from "$lib/paths";
+  import { user } from "$lib/stores/auth";
   import DatasetForm from "$lib/components/DatasetForm/DatasetForm.svelte";
   import { createDataset } from "$lib/repositories/datasets";
 
@@ -14,7 +15,13 @@
   const onSave = async (event: CustomEvent<DatasetFormData>) => {
     try {
       loading = true;
-      const dataset = await createDataset({ fetch, data: event.detail });
+
+      const dataset = await createDataset({
+        fetch,
+        apiToken: $user.apiToken,
+        data: event.detail,
+      });
+
       await goto(paths.datasetDetail({ id: dataset.id }));
     } finally {
       loading = false;

--- a/client/src/routes/fiches/[id]/edit.svelte
+++ b/client/src/routes/fiches/[id]/edit.svelte
@@ -1,9 +1,15 @@
 <script context="module" lang="ts">
   import type { Load } from "@sveltejs/kit";
+  import { get } from "svelte/store";
   import { getDatasetByID, updateDataset } from "$lib/repositories/datasets";
 
   export const load: Load = async ({ fetch, params }) => {
-    const dataset = await getDatasetByID({ fetch, id: params.id });
+    const dataset = await getDatasetByID({
+      fetch,
+      apiToken: get(user).apiToken,
+      id: params.id,
+    });
+
     return {
       props: {
         dataset,
@@ -29,7 +35,12 @@
   const onSave = async (event: CustomEvent<DatasetFormData>) => {
     try {
       loading = true;
-      await updateDataset({ fetch, id, data: event.detail });
+      await updateDataset({
+        fetch,
+        apiToken: $user.apiToken,
+        id,
+        data: event.detail,
+      });
       await goto(paths.datasetDetail({ id }));
     } finally {
       loading = false;

--- a/client/src/routes/fiches/[id]/index.svelte
+++ b/client/src/routes/fiches/[id]/index.svelte
@@ -1,9 +1,16 @@
 <script context="module" lang="ts">
   import type { Load } from "@sveltejs/kit";
+  import { get } from "svelte/store";
   import { getDatasetByID } from "$lib/repositories/datasets";
+  import { user } from "$lib/stores/auth";
 
   export const load: Load = async ({ fetch, params }) => {
-    const dataset = await getDatasetByID({ fetch, id: params.id });
+    const dataset = await getDatasetByID({
+      fetch,
+      apiToken: get(user).apiToken,
+      id: params.id,
+    });
+
     return {
       props: {
         dataset,

--- a/client/src/routes/fiches/search.svelte
+++ b/client/src/routes/fiches/search.svelte
@@ -1,10 +1,18 @@
 <script context="module" lang="ts">
   import type { Load } from "@sveltejs/kit";
+  import { get } from "svelte/store";
   import { getDatasets } from "$lib/repositories/datasets";
+  import { user } from "$lib/stores/auth";
 
   export const load: Load = async ({ fetch, url }) => {
     const q = url.searchParams.get("q") || "";
-    const datasets = await getDatasets({ fetch, q });
+
+    const datasets = await getDatasets({
+      fetch,
+      apiToken: get(user).apiToken,
+      q,
+    });
+
     return {
       props: {
         q,

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -1,9 +1,12 @@
 <script context="module" lang="ts">
   import type { Load } from "@sveltejs/kit";
+  import { get } from "svelte/store";
+  import { user } from "$lib/stores/auth";
   import { getDatasets } from "$lib/repositories/datasets";
 
   export const load: Load = async ({ fetch }) => {
-    const datasets = await getDatasets({ fetch });
+    const datasets = await getDatasets({ fetch, apiToken: get(user).apiToken });
+
     return {
       props: {
         datasets,

--- a/client/src/tests/e2e/fixtures.ts
+++ b/client/src/tests/e2e/fixtures.ts
@@ -45,6 +45,8 @@ export const test = base.extend<AppTestArgs>({
   },
 
   dataset: async ({ apiContext, adminApiToken }, use) => {
+    const headers = { Authorization: `Bearer ${adminApiToken}` };
+
     const data = getFakeDataset({
       title: "Sample title",
       description: "Sample description",
@@ -55,6 +57,7 @@ export const test = base.extend<AppTestArgs>({
     });
     let response = await apiContext.post("/datasets/", {
       data: toPayload(data),
+      headers,
     });
     expect(response.ok()).toBeTruthy();
     const dataset = await response.json();
@@ -62,7 +65,7 @@ export const test = base.extend<AppTestArgs>({
     await use(dataset);
 
     response = await apiContext.delete(`/datasets/${dataset.id}/`, {
-      headers: { Authorization: `Bearer ${adminApiToken}` },
+      headers,
     });
     expect(response.ok()).toBeTruthy();
   },

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -28,7 +28,11 @@ from .schemas import DatasetCreate, DatasetUpdate
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 
 
-@router.get("/", response_model=List[DatasetView])
+@router.get(
+    "/",
+    dependencies=[Depends(IsAuthenticated())],
+    response_model=List[DatasetView],
+)
 async def list_datasets(
     q: str = None, highlight: bool = False
 ) -> Union[JSONResponse, List[DatasetView]]:
@@ -43,7 +47,12 @@ async def list_datasets(
     return await bus.execute(query)
 
 
-@router.get("/{id}/", response_model=DatasetView, responses={404: {}})
+@router.get(
+    "/{id}/",
+    dependencies=[Depends(IsAuthenticated())],
+    response_model=DatasetView,
+    responses={404: {}},
+)
 async def get_dataset_by_id(id: ID) -> DatasetView:
     bus = resolve(MessageBus)
 
@@ -54,7 +63,12 @@ async def get_dataset_by_id(id: ID) -> DatasetView:
         raise HTTPException(404)
 
 
-@router.post("/", response_model=DatasetView, status_code=201)
+@router.post(
+    "/",
+    dependencies=[Depends(IsAuthenticated())],
+    response_model=DatasetView,
+    status_code=201,
+)
 async def create_dataset(data: DatasetCreate) -> DatasetView:
     bus = resolve(MessageBus)
 
@@ -66,7 +80,12 @@ async def create_dataset(data: DatasetCreate) -> DatasetView:
     return await bus.execute(query)
 
 
-@router.put("/{id}/", response_model=DatasetView, responses={404: {}})
+@router.put(
+    "/{id}/",
+    dependencies=[Depends(IsAuthenticated())],
+    response_model=DatasetView,
+    responses={404: {}},
+)
 async def update_dataset(id: ID, data: DatasetUpdate) -> DatasetView:
     bus = resolve(MessageBus)
 

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -60,9 +60,12 @@ from ..helpers import TestUser, approx_datetime
     ],
 )
 async def test_create_dataset_invalid(
-    client: httpx.AsyncClient, payload: dict, expected_errors_attrs: list
+    client: httpx.AsyncClient,
+    temp_user: TestUser,
+    payload: dict,
+    expected_errors_attrs: list,
 ) -> None:
-    response = await client.post("/datasets/", json=payload)
+    response = await client.post("/datasets/", json=payload, auth=temp_user.auth)
     assert response.status_code == 422
 
     data = response.json()
@@ -99,8 +102,12 @@ CREATE_ANY_DATASET = CreateDataset(
 
 
 @pytest.mark.asyncio
-async def test_dataset_crud(client: httpx.AsyncClient, admin_user: TestUser) -> None:
-    response = await client.post("/datasets/", json=CREATE_DATASET_PAYLOAD)
+async def test_dataset_crud(
+    client: httpx.AsyncClient, temp_user: TestUser, admin_user: TestUser
+) -> None:
+    response = await client.post(
+        "/datasets/", json=CREATE_DATASET_PAYLOAD, auth=temp_user.auth
+    )
     assert response.status_code == 201
     data = response.json()
 
@@ -131,38 +138,72 @@ async def test_dataset_crud(client: httpx.AsyncClient, admin_user: TestUser) -> 
     }
 
     non_existing_id = id_factory()
-    response = await client.get(f"/datasets/{non_existing_id}/")
+
+    response = await client.get(f"/datasets/{non_existing_id}/", auth=temp_user.auth)
     assert response.status_code == 404
 
-    response = await client.get(f"/datasets/{pk}/")
+    response = await client.get(f"/datasets/{pk}/", auth=temp_user.auth)
     assert response.status_code == 200
     assert response.json() == data
 
-    response = await client.get("/datasets/")
+    response = await client.get("/datasets/", auth=temp_user.auth)
     assert response.status_code == 200
     assert response.json() == [data]
 
     response = await client.delete(f"/datasets/{pk}/", auth=admin_user.auth)
     assert response.status_code == 204
 
-    response = await client.get(f"/datasets/{pk}/")
+    response = await client.get(f"/datasets/{pk}/", auth=temp_user.auth)
     assert response.status_code == 404
 
-    response = await client.get("/datasets/")
+    response = await client.get("/datasets/", auth=temp_user.auth)
     assert response.status_code == 200
     assert response.json() == []
 
 
 @pytest.mark.asyncio
+class TestDatasetPermissions:
+    async def test_create_not_authenticated(self, client: httpx.AsyncClient) -> None:
+        response = await client.post("/datasets/", json=CREATE_DATASET_PAYLOAD)
+        assert response.status_code == 401
+
+    async def test_get_not_authenticated(self, client: httpx.AsyncClient) -> None:
+        pk = id_factory()
+        response = await client.get(f"/datasets/{pk}/")
+        assert response.status_code == 401
+
+    async def test_list_not_authenticated(self, client: httpx.AsyncClient) -> None:
+        response = await client.get("/datasets/")
+        assert response.status_code == 401
+
+    async def test_update_not_authenticated(self, client: httpx.AsyncClient) -> None:
+        pk = id_factory()
+        response = await client.put(f"/datasets/{pk}/", json={})
+        assert response.status_code == 401
+
+    async def test_delete_not_authenticated(self, client: httpx.AsyncClient) -> None:
+        pk = id_factory()
+        response = await client.delete(f"/datasets/{pk}/")
+        assert response.status_code == 401
+
+    async def test_delete_not_admin(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
+        pk = id_factory()
+        response = await client.delete(f"/datasets/{pk}/", auth=temp_user.auth)
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_dataset_get_all_uses_reverse_chronological_order(
-    client: httpx.AsyncClient,
+    client: httpx.AsyncClient, temp_user: TestUser
 ) -> None:
     bus = resolve(MessageBus)
     await bus.execute(CREATE_ANY_DATASET.copy(update={"title": "Oldest"}))
     await bus.execute(CREATE_ANY_DATASET.copy(update={"title": "Intermediate"}))
     await bus.execute(CREATE_ANY_DATASET.copy(update={"title": "Newest"}))
 
-    response = await client.get("/datasets/")
+    response = await client.get("/datasets/", auth=temp_user.auth)
     assert response.status_code == 200
     titles = [dataset["title"] for dataset in response.json()]
     assert titles == ["Newest", "Intermediate", "Oldest"]
@@ -180,16 +221,18 @@ class TestDatasetOptionalFields:
         ],
     )
     async def test_optional_fields_missing_uses_defaults(
-        self, client: httpx.AsyncClient, field: str, default: Any
+        self, client: httpx.AsyncClient, temp_user: TestUser, field: str, default: Any
     ) -> None:
         payload = CREATE_DATASET_PAYLOAD.copy()
         payload.pop(field)
-        response = await client.post("/datasets/", json=payload)
+        response = await client.post("/datasets/", json=payload, auth=temp_user.auth)
         assert response.status_code == 201
         dataset = response.json()
         assert dataset[field] == default
 
-    async def test_optional_fields_invalid(self, client: httpx.AsyncClient) -> None:
+    async def test_optional_fields_invalid(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
         response = await client.post(
             "/datasets/",
             json={
@@ -199,6 +242,7 @@ class TestDatasetOptionalFields:
                 "update_frequency": "not_in_enum",
                 "last_updated_at": "not_a_datetime",
             },
+            auth=temp_user.auth,
         )
         assert response.status_code == 422
         (
@@ -219,19 +263,26 @@ class TestDatasetOptionalFields:
 
 @pytest.mark.asyncio
 class TestDatasetUpdate:
-    async def test_not_found(self, client: httpx.AsyncClient) -> None:
+    async def test_not_found(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
         response = await client.put(
             f"/datasets/{id_factory()}/",
             json=CREATE_DATASET_PAYLOAD,
+            auth=temp_user.auth,
         )
         assert response.status_code == 404
 
-    async def test_full_entity_expected(self, client: httpx.AsyncClient) -> None:
+    async def test_full_entity_expected(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_ANY_DATASET)
 
         # Apply PUT semantics, which expect a full entity.
-        response = await client.put(f"/datasets/{dataset_id}/", json={})
+        response = await client.put(
+            f"/datasets/{dataset_id}/", json={}, auth=temp_user.auth
+        )
         assert response.status_code == 422
         fields = [
             "title",
@@ -251,7 +302,9 @@ class TestDatasetUpdate:
             assert error["loc"] == ["body", field], field
             assert error["type"] == "value_error.missing", field
 
-    async def test_fields_empty_invalid(self, client: httpx.AsyncClient) -> None:
+    async def test_fields_empty_invalid(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_ANY_DATASET)
 
@@ -269,6 +322,7 @@ class TestDatasetUpdate:
                 "update_frequency": "weekly",
                 "last_updated_at": known_date.isoformat(),
             },
+            auth=temp_user.auth,
         )
         assert response.status_code == 422
 
@@ -286,7 +340,7 @@ class TestDatasetUpdate:
         assert err_formats["loc"] == ["body", "formats"]
         assert "at least one" in err_formats["msg"].lower()
 
-    async def test_update(self, client: httpx.AsyncClient) -> None:
+    async def test_update(self, client: httpx.AsyncClient, temp_user: TestUser) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_ANY_DATASET)
 
@@ -306,6 +360,7 @@ class TestDatasetUpdate:
                 "update_frequency": "weekly",
                 "last_updated_at": other_known_date.isoformat(),
             },
+            auth=temp_user.auth,
         )
         assert response.status_code == 200
 
@@ -343,7 +398,9 @@ class TestDatasetUpdate:
 
 @pytest.mark.asyncio
 class TestFormats:
-    async def test_formats_add(self, client: httpx.AsyncClient) -> None:
+    async def test_formats_add(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_ANY_DATASET)
 
@@ -354,12 +411,15 @@ class TestFormats:
                 "geographical_coverage": CREATE_ANY_DATASET.geographical_coverage.value,
                 "formats": ["website", "api", "file_gis"],
             },
+            auth=temp_user.auth,
         )
 
         assert response.status_code == 200
         assert sorted(response.json()["formats"]) == ["api", "file_gis", "website"]
 
-    async def test_formats_remove(self, client: httpx.AsyncClient) -> None:
+    async def test_formats_remove(
+        self, client: httpx.AsyncClient, temp_user: TestUser
+    ) -> None:
         bus = resolve(MessageBus)
         dataset_id = await bus.execute(CREATE_ANY_DATASET)
 
@@ -370,6 +430,7 @@ class TestFormats:
                 "geographical_coverage": CREATE_ANY_DATASET.geographical_coverage.value,
                 "formats": ["website"],
             },
+            auth=temp_user.auth,
         )
 
         assert response.status_code == 200
@@ -379,18 +440,12 @@ class TestFormats:
 @pytest.mark.asyncio
 class TestDeleteDataset:
     async def test_delete(
-        self, client: httpx.AsyncClient, temp_user: TestUser, admin_user: TestUser
+        self, client: httpx.AsyncClient, admin_user: TestUser
     ) -> None:
         bus = resolve(MessageBus)
 
         dataset_id = await bus.execute(CREATE_ANY_DATASET)
         dataset = await bus.execute(GetDatasetByID(id=dataset_id))
-
-        # Permissions
-        response = await client.delete(f"/datasets/{dataset_id}/")
-        assert response.status_code == 401
-        response = await client.delete(f"/datasets/{dataset_id}/", auth=temp_user.auth)
-        assert response.status_code == 403
 
         response = await client.delete(f"/datasets/{dataset_id}/", auth=admin_user.auth)
         assert response.status_code == 204


### PR DESCRIPTION
Closes #194 

Ça devrait débloquer aussi #165 / #187 : tous les endpoints de la partie de l'outil accessible seulement si connecté renverraient maintenant une 401 en cas de nécessité de déconnexion.