### PR TITLE
Fix OpenAPI serialization of Computed fields

### DIFF
--- a/server/domain/common/pagination.py
+++ b/server/domain/common/pagination.py
@@ -1,4 +1,3 @@
-import math
 from typing import Generic, List, TypeVar
 
 from pydantic import BaseModel, Field
@@ -29,7 +28,7 @@ class Pagination(GenericModel, Generic[T]):
     total_items: int
     page_size: int
     total_pages: Computed[int] = Field(
-        lambda self: math.ceil(self.total_items / self.page_size)
+        Computed.Expr("math.ceil(total_items / page_size)")
     )
 
     class Config:

--- a/server/infrastructure/helpers/pydantic.py
+++ b/server/infrastructure/helpers/pydantic.py
@@ -13,9 +13,9 @@ class Computed(Generic[T]):
     Usage:
         class Model(BaseModel):
             x: float
-            x_squared: Computed[float] = Field("lambda self: self.x ** 2")
+            x_squared: Computed[float] = Field(Computed.Expr("x ** 2"))
 
-    Limitation: does not support re-computing when dependant fields such.
+    Limitation: does not support re-computing when dependant fields change.
 
     Inspired by:
         https://github.com/samuelcolvin/pydantic/issues/935#issuecomment-961591416
@@ -44,7 +44,7 @@ class Computed(Generic[T]):
         assert field.sub_fields
         result = eval(v, cls.__expr_globals__, values)
         typ = field.sub_fields[0]
-        validated, error = typ.validate(result, {}, loc="Computed")
+        validated, error = typ.validate(result, {}, loc=field.alias)
         if error:
             raise ValueError(error)
         assert validated is not None

--- a/server/infrastructure/helpers/pydantic.py
+++ b/server/infrastructure/helpers/pydantic.py
@@ -1,5 +1,5 @@
-from types import SimpleNamespace
-from typing import Callable, Generic, Iterator, TypeVar, Union
+import math
+from typing import Generic, Iterator, TypeVar, Union
 
 from pydantic.fields import ModelField
 
@@ -13,13 +13,18 @@ class Computed(Generic[T]):
     Usage:
         class Model(BaseModel):
             x: float
-            x_squared: Computed[float] = Field(lambda self: self.x ** 2)
+            x_squared: Computed[float] = Field("lambda self: self.x ** 2")
 
     Limitation: does not support re-computing when dependant fields such.
 
     Inspired by:
         https://github.com/samuelcolvin/pydantic/issues/935#issuecomment-961591416
     """
+
+    class Expr(str):
+        pass
+
+    __expr_globals__ = {"math": math}
 
     validate_always = True
 
@@ -28,14 +33,18 @@ class Computed(Generic[T]):
         yield cls.validate
 
     @classmethod
-    def validate(cls, v: Union[T, Callable], field: ModelField, values: dict) -> T:
-        if not callable(v):
+    def __modify_schema__(cls, field_schema: dict, field: ModelField) -> None:
+        field_schema["default"] = f"Computed({field.default})"
+
+    @classmethod
+    def validate(cls, v: Union[T, Expr], field: ModelField, values: dict) -> T:
+        if not isinstance(v, cls.Expr):
             return v
 
         assert field.sub_fields
-        result = v(SimpleNamespace(**values))
+        result = eval(v, cls.__expr_globals__, values)
         typ = field.sub_fields[0]
-        validated, error = typ.validate(result, {}, loc="Expr")
+        validated, error = typ.validate(result, {}, loc="Computed")
         if error:
             raise ValueError(error)
         assert validated is not None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,14 @@ async def test_index(client: httpx.AsyncClient) -> None:
     assert response.headers["Location"] == "http://testserver/docs"
 
 
+@pytest.mark.asyncio
+async def test_api_docs(client: httpx.AsyncClient) -> None:
+    response = await client.get("/docs")
+    assert response.status_code == 200
+    response = await client.get("/openapi.json")
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize("origin", ["http://localhost:3000"])
 @pytest.mark.asyncio
 async def test_cors(client: httpx.AsyncClient, origin: str) -> None:

--- a/tests/unit/test_pydantic.py
+++ b/tests/unit/test_pydantic.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from server.infrastructure.helpers.pydantic import Computed
+
+
+def test_computed() -> None:
+    class Square(BaseModel):
+        side: float
+        area: Computed[float] = Field(Computed.Expr("side ** 2"))
+
+    square = Square(side=3)
+    assert square.area == 9
+    assert square.dict() == {"side": 3, "area": 9}
+
+    square.side = 4
+    assert square.area == 9  # Watching changes is not supported
+
+
+def test_computed_validate() -> None:
+    class Model(BaseModel):
+        x: Computed[int] = Field(Computed.Expr("'not an int'"))
+
+    with pytest.raises(ValidationError) as ctx:
+        Model()
+
+    (error,) = ctx.value.errors()
+    assert error["loc"] == ("x",)
+    assert error["type"] == "value_error"


### PR DESCRIPTION
Suite à #224, la doc d'API est actuellement HS : https://catalogue.multi.coop/api/docs

> Errors
> Fetch error
> Internal Server Error /api/openapi.json

Ceci en raison de l'implémentation de l'utilitaire `Computed` qui utilise une fonction et ne peut donc pas être sérialisé en JSON.

Cette PR est un refactor pour que le calcul se fasse à partir d'une string qui est ensuite évaluée. Malgré [Eval really is dangerous](https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html), la string en question n'est pas issue d'une entrée utilisateur, c'est donc a priori sûr.