### PR TITLE
Fix missing jest-environment in Pagination.spec.ts

### DIFF
--- a/client/src/lib/components/Pagination/Pagination.spec.ts
+++ b/client/src/lib/components/Pagination/Pagination.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/svelte";
 import type { GetPageLink } from "src/definitions/pagination";


### PR DESCRIPTION
Correction suite à #233 et #229 dont la combinaison a cassé les TU sur master (c'est ma faute : j'ai merge #233 sans mettre à jour sur master qui venait de recevoir #229, ne plus faire ça...)