### PR TITLE
Allow running CI for PRs from forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/228#issuecomment-1123577518

Actuellement la CI ne se lance que lors d'un `push`, ou d'un run manuel (cf #231).

Pour les PRs créées depuis des forks publics (contributeurs externes), ces événements ne sont pas déclenchés : elles déclenchent l'événement `pull_request`.

Voir : https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories

Cette PR modifie la configuration pour que la CI se lance 1/ lors d'un `push` sur master (suite à une PR mergée), ou 2/ lors d'une `pull_request`, englobant contributeurs internes ou externes.