### PR TITLE
Add changepassword tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ initdatareset: #- Initialize data, resetting any changed target entities
 id: #- Generate an ID suitable for use in database entities
 	${bin}python -m tools.makeid
 
+changepassword: #- Change password of a user account
+	${bin}python -m tools.changepassword
+
 dbdiagram: #- Generate database diagram image
 	${bin}python -m tools.erd docs/db.erd.json -o docs/db.dot
 	dot docs/db.dot -T png -o docs/db.png

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -11,3 +11,8 @@ class CreateUser(Command[ID]):
 
 class DeleteUser(Command[None]):
     id: ID
+
+
+class ChangePassword(Command[None]):
+    email: str
+    password: SecretStr

--- a/server/domain/auth/entities.py
+++ b/server/domain/auth/entities.py
@@ -17,5 +17,11 @@ class User(Entity):
     role: UserRole
     api_token: str
 
+    def update_password(self, password_hash: str) -> None:
+        self.password_hash = password_hash
+
+    def update_api_token(self, api_token: str) -> None:
+        self.api_token = api_token
+
     class Config:
         orm_mode = True

--- a/server/domain/auth/repositories.py
+++ b/server/domain/auth/repositories.py
@@ -13,7 +13,13 @@ class UserRepository(Repository):
     async def get_by_email(self, email: str) -> Optional[User]:
         raise NotImplementedError  # pragma: no cover
 
+    async def get_by_api_token(self, api_token: str) -> Optional[User]:
+        raise NotImplementedError  # pragma: no cover
+
     async def insert(self, entity: User) -> ID:
+        raise NotImplementedError  # pragma: no cover
+
+    async def update(self, entity: User) -> None:
         raise NotImplementedError  # pragma: no cover
 
     async def delete(self, id: ID) -> None:

--- a/server/infrastructure/auth/module.py
+++ b/server/infrastructure/auth/module.py
@@ -1,5 +1,6 @@
-from server.application.auth.commands import CreateUser, DeleteUser
+from server.application.auth.commands import ChangePassword, CreateUser, DeleteUser
 from server.application.auth.handlers import (
+    change_password,
     create_user,
     delete_user,
     get_user_by_api_token,
@@ -14,6 +15,7 @@ class AuthModule(Module):
     command_handlers = {
         CreateUser: create_user,
         DeleteUser: delete_user,
+        ChangePassword: change_password,
     }
 
     query_handlers = {

--- a/tests/application/test_auth.py
+++ b/tests/application/test_auth.py
@@ -1,0 +1,22 @@
+import pytest
+
+from server.application.auth.commands import ChangePassword, CreateUser
+from server.application.auth.queries import Login
+from server.config.di import resolve
+from server.domain.auth.exceptions import LoginFailed
+from server.seedwork.application.messages import MessageBus
+
+
+@pytest.mark.asyncio
+async def test_changepassword() -> None:
+    bus = resolve(MessageBus)
+    email = "changepassworduser@mydomain.org"
+
+    await bus.execute(CreateUser(email=email, password="initialpwd"))
+
+    await bus.execute(ChangePassword(email=email, password="newpwd"))
+
+    with pytest.raises(LoginFailed):
+        await bus.execute(Login(email=email, password="initialpwd"))
+
+    await bus.execute(Login(email=email, password="newpwd"))

--- a/tools/changepassword.py
+++ b/tools/changepassword.py
@@ -1,0 +1,48 @@
+import asyncio
+import sys
+
+import click
+from pydantic import SecretStr
+
+from server.application.auth.commands import ChangePassword
+from server.config.di import bootstrap, resolve
+from server.domain.auth.entities import User
+from server.domain.auth.repositories import UserRepository
+from server.seedwork.application.messages import MessageBus
+
+
+async def _prompt_user() -> User:
+    repository = resolve(UserRepository)
+
+    email = click.prompt("Email")
+
+    user = await repository.get_by_email(email)
+
+    if user is None:
+        click.echo(click.style(f"User does not exist: {email}", fg="red"))
+        sys.exit(1)
+
+    return user
+
+
+def _prompt_password() -> SecretStr:
+    return click.prompt(
+        "Password",
+        confirmation_prompt="Password (repeat)",
+        value_proc=SecretStr,
+        hide_input=True,
+    )
+
+
+async def main() -> None:
+    bus = resolve(MessageBus)
+
+    user = await _prompt_user()
+    password = _prompt_password()
+
+    await bus.execute(ChangePassword(email=user.email, password=password))
+
+
+if __name__ == "__main__":
+    bootstrap()
+    asyncio.run(main())


### PR DESCRIPTION
Refs #220 

Cette PR ajoute un outil d'administration `make changepassword` qui permet de changer le mot de passe d'un utilisateur.

Peut s'avérer utile dans la gestion manuelle des comptes utilisateurs telle que faite pour l'instant.