### PR TITLE
Refactor dataset form menu

### DIFF
--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -400,7 +400,9 @@
       {/if}
     </div>
   </div>
+
   <h2 id="mot-cles" class="fr-mb-5w">Mot-clés thématiques</h2>
+
   <div class="form--content fr-mb-8w">
     <TagSelector
       error={typeof $errors.tags === "string" ? $errors.tags : ""}

--- a/client/src/lib/components/DatasetFormLayout/DatasetFormLayout.svelte
+++ b/client/src/lib/components/DatasetFormLayout/DatasetFormLayout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { getPageY } from "$lib/util/html";
+  import { hasItems, first, last } from "$lib/util/array";
 
   type Anchor = {
     element: HTMLElement;
@@ -9,7 +10,7 @@
     y: number;
   };
 
-  let slotContent: HTMLElement;
+  let layoutContent: HTMLElement;
   let anchors: Anchor[] = [];
   let activeAnchorId = "";
   // Make anchor active when it passes below this fraction of the screen.
@@ -20,7 +21,7 @@
       window.pageYOffset + window.innerHeight >= document.body.offsetHeight;
 
     if (hasReachedBottom) {
-      activeAnchorId = anchors[anchors.length - 1].id;
+      activeAnchorId = hasItems(anchors) ? last(anchors).id : "";
       return;
     }
 
@@ -28,8 +29,8 @@
 
     const anchorsBelowTrigger = anchors.filter((anchor) => anchor.y < triggerY);
 
-    if (anchorsBelowTrigger.length > 0) {
-      activeAnchorId = anchorsBelowTrigger[anchorsBelowTrigger.length - 1].id;
+    if (hasItems(anchorsBelowTrigger)) {
+      activeAnchorId = last(anchorsBelowTrigger).id;
     }
   };
 
@@ -37,17 +38,19 @@
     anchors.forEach((anchor) => (anchor.y = getPageY(anchor.element)));
 
   onMount(() => {
-    slotContent.querySelectorAll<HTMLElement>("h2[id]").forEach((element) => {
+    layoutContent.querySelectorAll<HTMLElement>("h2[id]").forEach((element) => {
       const anchor = {
         element,
         id: element.id,
-        label: element.textContent!,
+        label: element.textContent || "",
         y: getPageY(element),
       };
       anchors = [...anchors, anchor];
     });
 
-    activeAnchorId = anchors[0].id;
+    if (hasItems(anchors)) {
+      activeAnchorId = first(anchors).id;
+    }
   });
 </script>
 
@@ -85,7 +88,7 @@
         </div>
       </nav>
     </div>
-    <div bind:this={slotContent} class="fr-col-md-9">
+    <div bind:this={layoutContent} class="fr-col-md-9">
       <slot />
     </div>
   </div>

--- a/client/src/lib/components/DatasetFormLayout/DatasetFormLayout.svelte
+++ b/client/src/lib/components/DatasetFormLayout/DatasetFormLayout.svelte
@@ -1,46 +1,61 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  type Anchor = { element: Element; y: number };
+  import { getPageY } from "$lib/util/html";
 
-  let segment = "";
+  type Anchor = {
+    element: HTMLElement;
+    id: string;
+    label: string;
+    y: number;
+  };
 
-  let container: Element;
+  let slotContent: HTMLElement;
   let anchors: Anchor[] = [];
+  let activeAnchorId = "";
+  // Make anchor active when it passes below this fraction of the screen.
+  const triggerFraction = 1 / 4;
 
   const handleScroll = () => {
     const hasReachedBottom =
       window.pageYOffset + window.innerHeight >= document.body.offsetHeight;
+
     if (hasReachedBottom) {
-      segment = anchors[0].element.id;
+      activeAnchorId = anchors[anchors.length - 1].id;
       return;
     }
 
-    const firstAnchorAboveHere = anchors.find(
-      (anchor) => anchor.y < window.pageYOffset + window.innerHeight / 2
-    );
+    const triggerY = window.pageYOffset + window.innerHeight * triggerFraction;
 
-    if (firstAnchorAboveHere) {
-      segment = firstAnchorAboveHere.element.id;
+    const anchorsBelowTrigger = anchors.filter((anchor) => anchor.y < triggerY);
+
+    if (anchorsBelowTrigger.length > 0) {
+      activeAnchorId = anchorsBelowTrigger[anchorsBelowTrigger.length - 1].id;
     }
   };
 
-  const getY = (element: Element) => element.getBoundingClientRect().top;
-
   const onresize = () =>
-    anchors.forEach((anchor) => (anchor.y = getY(anchor.element)));
+    anchors.forEach((anchor) => (anchor.y = getPageY(anchor.element)));
 
   onMount(() => {
-    container.querySelectorAll("h2[id]").forEach((anchor) => {
-      anchors.unshift({ element: anchor, y: getY(anchor) });
+    slotContent.querySelectorAll<HTMLElement>("h2[id]").forEach((element) => {
+      const anchor = {
+        element,
+        id: element.id,
+        label: element.textContent!,
+        y: getPageY(element),
+      };
+      anchors = [...anchors, anchor];
     });
+
+    activeAnchorId = anchors[0].id;
   });
 </script>
 
 <svelte:window on:scroll={handleScroll} on:resize={onresize} />
 
-<section bind:this={container} class="fr-container">
+<section class="fr-container">
   <div class="fr-grid-row fr-grid-row--gutters">
-    <div class="fr-col-lg-3">
+    <div class="fr-col-md-3">
       <nav class="fr-sidemenu fr-sidemenu--sticky" aria-label="Menu latéral">
         <div class="fr-sidemenu__inner">
           <button
@@ -51,68 +66,26 @@
           >
           <div class="fr-collapse" id="fr-sidemenu-wrapper">
             <ul class="fr-sidemenu__list">
-              <li class="fr-sidemenu__item">
-                <a
-                  aria-current={segment === "information-generales" || !segment
-                    ? "page"
-                    : undefined}
-                  class="fr-sidemenu__link"
-                  href="#information-generales"
-                  target="_self">Informations générales</a
-                >
-              </li>
-
-              <li class="fr-sidemenu__item">
-                <a
-                  aria-current={segment === "source-formats"
-                    ? "page"
-                    : undefined}
-                  class="fr-sidemenu__link"
-                  href="#source-formats"
-                  target="_self">Sources et formats</a
-                >
-              </li>
-
-              <li class="fr-sidemenu__item">
-                <a
-                  on:click={() => (segment = "mot-cles")}
-                  aria-current={segment === "mot-cles" ? "page" : undefined}
-                  class="fr-sidemenu__link"
-                  href="#mot-cles"
-                  target="_self">Mot-clés thématiques</a
-                >
-              </li>
-              <li class="fr-sidemenu__item">
-                <a
-                  aria-current={segment === "contacts" ? "page" : undefined}
-                  class="fr-sidemenu__link"
-                  href="#contacts"
-                  target="_self">Contacts</a
-                >
-              </li>
-              <li class="fr-sidemenu__item">
-                <a
-                  on:click={() => (segment = "mise-a-jour")}
-                  aria-current={segment === "mise-a-jour" ? "page" : undefined}
-                  class="fr-sidemenu__link"
-                  href="#mise-a-jour"
-                  target="_self">Mise à jour</a
-                >
-              </li>
-              <li class="fr-sidemenu__item">
-                <a
-                  aria-current={segment === "ouverture" ? "page" : undefined}
-                  class="fr-sidemenu__link"
-                  href="#ouverture"
-                  target="_self">Ouverture</a
-                >
-              </li>
+              {#each anchors as anchor}
+                <li class="fr-sidemenu__item">
+                  <a
+                    aria-current={anchor.id === activeAnchorId
+                      ? "page"
+                      : undefined}
+                    class="fr-sidemenu__link"
+                    href="#{anchor.id}"
+                    target="_self"
+                  >
+                    {anchor.label}
+                  </a>
+                </li>
+              {/each}
             </ul>
           </div>
         </div>
       </nav>
     </div>
-    <div class="fr-col-lg-9">
+    <div bind:this={slotContent} class="fr-col-md-9">
       <slot />
     </div>
   </div>

--- a/client/src/lib/util/array.ts
+++ b/client/src/lib/util/array.ts
@@ -2,3 +2,19 @@ export const range = (start: number, end: number): number[] => {
   const length = end - start;
   return Array.from({ length }, (_, idx) => start + idx);
 };
+
+interface ArrayWithItems<T> extends Array<T> {
+  0: T; // Ensure array has at least one item.
+}
+
+export const hasItems = <T>(arr: T[]): arr is ArrayWithItems<T> => {
+  return arr.length > 0;
+};
+
+export const first = <T>(arr: ArrayWithItems<T>): T => {
+  return arr[0];
+};
+
+export const last = <T>(arr: ArrayWithItems<T>): T => {
+  return arr[arr.length - 1];
+};

--- a/client/src/lib/util/html.ts
+++ b/client/src/lib/util/html.ts
@@ -1,0 +1,11 @@
+/**
+ * @returns The absolute Y page coordinate of an element.
+ */
+export const getPageY = (element: HTMLElement): number => {
+  let y = 0;
+  while (element.offsetParent) {
+    y += element.offsetTop;
+    element = element.offsetParent as HTMLElement;
+  }
+  return y;
+};

--- a/client/src/lib/util/html.ts
+++ b/client/src/lib/util/html.ts
@@ -1,5 +1,5 @@
 /**
- * @returns The absolute Y page coordinate of an element.
+ * @returns The absolute Y page coordinate of the element.
  */
 export const getPageY = (element: HTMLElement): number => {
   let y = 0;

--- a/client/src/playwright.config.ts
+++ b/client/src/playwright.config.ts
@@ -22,7 +22,7 @@ const getAdminTestPassword = (): string => {
 const config: PlaywrightTestConfig<AppTestArgs> = {
   testDir: "./tests/e2e/",
   globalSetup: "./tests/e2e/global-setup.ts",
-  retries: 0,
+  retries: 3,
   use: {
     baseURL: "http://localhost:3000",
     browserName: "firefox",

--- a/client/src/playwright.config.ts
+++ b/client/src/playwright.config.ts
@@ -22,7 +22,7 @@ const getAdminTestPassword = (): string => {
 const config: PlaywrightTestConfig<AppTestArgs> = {
   testDir: "./tests/e2e/",
   globalSetup: "./tests/e2e/global-setup.ts",
-  retries: 3,
+  retries: 0,
   use: {
     baseURL: "http://localhost:3000",
     browserName: "firefox",

--- a/client/src/tests/e2e/contribuer.spec.ts
+++ b/client/src/tests/e2e/contribuer.spec.ts
@@ -72,9 +72,6 @@ test.describe("Basic form submission", () => {
     const contactEmail2 = page.locator("[id='contactEmails-1']");
     await contactEmail2.fill(contactEmail2Text);
     expect(await contactEmail2.inputValue()).toBe(contactEmail2Text);
-    expect(
-      page.locator("a.fr-sidemenu__link", { hasText: "Contacts" }).first()
-    ).toHaveAttribute("aria-current", "page");
 
     // "Mise à jour" section
 
@@ -135,5 +132,34 @@ test.describe("Basic form submission", () => {
     expect(hasTag).toBeTruthy();
 
     await page.locator("text='Modifier'").waitFor();
+  });
+
+  test("Navigates on page and sees active sidebar item change", async ({
+    page,
+  }) => {
+    await page.goto("/contribuer");
+
+    const activeSidebarItem = page.locator(
+      "[aria-label='Menu latéral'] [aria-current=page]"
+    );
+
+    // Initial state.
+    await expect(activeSidebarItem).toHaveText("Informations générales");
+
+    // Scroll to bottom.
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(activeSidebarItem).toHaveText("Ouverture");
+
+    // Move to a particular section using click.
+    // Purposefully test a small-size section: it should become active
+    // even if the next section is fairly high on the page.
+    await page.click(
+      "[aria-label='Menu latéral'] >> text='Mot-clés thématiques'"
+    );
+    await expect(activeSidebarItem).toHaveText("Mot-clés thématiques");
+
+    // Move up 1/4th of the window, should make previous section active.
+    await page.evaluate(() => window.scrollBy(0, -window.innerHeight / 4));
+    await expect(activeSidebarItem).toHaveText("Sources et formats");
   });
 });


### PR DESCRIPTION
* Améliore le test E2E, refs https://github.com/etalab/catalogage-donnees/pull/228#discussion_r879217656
* Corrige un bug (que j'ai découvert en écrivant le test E2E) : quand on cliquait sur "Mot-clés", l'item ne devenait pas actif. C'est parce que la section suivante ("Contacts") dépassait le trigger fixé à 50% de la page. J'ai pour cela remonté le trigger à 25% de la page. (Ça reste un bricolage car si une section N a une taille inférieure à ce trigger, alors on aura le même bug : la section N+1 sera active quand on clique sur l'item N.)
* Affiche les éléments en fonction des `anchors` collectés -- jusqu'ici ils étaient "en dur" ce qui constituait un couplage avec le formulaire.
* Corrige le point de rupture (lg -> md) pour le faire correspondre à celui où le menu passe en mode "dropdown".
* Améliore la sûreté du typage (cas certes hypothétique où il n'y a aucun `<h2>` dans la page)