### PR TITLE
Set default git_version in common group variables

### DIFF
--- a/ops/ansible/environments/demo/group_vars/web.yml
+++ b/ops/ansible/environments/demo/group_vars/web.yml
@@ -1,5 +1,3 @@
-git_version: master
-
 tls_enabled: true
 
 initdata_src: "{{ inventory_dir }}/assets/initdata.yml"

--- a/ops/ansible/environments/sandbox/group_vars/web.yml
+++ b/ops/ansible/environments/sandbox/group_vars/web.yml
@@ -1,3 +1,1 @@
-git_version: master
-
 tls_enabled: true

--- a/ops/ansible/environments/staging/group_vars/web.yml
+++ b/ops/ansible/environments/staging/group_vars/web.yml
@@ -1,5 +1,3 @@
-git_version: master
-
 tls_enabled: true
 
 initdata_src: "{{ inventory_dir }}/assets/initdata.yml"

--- a/ops/ansible/group_vars/web.yml
+++ b/ops/ansible/group_vars/web.yml
@@ -4,6 +4,7 @@ pyenv_python_version: "3.8.9"
 nvm_node_version: "v16.13.2"
 
 git_repo: "https://github.com/etalab/catalogage-donnees.git"
+git_version: master
 
 api_port: 3579
 client_port: 3000


### PR DESCRIPTION
Petit refacto Ansible suite à #168 

`git_version: master` est précisé dans chaque environnement alors qu'il devrait être la valeur par défaut de ce repo. Je le déplace donc dans le `group_vars/web.yml`, aux côtés des autres valeurs du repo.

En effet, les `group_vars/web.yml` des environnements ne devraient contenir que des variables spécifiques à l'environnement.