### PR TITLE
Refactor DI container code

### DIFF
--- a/server/seedwork/application/di.py
+++ b/server/seedwork/application/di.py
@@ -1,0 +1,37 @@
+from typing import Callable, Optional, Type, TypeVar
+
+import punq
+
+T = TypeVar("T")
+
+
+class Container:
+    """
+    Implements a configurable DI container.
+    """
+
+    def __init__(
+        self, configure: Callable[["Container"], None] = lambda _: None
+    ) -> None:
+        self._impl: Optional[punq.Container] = None
+        self._configure = configure
+
+    def bootstrap(self) -> None:
+        self._impl = punq.Container()
+        self._configure(self)
+
+    def register_instance(self, type_: Type[T], instance: T) -> None:
+        """
+        Register a singleton instance.
+        """
+        assert self._impl is not None
+        self._impl.register(type_, instance=instance)
+
+    def resolve(self, type_: Type[T]) -> T:
+        if self._impl is None:
+            raise RuntimeError("Container not ready. Please call bootstrap()")
+
+        try:
+            return self._impl.resolve(type_)
+        except punq.MissingDependencyError:
+            raise RuntimeError(f"Failed to resolve implementation for {type_}")

--- a/server/seedwork/application/modules.py
+++ b/server/seedwork/application/modules.py
@@ -1,4 +1,5 @@
-from typing import ClassVar
+import importlib
+from typing import ClassVar, List
 
 from .types import CommandHandlers, QueryHandlers
 
@@ -6,3 +7,17 @@ from .types import CommandHandlers, QueryHandlers
 class Module:
     command_handlers: ClassVar[CommandHandlers]
     query_handlers: ClassVar[QueryHandlers]
+
+
+def load_modules(paths: List[str]) -> List[Module]:
+    """
+    Load modules by Python path.
+
+    server.application.example.module.ExampleModule -> ExampleModule
+    """
+    modules = []
+    for classpath in paths:
+        modpath, _, classname = classpath.rpartition(".")
+        mod = importlib.import_module(modpath)
+        modules.append(getattr(mod, classname))
+    return modules

--- a/tests/unit/test_di.py
+++ b/tests/unit/test_di.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+
+import pytest
+
+from server.seedwork.application.di import Container
+
+
+@dataclass
+class Person:
+    name: str
+
+
+def test_container_empty() -> None:
+    container = Container()
+
+    with pytest.raises(RuntimeError, match="Container not ready"):
+        container.resolve(Person)
+
+    container.bootstrap()
+
+    with pytest.raises(RuntimeError, match="Failed to resolve implementation"):
+        container.resolve(Person)
+
+
+def test_container_configured() -> None:
+    @dataclass
+    class Person:
+        name: str
+
+    def configure(container: Container) -> None:
+        container.register_instance(Person, Person("Tiffany"))
+
+    container = Container(configure)
+    container.bootstrap()
+    person = container.resolve(Person)
+    assert person.name == "Tiffany"


### PR DESCRIPTION
Contexte : j'explorais le découplage du système de DI par rapport à FastAPI en essayant le remplacer par celui d'un autre framework web, Xpresso : https://github.com/adriangb/xpresso/discussions/96

Il s'avère qu'on gagnerait à moins coupler la DI à la librarie `punq`. Certaines autres modifications seraient ausi bienvenues. Donc :

* Suppression de `override()`, qui n'était pas utilisé
* Création d'un `Container` dans `server.seedwork`, qui encapsule l'usage de `punq`
* Tests unitaires pour `Container`
* Déplacement de l'utilitaire de chargement des modules vers `server.seedwork`
* Mise à jour de la fonction de configuration qui accepte désormais un `Container` (l'injection de dépendance originelle...)
* Mise à jour des docstrings