### PR TITLE
Drop --ff-only from ops-staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ ops-initdata: #- Run initdata in environment
 ops-staging: #- Sync staging branch with changes from current branch 
 	git checkout staging 
 	git pull --rebase origin staging
-	git merge --ff-only --no-edit $(git_current_ref)
+	git merge --no-edit $(git_current_ref)
 	@echo "Success. You may now push and deploy"
 
 ops-staging-sync: #- Sync staging branch with master


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/237#issuecomment-1128665050

En réalité, `--ff-only` ne peut pas fonctionner dans notre cas une fois qu'une PR a été mergée dans staging.

En effet, à partir de ce moment-là, l'historique entre staging et n'importe quelle autre PR n'est plus linéaire, donc le fast-forward échoue avec ce message :

```
fatal: Not possible to fast-forward, aborting.
make: *** [Makefile:142: ops-staging] Error 128
```

Il est donc impossible de mettre plusieurs PR dans staging, ce qui est l'inverse de l'objectif qui était visé.

Il faut donc revenir à ce qui avait d'abord été fait dans #237, à savoir un `git merge` simple qui créera un merge commit si besoin.