### PR TITLE
Make staging-sync recreate staging branch instead of patching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,8 @@ ops-staging: #- Sync staging branch with changes from current branch
 	@echo "Success. You may now push and deploy"
 
 ops-staging-sync: #- Sync staging branch with master
-	git checkout staging
-	git diff --no-prefix staging..master | patch -p0
-	git add -A
-	git commit -m "Sync staging with master"
-	@echo "Success. You may now push and deploy"
+	git checkout master
+	git pull --rebase origin master
+	git branch -D staging
+	git checkout -b staging
+	@echo "Almost done. You must now force-push (hint: git push --set-upstream origin staging --force)"

--- a/docs/fr/ops.md
+++ b/docs/fr/ops.md
@@ -117,7 +117,7 @@ Vous devez ensuite déployer staging :
 make ops-deploy env=staging
 ```
 
-**N.B.** Tous les changements finalement adoptés dans `master` ne seront pas ajoutés à `staging`. La branche de staging devrait donc être régulièrement resynchronisée avec `master`. Pour cela, lancez :
+**N.B.** Tous les changements finalement adoptés dans `master` ne seront pas ajoutés à `staging`. La branche de staging devrait donc être régulièrement recréée à partir `master`. Pour vous y aider, lancez :
 
 ```
 make ops-staging-sync


### PR DESCRIPTION
Avec la stratégie de reset actuelle (créer un patch), le `make ops-staging` échoue car il devient très souvent impossible de faire un _fast-forward merge_.

À la place, je pense qu'on devrait synchroniser staging en recréant complètement la branche.