### PR TITLE
Generalize passing passwords from env in initdata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/${DB:-catalogage}"
 
-TOOLS_ADMIN_PASSWORD="admin"
+TOOLS_PASSWORDS="admin@catalogue.data.gouv.fr=admin"

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/${DB:-catalogage}"
 
-TOOLS_PASSWORDS="admin@catalogue.data.gouv.fr=admin"
+TOOLS_PASSWORDS='{"admin@catalogue.data.gouv.fr": "admin"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     env:
       APP_DATABASE_URL: "postgresql+asyncpg://username:password@localhost:5432/catalogage"
-      TOOLS_PASSWORDs: admin@catalogue.data.gouv.fr=ci-admin
+      TOOLS_PASSWORDS: '{"admin@catalogue.data.gouv.fr": "ci-admin"}'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     env:
       APP_DATABASE_URL: "postgresql+asyncpg://username:password@localhost:5432/catalogage"
-      TOOLS_ADMIN_PASSWORD: ci-admin
+      TOOLS_PASSWORDs: admin@catalogue.data.gouv.fr=ci-admin
 
     steps:
       - uses: actions/checkout@v2

--- a/client/src/playwright.config.ts
+++ b/client/src/playwright.config.ts
@@ -2,10 +2,26 @@ import path from "path";
 import dotenv from "dotenv";
 import type { PlaywrightTestConfig } from "@playwright/test";
 import type { AppTestArgs } from "src/tests/e2e/fixtures";
+import { ADMIN_EMAIL } from "./tests/e2e/constants";
 
 dotenv.config({
   path: path.resolve("..", ".env"),
 });
+
+const getAdminTestPassword = (): string => {
+  const passwords = Object.fromEntries(
+    process.env.TOOLS_PASSWORDS.split(",")
+      .map((value) => value.trim())
+      .map((value) => value.split("="))
+  );
+  const adminPassword = passwords[ADMIN_EMAIL];
+  if (!adminPassword) {
+    throw new Error(
+      `Password for ${ADMIN_EMAIL} not defined in TOOLS_PASSWORDS`
+    );
+  }
+  return adminPassword;
+};
 
 const config: PlaywrightTestConfig<AppTestArgs> = {
   testDir: "./tests/e2e/",
@@ -22,7 +38,7 @@ const config: PlaywrightTestConfig<AppTestArgs> = {
     {
       name: "default",
       use: {
-        adminTestPassword: process.env.TOOLS_ADMIN_PASSWORD,
+        adminTestPassword: getAdminTestPassword(),
       },
     },
   ],

--- a/client/src/playwright.config.ts
+++ b/client/src/playwright.config.ts
@@ -9,11 +9,7 @@ dotenv.config({
 });
 
 const getAdminTestPassword = (): string => {
-  const passwords = Object.fromEntries(
-    process.env.TOOLS_PASSWORDS.split(",")
-      .map((value) => value.trim())
-      .map((value) => value.split("="))
-  );
+  const passwords = JSON.parse(process.env.TOOLS_PASSWORDS);
   const adminPassword = passwords[ADMIN_EMAIL];
   if (!adminPassword) {
     throw new Error(

--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -195,6 +195,6 @@ Des paramètres avancés (principalement dédiés au déploiement - voir [Opéra
 |---|---|---|
 | `APP_SERVER_MODE` | Un mode d'opération qui configure Uvicorn en conséquence : <br> - `local` : pour le développement local (_hot reload_ activé, etc) <br> - `live` : pour tout déploiement tel que défini via Ansible | `local` |
 | `APP_PORT` | Port du server d'API | `3579` |
-| `TOOLS_ADMIN_PASSWORD` | Mot de passe admin initial (voir [Données initiales](./outils.md#données-initiales)) | |
+| `TOOLS_PASSWORDS` | Mots de passe pour les [Données initiales](./outils.md#données-initiales)) | |
 | `VITE_API_BROWSER_URL` | URL utilisée par le navigateur lors de requêtes d'API. En mode `live`, indiquer le chemin vers l'API configuré sur Nginx : `/api`. | `http://localhost:3579` |
 | `VITE_API_SSR_URL` | URL utilisée par le serveur frontend lors de requêtes d'API | `http://localhost:3579` |

--- a/docs/fr/demarrage.md
+++ b/docs/fr/demarrage.md
@@ -195,6 +195,6 @@ Des paramètres avancés (principalement dédiés au déploiement - voir [Opéra
 |---|---|---|
 | `APP_SERVER_MODE` | Un mode d'opération qui configure Uvicorn en conséquence : <br> - `local` : pour le développement local (_hot reload_ activé, etc) <br> - `live` : pour tout déploiement tel que défini via Ansible | `local` |
 | `APP_PORT` | Port du server d'API | `3579` |
-| `TOOLS_PASSWORDS` | Mots de passe pour les [Données initiales](./outils.md#données-initiales)) | |
+| `TOOLS_PASSWORDS` | Mapping `email -> password`, voir [Données initiales](./outils.md#données-initiales)) | |
 | `VITE_API_BROWSER_URL` | URL utilisée par le navigateur lors de requêtes d'API. En mode `live`, indiquer le chemin vers l'API configuré sur Nginx : `/api`. | `http://localhost:3579` |
 | `VITE_API_SSR_URL` | URL utilisée par le serveur frontend lors de requêtes d'API | `http://localhost:3579` |

--- a/docs/fr/outils.md
+++ b/docs/fr/outils.md
@@ -62,10 +62,10 @@ Structure :
   * `params` - dict
     * title, description, et autres champs de [`DatasetCreate` (API docs)](https://demo.catalogue.multi.coop/api/docs)
 
-Il est possible de passer des mots de passe utilisateur secrets en utilisant la valeur spéciale `password: __env__` et en définissant une variable d'environnement `TOOLS_PASSWORD` qui fait correspondre emails et mots de passe :
+Il est possible de passer des mots de passe utilisateur secrets en utilisant la valeur spéciale `password: __env__`. Le mot de passe correspondant à l'email doit alors être défini dans un objet JSON via la variable d'environnement `TOOLS_PASSWORD` :
 
 ```bash
-TOOLS_PASSWORDS="email1=password1, email2=password2, ..." venv/bin/python -m tools.initdata /path/to/initdata.yml
+TOOLS_PASSWORDS='{"email1": "password1", "email2": "password2", ...}' venv/bin/python -m tools.initdata /path/to/initdata.yml
 ```
 
 Exemple :
@@ -78,8 +78,7 @@ users:
       email: "john.doe@example.org"
       password: "example"
   - # Utilisateur admin.
-    # Mot de passe défini par $TOOLS_PASSWORDS (format : '<email>=<password>' séparés par des virgules),
-    # ou demandé en ligne de commande si vide.
+    # Mot de passe défini par $TOOLS_PASSWORDS, ou demandé en ligne de commande si vide.
     id: "<UUID>"
     params:
       email: "sarah.conor@example.org"
@@ -102,7 +101,7 @@ datasets:
 Utilisation :
 
 ```
-TOOLS_PASSWORDS="sarah.conor@example.org=sarahpwd" venv/bin/python -m tools.initdata /path/to/initdata.yml
+TOOLS_PASSWORDS='{"sarah.conor@example.org": "sarahpwd"}' venv/bin/python -m tools.initdata /path/to/initdata.yml
 ```
 
 N.B. : Avant de créer chaque entité, le script s'assure qu'elle n'existe pas déjà en base. En passant le flag `--reset` (intégré dans `make initdatareset`), les champs des entités existantes sont réinitialisées à leurs valeurs définies dans le fichier YAML.

--- a/docs/fr/outils.md
+++ b/docs/fr/outils.md
@@ -40,21 +40,50 @@ Si celles-ci ont changé (suite à des manipulations manuelles dans le frontend,
 make initdatareset
 ```
 
-Les données à charger sont définies dans le fichier YAML `tools/initdata.yml`. Sa structure est ad-hoc. Elle est fortement corrélée au traitement réalisé par le script.
+Ces commandes `make` sont branchées sur le fichier `tools/initdata.yml`. Pour utiliser un fichier différent, invoquer le script Python directement :
+
+```
+venv/bin/python -m tools.initdata <file>
+```
+
+La structure d'un fichier d'initdata est ad-hoc, et fortement corrélée au traitement réalisé par le script.
+
+Structure :
+
+* `users` - list
+  * `id` - str - UUID
+  * `params` - dict
+    * `email` - str
+    * `password` - str - Utiliser `__env__` pour tirer le mot de passe de `TOOLS_PASSWORDS`
+  * `extras` - _Optionnel_, dict
+    * `role` - str, `USER | ADMIN`
+* `datasets` - list
+  * `id` - str - UUID
+  * `params` - dict
+    * title, description, et autres champs de [`DatasetCreate` (API docs)](https://demo.catalogue.multi.coop/api/docs)
+
+Il est possible de passer des mots de passe utilisateur secrets en utilisant la valeur spéciale `password: __env__` et en définissant une variable d'environnement `TOOLS_PASSWORD` qui fait correspondre emails et mots de passe :
+
+```bash
+TOOLS_PASSWORDS="email1=password1, email2=password2, ..." venv/bin/python -m tools.initdata /path/to/initdata.yml
+```
+
+Exemple :
 
 ```yaml
 users:
   - # Utilisateur standard.
     id: "<UUID>"
     params:
-      email: "<email>"
-      password: "<password>"
+      email: "john.doe@example.org"
+      password: "example"
   - # Utilisateur admin.
-    # Mot de passe défini par $TOOLS_ADMIN_PASSWORD,
+    # Mot de passe défini par $TOOLS_PASSWORDS (format : '<email>=<password>' séparés par des virgules),
     # ou demandé en ligne de commande si vide.
     id: "<UUID>"
     params:
-      email: "<email>"
+      email: "sarah.conor@example.org"
+      password: __env__
     extras:
       role: ADMIN
   - # ...
@@ -66,16 +95,23 @@ datasets:
       description: "<description>"
       formats:
         - "<format>"
+      # ...
   - # ...
 ```
 
-Avant de créer chaque entité, le script s'assure qu'elle n'existe pas déjà en base.
+Utilisation :
 
-(Lire le code source pour les détails.)
+```
+TOOLS_PASSWORDS="sarah.conor@example.org=sarahpwd" venv/bin/python -m tools.initdata /path/to/initdata.yml
+```
 
-## Générer un ID
+N.B. : Avant de créer chaque entité, le script s'assure qu'elle n'existe pas déjà en base. En passant le flag `--reset` (intégré dans `make initdatareset`), les champs des entités existantes sont réinitialisées à leurs valeurs définies dans le fichier YAML.
 
-Pour générer un ID d'entité, lancer :
+Pour plus de détails, lire le code source.
+
+## Générer un UUID
+
+Pour générer un UUID d'entité, lancer :
 
 ```
 make id

--- a/ops/ansible/roles/web/templates/.env.j2
+++ b/ops/ansible/roles/web/templates/.env.j2
@@ -1,7 +1,7 @@
 APP_SERVER_MODE=live
 APP_PORT="{{ api_port }}"
 APP_DATABASE_URL="{{ database_url }}"
-TOOLS_ADMIN_PASSWORD="{{ admin_password }}"
+TOOLS_PASSWORDS="admin@catalogue.data.gouv.fr={{ admin_password }}"
 VITE_SERVER_MODE=live
 VITE_API_BROWSER_URL="/api"
 VITE_API_SSR_URL="http://localhost:{{ api_port }}"

--- a/ops/ansible/roles/web/templates/.env.j2
+++ b/ops/ansible/roles/web/templates/.env.j2
@@ -1,7 +1,7 @@
 APP_SERVER_MODE=live
 APP_PORT="{{ api_port }}"
 APP_DATABASE_URL="{{ database_url }}"
-TOOLS_PASSWORDS="admin@catalogue.data.gouv.fr={{ admin_password }}"
+TOOLS_PASSWORDS='{"admin@catalogue.data.gouv.fr": "{{ admin_password }}"}'
 VITE_SERVER_MODE=live
 VITE_API_BROWSER_URL="/api"
 VITE_API_SSR_URL="http://localhost:{{ api_port }}"

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -7,6 +7,7 @@ users:
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:
       email: admin@catalogue.data.gouv.fr
+      password: __env__
     extras:
       role: ADMIN
 


### PR DESCRIPTION
Refs #170 

Cette PR généralise le mécanisme introduit dans #164 pour pouvoir définir des mots de passe utilisateur par variables d'environnement, sans les hardcoder en clair dans un fichier texte.

On peut désormais passer un objet JSON faisant correspondre email et password, et indiquer `password: __env__` dans le fichier d'initdata.

Cela permet de définir les mdp d'administrateurs aussi bien que d'utilisateurs standards, autant que l'on veut (au lieu d'1 seul admin).