### PR TITLE
Enable strict null checks

### DIFF
--- a/client/src/definitions/auth.ts
+++ b/client/src/definitions/auth.ts
@@ -1,3 +1,5 @@
+import type { Maybe } from "$lib/util/maybe";
+
 export interface LoginFormData {
   email: string;
   password: string;
@@ -24,5 +26,5 @@ export interface User {
 
 export interface UserInfo {
   loggedIn: boolean;
-  user: User | null;
+  user: Maybe<User>;
 }

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -2,7 +2,7 @@
 // See: https://vitejs.dev/guide/env-and-mode.html#env-files
 const { VITE_API_BROWSER_URL, VITE_API_SSR_URL } = import.meta.env;
 
-const stringOnly = (value: string | boolean) =>
+const stringOnly = (value: string | boolean | undefined) =>
   typeof value === "string" ? value : undefined;
 
 export const API_BROWSER_URL =

--- a/client/src/lib/auth/guard.ts
+++ b/client/src/lib/auth/guard.ts
@@ -1,7 +1,8 @@
 import { get } from "svelte/store";
 import type { LoadOutput } from "@sveltejs/kit";
-import { isLoggedIn } from "../stores/auth";
+import { user } from "../stores/auth";
 import { PUBLIC_PAGES } from "src/constants";
+import { Maybe } from "$lib/util/maybe";
 
 /**
  * Force-redirect to the login page if an unauthenticated user
@@ -12,7 +13,7 @@ export const authGuard = (url: URL): LoadOutput => {
     return {};
   }
 
-  if (get(isLoggedIn)) {
+  if (Maybe.Some(get(user))) {
     return {};
   }
 

--- a/client/src/lib/components/ContactEmailsField/ContactEmailsField.spec.ts
+++ b/client/src/lib/components/ContactEmailsField/ContactEmailsField.spec.ts
@@ -65,7 +65,7 @@ describe("ContactEmailsField component", () => {
       target: { value: "contact@mydomain.org" },
     });
     expect(inputs.length).toBe(4);
-    const removeButton = getByRoleIn(inputs[2].parentElement, "button", {
+    const removeButton = getByRoleIn(inputs[2].parentElement!, "button", {
       name: /Supprimer/i,
     });
 

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 
 import DatasetForm from "./DatasetForm.svelte";
-import { render, fireEvent, waitFor } from "@testing-library/svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 import type { DataFormat, DatasetFormData } from "src/definitions/datasets";
 
 describe("Test the dataset form", () => {
@@ -200,11 +200,11 @@ describe("Test the dataset form", () => {
     await fireEvent.blur(lastUpdatedAt);
     await fireEvent.blur(updateFrequency);
 
-    let submittedValue: DatasetFormData;
-    component.$on("save", (event) => (submittedValue = event.detail));
     const form = getByRole("form");
     await fireEvent.submit(form);
-    await waitFor(() => expect(submittedValue).toBeDefined());
+    const submittedValue = await new Promise<DatasetFormData>((resolve) => {
+      component.$on("save", (event) => resolve(event.detail));
+    });
     expect(submittedValue.lastUpdatedAt).toBe(null);
     expect(submittedValue.updateFrequency).toBe(null);
     expect(submittedValue.publishedUrl).toBe(null);

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -20,19 +20,20 @@
   import Select from "../Select/Select.svelte";
   import { toSelectOptions } from "src/lib/transformers/form";
   import { handleSelectChange } from "src/lib/util/form";
+  import { DropMaybe, Maybe, AddMaybe } from "$lib/util/maybe";
 
   export let submitLabel = "Publier ce jeu de données";
   export let loadingLabel = "Publication en cours...";
   export let loading = false;
 
-  export let initial: DatasetFormData = {
+  export let initial: AddMaybe<DatasetFormData, "geographicalCoverage"> = {
     title: "",
     description: "",
     service: "",
     formats: [],
     entrypointEmail: "",
     contactEmails: [$user?.email || ""],
-    geographicalCoverage: null,
+    geographicalCoverage: null, // Allow select null option upon creation
     lastUpdatedAt: null,
     updateFrequency: null,
     technicalSource: "",
@@ -48,7 +49,7 @@
     dataFormats: boolean[];
     entrypointEmail: string;
     contactEmails: string[];
-    geographicalCoverage: GeographicalCoverage;
+    geographicalCoverage: Maybe<GeographicalCoverage>;
     lastUpdatedAt: string | null;
     updateFrequency: UpdateFrequency | null;
     technicalSource: string | null;
@@ -101,16 +102,21 @@
           ),
         lastUpdatedAt: yup.date().nullable(),
         updateFrequency: yup.string().nullable(),
-        geographicalCoverage: yup.string().required("Ce champs est requis"),
+        geographicalCoverage: yup
+          .string()
+          .nullable()
+          .required("Ce champs est requis"),
         technicalSource: yup.string().nullable(),
         publishedUrl: yup.string().nullable(),
       }),
-      onSubmit: (values) => {
+      onSubmit: (
+        values: DropMaybe<DatasetFormValues, "geographicalCoverage">
+      ) => {
         const formats = values.dataFormats
           .map((checked, index) =>
             checked ? dataFormatChoices[index].value : null
           )
-          .filter(Boolean);
+          .filter(Maybe.Some);
 
         const contactEmails = values.contactEmails.filter(Boolean);
 

--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
-  import { isLoggedIn, logout, user } from "$lib/stores/auth";
+  import { logout, user } from "$lib/stores/auth";
   import paths from "$lib/paths";
+  import { Maybe } from "$lib/util/maybe";
 
   type NavItem = {
     label: string;
@@ -70,7 +71,7 @@
         </div>
         <div class="fr-header__tools">
           <div class="fr-header__tools-links">
-            {#if $isLoggedIn}
+            {#if Maybe.Some($user)}
               <p>
                 {$user.email}
               </p>
@@ -113,7 +114,7 @@
 
       <div class="fr-header__menu-links" />
 
-      {#if $isLoggedIn}
+      {#if Maybe.Some($user)}
         <nav
           class="fr-nav"
           role="navigation"

--- a/client/src/lib/components/LoginForm/LoginForm.spec.ts
+++ b/client/src/lib/components/LoginForm/LoginForm.spec.ts
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, fireEvent, waitFor } from "@testing-library/svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 import type { LoginFormData } from "src/definitions/auth";
 
 import LoginForm from "./LoginForm.svelte";
@@ -47,13 +47,6 @@ describe("Test the dataset list item", () => {
   test("The form submits the logged in user", async () => {
     const { getByRole, getByLabelText, component } = render(LoginForm);
 
-    let submittedValue: LoginFormData;
-
-    component.$on(
-      "submit",
-      (event: CustomEvent<LoginFormData>) => (submittedValue = event.detail)
-    );
-
     await fireEvent.input(getByLabelText("Adresse e-mail"), {
       target: { value: "user@mydomain.org" },
     });
@@ -61,7 +54,10 @@ describe("Test the dataset list item", () => {
       target: { value: "p@ssw0rd" },
     });
     await fireEvent.click(getByRole("button"));
-    await waitFor(() => expect(submittedValue).toBeDefined());
+
+    const submittedValue = await new Promise<LoginFormData>((resolve) => {
+      component.$on("submit", (event) => resolve(event.detail));
+    });
 
     expect(submittedValue).toEqual({
       email: "user@mydomain.org",

--- a/client/src/lib/components/SearchForm/SearchForm.spec.ts
+++ b/client/src/lib/components/SearchForm/SearchForm.spec.ts
@@ -40,21 +40,19 @@ describe("Test the search form", () => {
   test("The form submits the search value", async () => {
     const { getByRole, component } = render(SearchForm);
 
-    let submittedValue: string;
-
-    component.$on(
-      "submit",
-      (event: CustomEvent<string>) => (submittedValue = event.detail)
-    );
+    const submittedValues: string[] = [];
+    component.$on("submit", (event: CustomEvent<string>) => {
+      submittedValues.push(event.detail);
+    });
 
     await fireEvent.click(getByRole("button"));
-    expect(submittedValue).toBe("");
+    expect(submittedValues.pop()).toBe("");
 
     await fireEvent.input(getByRole("searchbox"), {
       target: { value: "Forêt" },
     });
     await fireEvent.click(getByRole("button"));
-    expect(submittedValue).toBe("Forêt");
+    expect(submittedValues.pop()).toBe("Forêt");
   });
 
   test("The form can be large", async () => {

--- a/client/src/lib/components/Select/Select.spec.ts
+++ b/client/src/lib/components/Select/Select.spec.ts
@@ -48,9 +48,11 @@ describe("Test the select component", () => {
 
     const { getByRole } = render(Select, { props });
 
-    expect(
-      (getByRole("option", { name: placeholder }) as HTMLOptionElement).selected
-    ).toBeFalsy();
+    const option = getByRole("option", {
+      name: placeholder,
+    }) as HTMLOptionElement;
+    expect(option.value).toBe("null");
+    expect(option.selected).toBeTruthy();
   });
 
   test("should be marked as required", () => {

--- a/client/src/lib/components/Select/Select.svelte
+++ b/client/src/lib/components/Select/Select.svelte
@@ -11,7 +11,7 @@
   export let hintText = "";
   export let required = false;
   export let error = "";
-  export let value = "";
+  export let value: string | null = null;
 </script>
 
 <div class="fr-select-group" class:fr-select-group--error={error}>

--- a/client/src/lib/repositories/datasets.ts
+++ b/client/src/lib/repositories/datasets.ts
@@ -34,7 +34,7 @@ type GetDatasets = (opts: {
 }) => Promise<Dataset[]>;
 
 export const getDatasets: GetDatasets = async ({ fetch, apiToken, q }) => {
-  const queryItems = [];
+  const queryItems: [string, string][] = [];
   if (typeof q === "string") {
     queryItems.push(["q", q], ["highlight", "true"]);
   }

--- a/client/src/lib/stores/auth/index.ts
+++ b/client/src/lib/stores/auth/index.ts
@@ -1,5 +1,6 @@
 import type { UserInfo, User } from "src/definitions/auth";
 import { derived } from "svelte/store";
+import { Maybe } from "$lib/util/maybe";
 import { storable } from "../localStorage";
 
 const validateExistingUserInfo = (value: UserInfo): boolean => {
@@ -13,14 +14,15 @@ const userInfo = storable<UserInfo>(
   validateExistingUserInfo
 );
 
-export const isLoggedIn = derived(userInfo, (values) => values.loggedIn);
-
 export const user = derived(userInfo, (values) => values.user);
 
-export const isAdmin = derived(
-  userInfo,
-  (values) => values.user?.role === "ADMIN"
-);
+export const apiToken = derived(user, ($user) => {
+  return Maybe.Some($user) ? $user.apiToken : "";
+});
+
+export const isAdmin = derived(user, (user) => {
+  return user?.role === "ADMIN";
+});
 
 export const login = (user: User): void => {
   userInfo.set({ loggedIn: true, user });

--- a/client/src/lib/util/form.ts
+++ b/client/src/lib/util/form.ts
@@ -2,7 +2,7 @@ export const handleSelectChange = async <Inf>(
   fieldname: keyof Inf,
   event: Event,
   handleChange: (event: Event) => Promise<void>,
-  updateValidateField: (fieldname: keyof Inf, event: Event) => void
+  updateValidateField: (fieldname: keyof Inf, value: unknown) => void
 ): Promise<void> => {
   const target = event.currentTarget as EventTarget & HTMLSelectElement;
 

--- a/client/src/lib/util/maybe.ts
+++ b/client/src/lib/util/maybe.ts
@@ -1,0 +1,20 @@
+// See: https://github.com/kylecorbelli/typescript-nullable
+// See: https://engineering.dollarshaveclub.com/typescript-maybe-type-and-module-627506ecc5c8
+
+export type Maybe<T> = T | null | undefined;
+
+export type AddMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [key in K]: Maybe<T[K]>;
+};
+
+export type DropMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [key in K]: T[K] extends Maybe<infer U> ? U : never;
+};
+
+const Some = <T>(m: Maybe<T>): m is T => {
+  return m !== null && m !== undefined;
+};
+
+export const Maybe = {
+  Some,
+};

--- a/client/src/lib/util/urls.spec.ts
+++ b/client/src/lib/util/urls.spec.ts
@@ -1,7 +1,7 @@
 import { toQueryString } from "./urls";
 
 describe("toQueryString", () => {
-  const cases: [[string, string][], string][] = [
+  const cases: [[string, string | null | undefined][], string][] = [
     [[], ""],
     [[["q", undefined]], ""],
     [[["q", null]], ""],

--- a/client/src/lib/util/urls.ts
+++ b/client/src/lib/util/urls.ts
@@ -1,12 +1,15 @@
+import { Maybe } from "./maybe";
+
 /**
  * Create an URL query string, including a leading "?" if needed, dropping any null or undefined values.
  */
-export const toQueryString = (
-  items: [string, string | null | undefined][]
-): string => {
-  const definedItems = items.filter(([, value]) => typeof value === "string");
+export const toQueryString = (items: [string, Maybe<string>][]): string => {
   const params = new URLSearchParams();
-  definedItems.forEach(([name, value]) => params.append(name, value));
+  items.forEach(([name, value]) => {
+    if (Maybe.Some(value)) {
+      params.append(name, value);
+    }
+  });
   const qs = params.toString();
   return qs ? `?${qs}` : "";
 };

--- a/client/src/playwright.config.ts
+++ b/client/src/playwright.config.ts
@@ -9,7 +9,7 @@ dotenv.config({
 });
 
 const getAdminTestPassword = (): string => {
-  const passwords = JSON.parse(process.env.TOOLS_PASSWORDS);
+  const passwords = JSON.parse(process.env.TOOLS_PASSWORDS || "{}");
   const adminPassword = passwords[ADMIN_EMAIL];
   if (!adminPassword) {
     throw new Error(

--- a/client/src/routes/__error.svelte
+++ b/client/src/routes/__error.svelte
@@ -4,7 +4,7 @@
   export const load: ErrorLoad = ({ error, status }) => {
     return {
       props: {
-        title: `${status}: ${error.message}`,
+        title: `${status}: ${error ? error.message : "unknown error"}`,
       },
     };
   };

--- a/client/src/routes/contribuer/index.svelte
+++ b/client/src/routes/contribuer/index.svelte
@@ -6,7 +6,7 @@
   import { goto } from "$app/navigation";
   import type { DatasetFormData } from "src/definitions/datasets";
   import paths from "$lib/paths";
-  import { user } from "$lib/stores/auth";
+  import { apiToken } from "$lib/stores/auth";
   import DatasetForm from "$lib/components/DatasetForm/DatasetForm.svelte";
   import { createDataset } from "$lib/repositories/datasets";
 
@@ -18,7 +18,7 @@
 
       const dataset = await createDataset({
         fetch,
-        apiToken: $user.apiToken,
+        apiToken: $apiToken,
         data: event.detail,
       });
 

--- a/client/src/routes/fiches/[id]/edit.svelte
+++ b/client/src/routes/fiches/[id]/edit.svelte
@@ -6,7 +6,7 @@
   export const load: Load = async ({ fetch, params }) => {
     const dataset = await getDatasetByID({
       fetch,
-      apiToken: get(user).apiToken,
+      apiToken: get(apiToken),
       id: params.id,
     });
 
@@ -24,7 +24,7 @@
   import type { Dataset, DatasetFormData } from "src/definitions/datasets";
   import DatasetForm from "$lib/components/DatasetForm/DatasetForm.svelte";
   import paths from "$lib/paths";
-  import { isAdmin, user } from "$lib/stores/auth";
+  import { isAdmin, apiToken } from "$lib/stores/auth";
   import { deleteDataset } from "$lib/repositories/datasets";
 
   export let dataset: Dataset;
@@ -37,7 +37,7 @@
       loading = true;
       await updateDataset({
         fetch,
-        apiToken: $user.apiToken,
+        apiToken: $apiToken,
         id,
         data: event.detail,
       });
@@ -56,7 +56,7 @@
       return;
     }
 
-    await deleteDataset({ fetch, apiToken: $user.apiToken, id: dataset.id });
+    await deleteDataset({ fetch, apiToken: $apiToken, id: dataset.id });
     await goto(paths.home);
   };
 </script>

--- a/client/src/routes/fiches/[id]/index.svelte
+++ b/client/src/routes/fiches/[id]/index.svelte
@@ -2,12 +2,12 @@
   import type { Load } from "@sveltejs/kit";
   import { get } from "svelte/store";
   import { getDatasetByID } from "$lib/repositories/datasets";
-  import { user } from "$lib/stores/auth";
+  import { apiToken } from "$lib/stores/auth";
 
   export const load: Load = async ({ fetch, params }) => {
     const dataset = await getDatasetByID({
       fetch,
-      apiToken: get(user).apiToken,
+      apiToken: get(apiToken),
       id: params.id,
     });
 

--- a/client/src/routes/fiches/search.svelte
+++ b/client/src/routes/fiches/search.svelte
@@ -2,14 +2,14 @@
   import type { Load } from "@sveltejs/kit";
   import { get } from "svelte/store";
   import { getDatasets } from "$lib/repositories/datasets";
-  import { user } from "$lib/stores/auth";
+  import { apiToken } from "$lib/stores/auth";
 
   export const load: Load = async ({ fetch, url }) => {
     const q = url.searchParams.get("q") || "";
 
     const datasets = await getDatasets({
       fetch,
-      apiToken: get(user).apiToken,
+      apiToken: get(apiToken),
       q,
     });
 

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -1,11 +1,11 @@
 <script context="module" lang="ts">
   import type { Load } from "@sveltejs/kit";
   import { get } from "svelte/store";
-  import { user } from "$lib/stores/auth";
+  import { apiToken } from "$lib/stores/auth";
   import { getDatasets } from "$lib/repositories/datasets";
 
   export const load: Load = async ({ fetch }) => {
-    const datasets = await getDatasets({ fetch, apiToken: get(user).apiToken });
+    const datasets = await getDatasets({ fetch, apiToken: get(apiToken) });
 
     return {
       props: {

--- a/client/src/tests/e2e/global-setup.ts
+++ b/client/src/tests/e2e/global-setup.ts
@@ -21,7 +21,7 @@ export default async function globalSetup(
 
   await saveAuthenticatedState(browser, config, {
     email: ADMIN_EMAIL,
-    password: config.projects[0].use.adminTestPassword,
+    password: config.projects[0].use.adminTestPassword || "",
     path: STATE_AUTHENTICATED_ADMIN,
   });
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -11,6 +11,7 @@
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,
     "resolveJsonModule": true,
+    "strictNullChecks": true,
     /**
 			To have warnings/errors of the Svelte compiler at the correct position,
 			enable source maps by default.


### PR DESCRIPTION
Cette PR active l'option [strictNullChecks](https://www.typescriptlang.org/tsconfig/strictNullChecks.html) de TypeScript, et fait les modifications qui s'imposent.

Ça permet de mieux éviter les cas où on pourrait laisser passer une valeur `null`. Ceux-ci sont en effet circonscrits dans un type `Maybe<...>`.

Dans le cadre de #153 j'envisage de faire renvoyer un `Maybe<...>` aux fonctions de repositories dans le cas où un appel d'API échoue (l'erreur était gérée par un store qui va automatiquement rediriger vers login en cas de 401, mais pourrait aussi afficher des messages d'erreur, etc) -- voir #205. Cette PR serait donc un prérequis.