### PR TITLE
Update dataset detail subtitle to use hardcoded org name

### DIFF
--- a/client/src/routes/fiches/[id]/index.svelte
+++ b/client/src/routes/fiches/[id]/index.svelte
@@ -45,9 +45,7 @@
             {@html "Ministère<br />de la culture"}
           </p>
           <div>
-            <p class="fr-m-0 fr-text-mention--grey">
-              {dataset.service}
-            </p>
+            <p class="fr-m-0 fr-text-mention--grey">Ministère de la culture</p>
             <h1 class="fr-mb-0">
               {dataset.title}
             </h1>


### PR DESCRIPTION
Closes #243 

> Au dessus du titre : en attendant d'implémenter la donnée "organisation, mettre en dur "Ministère de la culture" et non le nom du producteur de la donnée

## Avant/après

![Screenshot 2022-05-23 at 17-32-12 Catalogue](https://user-images.githubusercontent.com/15911462/169855374-bf5185e1-26a6-4388-ad77-2fcee072f790.png) (19kB)
![Screenshot 2022-05-23 at 17-31-42 Catalogue](https://user-images.githubusercontent.com/15911462/169855385-fa2acf1b-0901-4927-b04a-b8ad238fd193.png) (17kB)

## Staging

Voir : https://staging.catalogue.multi.coop