### PR TITLE
Allow triggering manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/228#issuecomment-1123561540

GitHub Actions permet de déclencher manuellement un run de la CI, mais il faut pour cela l'activer, cf : https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
