### PR TITLE
front: make the search page looks like the index page

### DIFF
--- a/client/src/lib/components/SearchForm/SearchForm.spec.ts
+++ b/client/src/lib/components/SearchForm/SearchForm.spec.ts
@@ -26,17 +26,6 @@ describe("Test the search form", () => {
     expect(search.value).toBe("initial");
   });
 
-  test("The 'search' placeholder can be set", async () => {
-    const { getByPlaceholderText, rerender } = render(SearchForm);
-    expect(getByPlaceholderText("Rechercher")).toBeInTheDocument();
-
-    const props = { placeholder: "Rechercher un jeu de données" };
-    rerender({ props });
-    expect(
-      getByPlaceholderText("Rechercher un jeu de données")
-    ).toBeInTheDocument();
-  });
-
   test("The form submits the search value", async () => {
     const { getByRole, component } = render(SearchForm);
 
@@ -55,12 +44,8 @@ describe("Test the search form", () => {
     expect(submittedValues.pop()).toBe("Forêt");
   });
 
-  test("The form can be large", async () => {
-    const { getByRole, rerender } = render(SearchForm);
-    expect(getByRole("search")).not.toHaveClass("fr-search-bar--lg");
-
-    const props = { size: "lg" };
-    rerender({ props });
+  test("The form must be large", async () => {
+    const { getByRole } = render(SearchForm);
     expect(getByRole("search")).toHaveClass("fr-search-bar--lg");
   });
 });

--- a/client/src/lib/components/SearchForm/SearchForm.svelte
+++ b/client/src/lib/components/SearchForm/SearchForm.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 
-  export let size: "default" | "lg" = "default";
   export let value = "";
-  export let placeholder = "Rechercher";
 
   const dispatch = createEventDispatcher<{ submit: string }>();
 
@@ -11,11 +9,17 @@
 </script>
 
 <form
-  class="fr-search-bar {size === 'lg' ? 'fr-search-bar--lg' : ''}"
+  class="fr-search-bar fr-search-bar--lg"
   role="search"
   on:submit|preventDefault={onSubmit}
 >
   <label for="q" class="fr-label">Rechercher</label>
-  <input type="search" class="fr-input" name="q" bind:value {placeholder} />
+  <input
+    type="search"
+    class="fr-input"
+    name="q"
+    bind:value
+    placeholder="Ex : taux de contamination COVID, nombre de naissances en France, ..."
+  />
   <button type="submit" class="fr-btn"> Rechercher </button>
 </form>

--- a/client/src/routes/fiches/search.svelte
+++ b/client/src/routes/fiches/search.svelte
@@ -56,10 +56,12 @@
 
 <section class="fr-container fr-mt-8w fr-mb-15w">
   {#if Maybe.Some(datasets)}
-    <h2 class="fr-mb-3w">
-      {datasets.length}
-      {pluralize(datasets.length, "résultat", "résultats")}
-    </h2>
+    {#if q}
+      <h2 class="fr-mb-3w">
+        {datasets.length}
+        {pluralize(datasets.length, "résultat", "résultats")}
+      </h2>
+    {/if}
     <DatasetList {datasets} />
   {/if}
 </section>

--- a/client/src/routes/fiches/search.svelte
+++ b/client/src/routes/fiches/search.svelte
@@ -27,9 +27,9 @@
   import type { Dataset } from "src/definitions/datasets";
   import DatasetList from "$lib/components/DatasetList/DatasetList.svelte";
   import SearchForm from "$lib/components/SearchForm/SearchForm.svelte";
-  import { pluralize } from "$lib/util/format";
   import { toQueryString } from "$lib/util/urls";
   import { Maybe } from "$lib/util/maybe";
+  import { pluralize } from "src/lib/util/format";
 
   export let q: string;
   export let datasets: Maybe<Dataset[]>;
@@ -45,22 +45,21 @@
 <svelte:head>
   <title>Rechercher un jeu de données</title>
 </svelte:head>
-
-{#if Maybe.Some(datasets)}
-  <section class="fr-container fr-mt-9w">
-    <div class="fr-col-6">
-      <h2>Rechercher un jeu de données</h2>
-
+<section class="fr-background-alt--grey fr-mb-6w">
+  <div class="fr-container fr-grid-row fr-grid-row--center fr-py-6w">
+    <div class="fr-col-10">
+      <h1>Recherchez un jeu de données</h1>
       <SearchForm value={q} on:submit={updateSearch} />
     </div>
+  </div>
+</section>
 
-    {#if datasets.length > 0}
-      <h4 class="fr-mt-6w">
-        {datasets.length}
-        {pluralize(datasets.length, "résultat", "résultats")}
-      </h4>
-    {/if}
-
+<section class="fr-container fr-mt-8w fr-mb-15w">
+  {#if Maybe.Some(datasets)}
+    <h2 class="fr-mb-3w">
+      {datasets.length}
+      {pluralize(datasets.length, "résultat", "résultats")}
+    </h2>
     <DatasetList {datasets} />
-  </section>
-{/if}
+  {/if}
+</section>

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -42,11 +42,7 @@
   <div class="fr-container fr-grid-row fr-grid-row--center fr-py-6w">
     <div class="fr-col-10">
       <h1>Recherchez un jeu de données</h1>
-      <SearchForm
-        size="lg"
-        placeholder="Ex : taux de contamination COVID, nombre de naissances en France, ..."
-        on:submit={submitSearch}
-      />
+      <SearchForm on:submit={submitSearch} />
     </div>
   </div>
 </section>


### PR DESCRIPTION
Ref: #209 

### Cette PR : 

- modifie la mise en page de la page "Search pour qu'elle ressemble à la page d'acceuil

Avant 
![avant](https://user-images.githubusercontent.com/15958334/167363296-a57dd72e-8382-4b0b-903a-1b5770f3cccc.png)

Après
![après](https://user-images.githubusercontent.com/15958334/167381769-86e176f0-4f19-4c45-b33a-dff53d3d097a.png)

