### PR TITLE
Front: améliorations mineures #1 (voir Issue 209)

### DIFF
--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -60,13 +60,14 @@
             </div>
           </div>
           <div class="fr-header__service">
-            <a href={paths.home} title="Accueil - Catalogage des données">
-              <p class="fr-header__service-title">Catalogage des données</p>
+            <a
+              href={paths.home}
+              title="Accueil - Catalogue Interministériel des Données"
+            >
+              <p class="fr-header__service-title">
+                Catalogue Interministériel des Données
+              </p>
             </a>
-            <p class="fr-header__service-tagline">
-              Un outil pour cataloguer les jeux de données des différents
-              ministères
-            </p>
           </div>
         </div>
         <div class="fr-header__tools">

--- a/client/src/routes/fiches/search.svelte
+++ b/client/src/routes/fiches/search.svelte
@@ -54,10 +54,12 @@
       <SearchForm value={q} on:submit={updateSearch} />
     </div>
 
-    <h4 class="fr-mt-6w">
-      {datasets.length}
-      {pluralize(datasets.length, "résultat", "résultats")}
-    </h4>
+    {#if datasets.length > 0}
+      <h4 class="fr-mt-6w">
+        {datasets.length}
+        {pluralize(datasets.length, "résultat", "résultats")}
+      </h4>
+    {/if}
 
     <DatasetList {datasets} />
   </section>

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -52,9 +52,8 @@
 </section>
 
 <section class="fr-container fr-mt-8w fr-mb-15w">
-  <h2 class="fr-mb-3w">Dernières contributions</h2>
-
   {#if Maybe.Some(datasets)}
+    <h2 class="fr-mb-3w">{datasets.length} jeux de donnnées contribués</h2>
     <DatasetList {datasets} />
   {/if}
 </section>

--- a/client/src/tests/e2e/search.spec.ts
+++ b/client/src/tests/e2e/search.spec.ts
@@ -82,6 +82,5 @@ test.describe("Search", () => {
     expect(json.length).toBe(0);
 
     await expect(page).toHaveURL("/fiches/search?q=noresultsexpected");
-    await page.locator("text='0 résultats'").waitFor();
   });
 });


### PR DESCRIPTION
## Cette PR corrige : 

Ref : #209 

### Header

- [x]  Remplacer le texte "Catalogage des données" par "Catalogue Interministériel des Données" (le C.I.D. ???)
- [x] Supprimer le texte "Un outil pour cataloguer les jeux de données des différents ministères"

### Page d'accueil 
- [x] A la place du titre "Dernières contributions" mettre "XXX jeux de donnnées contribués" 

### Recherche

- [x] Lorsqu'il n'y a pas de recherche lancée supprimer "0 résultats"