### PR TITLE
Move validators from API schemas to application layer

### DIFF
--- a/server/api/app.py
+++ b/server/api/app.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from server.config import Settings
 from server.config.di import resolve
 
+from . import errors
 from .routes import router
 
 origins = [
@@ -19,6 +20,7 @@ def create_app(settings: Settings = None) -> FastAPI:
     app = FastAPI(
         debug=settings.debug,
         docs_url=settings.docs_url,
+        exception_handlers=errors.exception_handlers,
     )
 
     app.add_middleware(

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -24,7 +24,6 @@ from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
 from ..auth.dependencies import HasRole, IsAuthenticated
-from ..errors import wrap_request_validation_errors
 from .schemas import DatasetCreate, DatasetListParams, DatasetUpdate
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
@@ -76,8 +75,7 @@ async def get_dataset_by_id(id: ID) -> DatasetView:
 async def create_dataset(data: DatasetCreate) -> DatasetView:
     bus = resolve(MessageBus)
 
-    with wrap_request_validation_errors():
-        command = CreateDataset(**data.dict())
+    command = CreateDataset(**data.dict())
 
     id = await bus.execute(command)
 
@@ -94,8 +92,7 @@ async def create_dataset(data: DatasetCreate) -> DatasetView:
 async def update_dataset(id: ID, data: DatasetUpdate) -> DatasetView:
     bus = resolve(MessageBus)
 
-    with wrap_request_validation_errors():
-        command = UpdateDataset(id=id, **data.dict())
+    command = UpdateDataset(id=id, **data.dict())
 
     try:
         await bus.execute(command)

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -24,6 +24,7 @@ from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
 from ..auth.dependencies import HasRole, IsAuthenticated
+from ..errors import wrap_request_validation_errors
 from .schemas import DatasetCreate, DatasetListParams, DatasetUpdate
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
@@ -75,7 +76,8 @@ async def get_dataset_by_id(id: ID) -> DatasetView:
 async def create_dataset(data: DatasetCreate) -> DatasetView:
     bus = resolve(MessageBus)
 
-    command = CreateDataset(**data.dict())
+    with wrap_request_validation_errors():
+        command = CreateDataset(**data.dict())
 
     id = await bus.execute(command)
 
@@ -92,7 +94,8 @@ async def create_dataset(data: DatasetCreate) -> DatasetView:
 async def update_dataset(id: ID, data: DatasetUpdate) -> DatasetView:
     bus = resolve(MessageBus)
 
-    command = UpdateDataset(id=id, **data.dict())
+    with wrap_request_validation_errors():
+        command = UpdateDataset(id=id, **data.dict())
 
     try:
         await bus.execute(command)

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -2,7 +2,7 @@ import datetime as dt
 from typing import List, Optional
 
 from fastapi import Query
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic import BaseModel, EmailStr, Field
 
 from server.domain.common.pagination import PAGE_NUMBER_CONSTR, PAGE_SIZE_CONSTR
 from server.domain.common.types import ID
@@ -34,18 +34,6 @@ class DatasetCreate(BaseModel):
     published_url: Optional[str] = None
     tag_ids: List[ID] = Field(default_factory=list)
 
-    @validator("formats")
-    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
-        if not value:
-            raise ValueError("formats must contain at least one item")
-        return value
-
-    @validator("contact_emails")
-    def check_contact_emails_at_least_one(cls, value: List[str]) -> List[str]:
-        if not value:
-            raise ValueError("contact_emails must contain at least one item")
-        return value
-
 
 class DatasetUpdate(BaseModel):
     title: str
@@ -60,39 +48,3 @@ class DatasetUpdate(BaseModel):
     last_updated_at: Optional[dt.datetime] = Field(...)
     published_url: Optional[str] = Field(...)
     tag_ids: List[ID]
-
-    @validator("title")
-    def check_title_not_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("title must not be empty")
-        return value
-
-    @validator("description")
-    def check_description_not_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("description must not be empty")
-        return value
-
-    @validator("service")
-    def check_service_not_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("service must not be empty")
-        return value
-
-    @validator("formats")
-    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
-        if not value:
-            raise ValueError("formats must contain at least one item")
-        return value
-
-    @validator("contact_emails")
-    def check_contact_emails_at_least_one(cls, value: List[str]) -> List[str]:
-        if not value:
-            raise ValueError("contact_emails must contain at least one item")
-        return value
-
-    @validator("published_url")
-    def check_published_url_not_empty(cls, value: Optional[str]) -> Optional[str]:
-        if value is not None and not value:
-            raise ValueError("published_url must not be empty")
-        return value

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field
 
-from server.domain.common.pagination import PAGE_NUMBER_CONSTR, PAGE_SIZE_CONSTR
 from server.domain.common.types import ID
 from server.domain.datasets.entities import (
     DataFormat,
@@ -16,8 +15,8 @@ from server.domain.datasets.entities import (
 class DatasetListParams(BaseModel):
     q: str = Query(None)
     highlight: bool = Query(False)
-    page_number: int = Query(1, **PAGE_NUMBER_CONSTR)
-    page_size: int = Query(10, **PAGE_SIZE_CONSTR)
+    page_number: int = Query(1)
+    page_size: int = Query(10)
 
 
 class DatasetCreate(BaseModel):

--- a/server/api/errors.py
+++ b/server/api/errors.py
@@ -1,0 +1,32 @@
+from contextlib import contextmanager
+from typing import Iterator, List, Sequence, Tuple
+
+from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError
+from pydantic.error_wrappers import ErrorList, ErrorWrapper
+
+
+@contextmanager
+def wrap_request_validation_errors() -> Iterator[None]:
+    try:
+        yield
+    except ValidationError as exc:
+        errors = _add_loc_prefix(exc.raw_errors, ("body",))
+        raise RequestValidationError([errors])
+
+
+def _add_loc_prefix(
+    raw_errors: Sequence[ErrorList], prefix: Tuple[str, ...]
+) -> List[ErrorWrapper]:
+    errors: List[ErrorWrapper] = []
+
+    for raw_error in raw_errors:
+        if isinstance(raw_error, ErrorWrapper):
+            errors.append(
+                ErrorWrapper(raw_error.exc, loc=(*prefix, *raw_error.loc_tuple()))
+            )
+        else:
+            assert isinstance(raw_error, list)
+            errors.extend(_add_loc_prefix(raw_error, prefix))
+
+    return errors

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -1,11 +1,11 @@
-from pydantic import SecretStr
+from pydantic import EmailStr, SecretStr
 
 from server.domain.common.types import ID
 from server.seedwork.application.commands import Command
 
 
 class CreateUser(Command[ID]):
-    email: str
+    email: EmailStr
     password: SecretStr
 
 
@@ -14,5 +14,5 @@ class DeleteUser(Command[None]):
 
 
 class ChangePassword(Command[None]):
-    email: str
+    email: EmailStr
     password: SecretStr

--- a/server/application/auth/queries.py
+++ b/server/application/auth/queries.py
@@ -1,16 +1,16 @@
-from pydantic import SecretStr
+from pydantic import EmailStr, SecretStr
 
 from server.application.auth.views import AuthenticatedUserView, UserView
 from server.seedwork.application.queries import Query
 
 
 class Login(Query[AuthenticatedUserView]):
-    email: str
+    email: EmailStr
     password: SecretStr
 
 
 class GetUserByEmail(Query[UserView]):
-    email: str
+    email: EmailStr
 
 
 class GetUserByAPIToken(Query[UserView]):

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from typing import List, Optional
 
-from pydantic import Field
+from pydantic import EmailStr, Field, validator
 
 from server.domain.common.types import ID
 from server.domain.datasets.entities import (
@@ -19,12 +19,24 @@ class CreateDataset(Command[ID]):
     geographical_coverage: GeographicalCoverage
     formats: List[DataFormat]
     technical_source: Optional[str] = None
-    producer_email: Optional[str] = None
-    contact_emails: List[str]
+    producer_email: Optional[EmailStr] = None
+    contact_emails: List[EmailStr]
     update_frequency: Optional[UpdateFrequency] = None
     last_updated_at: Optional[dt.datetime] = None
     published_url: Optional[str] = None
     tag_ids: List[ID] = Field(default_factory=list)
+
+    @validator("formats")
+    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
+        if not value:
+            raise ValueError("formats must contain at least one item")
+        return value
+
+    @validator("contact_emails")
+    def check_contact_emails_at_least_one(cls, value: List[str]) -> List[str]:
+        if not value:
+            raise ValueError("contact_emails must contain at least one item")
+        return value
 
 
 class UpdateDataset(Command[None]):
@@ -35,12 +47,48 @@ class UpdateDataset(Command[None]):
     geographical_coverage: GeographicalCoverage
     formats: List[DataFormat]
     technical_source: Optional[str] = Field(...)
-    producer_email: Optional[str] = Field(...)
-    contact_emails: List[str]
+    producer_email: Optional[EmailStr] = Field(...)
+    contact_emails: List[EmailStr]
     update_frequency: Optional[UpdateFrequency] = Field(...)
     last_updated_at: Optional[dt.datetime] = Field(...)
     published_url: Optional[str] = Field(...)
     tag_ids: List[ID]
+
+    @validator("title")
+    def check_title_not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("title must not be empty")
+        return value
+
+    @validator("description")
+    def check_description_not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("description must not be empty")
+        return value
+
+    @validator("service")
+    def check_service_not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("service must not be empty")
+        return value
+
+    @validator("formats")
+    def check_formats_at_least_one(cls, value: List[DataFormat]) -> List[DataFormat]:
+        if not value:
+            raise ValueError("formats must contain at least one item")
+        return value
+
+    @validator("contact_emails")
+    def check_contact_emails_at_least_one(cls, value: List[str]) -> List[str]:
+        if not value:
+            raise ValueError("contact_emails must contain at least one item")
+        return value
+
+    @validator("published_url")
+    def check_published_url_not_empty(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None and not value:
+            raise ValueError("published_url must not be empty")
+        return value
 
 
 class DeleteDataset(Command[None]):

--- a/server/domain/common/pagination.py
+++ b/server/domain/common/pagination.py
@@ -8,16 +8,10 @@ from server.infrastructure.helpers.pydantic import Computed
 
 T = TypeVar("T")
 
-PAGE_NUMBER_CONSTR: dict = {"ge": 1, "le": 10_000}
-PAGE_SIZE_CONSTR: dict = {"ge": 1, "le": 100}
-
-PageNumber = Annotated[int, Field(**PAGE_NUMBER_CONSTR)]
-PageSize = Annotated[int, Field(**PAGE_SIZE_CONSTR)]
-
 
 class Page(BaseModel):
-    number: PageNumber = 1
-    size: PageSize = 10
+    number: Annotated[int, Field(ge=1, le=10_000)] = 1
+    size: Annotated[int, Field(ge=1, le=100)] = 10
 
     class Config:
         allow_mutation = False

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 
 import httpx
 import pytest
+from pydantic import EmailStr
 
 from server.application.datasets.commands import (
     CreateDataset,
@@ -179,7 +180,7 @@ async def test_search_results_change_when_data_changes(
         service="Service",
         geographical_coverage=GeographicalCoverage.DEPARTMENT,
         formats=[DataFormat.OTHER],
-        contact_emails=["person@mydomain.org"],
+        contact_emails=[EmailStr("person@mydomain.org")],
     )
     pk = await bus.execute(command)
     # New dataset is returned in search results
@@ -202,7 +203,7 @@ async def test_search_results_change_when_data_changes(
         formats=[DataFormat.OTHER],
         technical_source=None,
         producer_email=None,
-        contact_emails=["person@mydomain.org"],
+        contact_emails=[EmailStr("person@mydomain.org")],
         update_frequency=None,
         last_updated_at=None,
         published_url=None,
@@ -229,7 +230,7 @@ async def test_search_results_change_when_data_changes(
         formats=[DataFormat.OTHER],
         technical_source=None,
         producer_email=None,
-        contact_emails=["person@mydomain.org"],
+        contact_emails=[EmailStr("person@mydomain.org")],
         update_frequency=None,
         last_updated_at=None,
         published_url=None,

--- a/tests/application/test_auth.py
+++ b/tests/application/test_auth.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import EmailStr, SecretStr
 
 from server.application.auth.commands import ChangePassword, CreateUser
 from server.application.auth.queries import Login
@@ -10,13 +11,13 @@ from server.seedwork.application.messages import MessageBus
 @pytest.mark.asyncio
 async def test_changepassword() -> None:
     bus = resolve(MessageBus)
-    email = "changepassworduser@mydomain.org"
+    email = EmailStr("changepassworduser@mydomain.org")
 
-    await bus.execute(CreateUser(email=email, password="initialpwd"))
+    await bus.execute(CreateUser(email=email, password=SecretStr("initialpwd")))
 
-    await bus.execute(ChangePassword(email=email, password="newpwd"))
+    await bus.execute(ChangePassword(email=email, password=SecretStr("newpwd")))
 
     with pytest.raises(LoginFailed):
-        await bus.execute(Login(email=email, password="initialpwd"))
+        await bus.execute(Login(email=email, password=SecretStr("initialpwd")))
 
-    await bus.execute(Login(email=email, password="newpwd"))
+    await bus.execute(Login(email=email, password=SecretStr("newpwd")))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@ import itertools
 from typing import Callable
 
 import httpx
+from pydantic import EmailStr, SecretStr
 
 from server.application.auth.commands import CreateUser
 from server.config.di import resolve
@@ -48,8 +49,8 @@ async def create_test_user(role: UserRole) -> TestUser:
     bus = resolve(MessageBus)
     user_repository = resolve(UserRepository)
 
-    email = f"temp{next(_temp_user_ids)}@mydomain.org"
-    password = "s3kr3t"
+    email = EmailStr(f"temp{next(_temp_user_ids)}@mydomain.org")
+    password = SecretStr("s3kr3t")
 
     command = CreateUser(email=email, password=password)
     await bus.execute(command, role=role)
@@ -57,4 +58,4 @@ async def create_test_user(role: UserRole) -> TestUser:
     user = await user_repository.get_by_email(email)
     assert user is not None
 
-    return TestUser(**user.dict(), password=password)
+    return TestUser(**user.dict(), password=password.get_secret_value())

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import EmailStr, SecretStr
 
 from server.application.auth.commands import DeleteUser
 from server.application.auth.queries import Login
@@ -82,7 +83,9 @@ async def test_initdata_env_password(
     monkeypatch.setenv("TOOLS_PASSWORDS", json.dumps({"test@admin.org": "testpwd"}))
     await initdata.main(path, no_input=True)
 
-    user = await bus.execute(Login(email="test@admin.org", password="testpwd"))
+    user = await bus.execute(
+        Login(email=EmailStr("test@admin.org"), password=SecretStr("testpwd"))
+    )
 
     # (Delete user to prevent email collision below.)
     await bus.execute(DeleteUser(id=user.id))

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -53,8 +53,8 @@ datasets:
       formats:
         - website
       technical_source: SIG national de l'IGN
-      producer_email: service@example.org
-      contact_emails: []
+      producer_email: ign.service@mydomain.org
+      contact_emails: [ign.person@mydomain.org]
       update_frequency: null
       last_updated_at: null
       published_url: "https://www.data.gouv.fr/fr/datasets/donnees-brutes-de-l-inventaire-forestier/"
@@ -72,8 +72,8 @@ datasets:
       formats:
         - file_tabular
       technical_source: Système d'information central du CROUS
-      producer_email: service@example.org
-      contact_emails: []
+      producer_email: null
+      contact_emails: [crous.person@mydomain.org]
       update_frequency: null
       last_updated_at: null
       published_url: "https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/"
@@ -91,8 +91,8 @@ datasets:
       formats:
         - other
       technical_source: Catalogue des fiches de la DARES
-      producer_email: service@example.org
-      contact_emails: []
+      producer_email: null
+      contact_emails: [dares.person@mydomain.org]
       update_frequency: null
       last_updated_at: null
       published_url: "https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/"


### PR DESCRIPTION
Closes #259 

Cette PR déplace les validateurs personnalisés de la couche "infrastructure" (API) à la couche "application".

En effet, le problème dans #259 est que plus généralement nous appliquons la validation (ex : vérifier formats des emails) au niveau "infrastructure" uniquement. Or, `initdata` opère directement avec la couche "application". C'est le même problème que celui analysé dans cet article : https://jworks.io/input-validation-in-a-hexagonal-architecture/. Il débouche sur la même solution : passer la validation dans la couche "application" pour qu'elle soit exécutée peu importe la forme spécifique que peut prendre la couche d'infrastructure (script, API, ...).

Cependant, pour éviter un trop gros couplage entre les commandes et l'API, les schémas (nécessaires pour la doc OpenAPI) ne sont devenus ni des alias ni de simples subclasses des commandes, même si leurs champs respectifs sont largement dupliqués à ce jour. J'ai seulement déplacé les validateurs "domaine" (ex : vérifier qu'il y a au moins 1 email personnel), et ajusté les commandes pour qu'elles fassent une validation complète également (ex : utilisation de `EmailStr`). Les schémas d'API n'ont plus que pour responsabilité que d'ingérer les données d'API au bon format (ex : vérifier qu'un string d'enum est valide). Il y a une petite subtilité pour que les éventuelles erreurs soient correctement traitées par FastAPI : c'est géré par un `exception_handler`.