### PR TITLE
Add geographical_coverage filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,17 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-          cache: "pip"
+          # cache: "pip"
 
       - uses: actions/setup-node@v2
-        with:
-          cache: 'npm'
-          cache-dependency-path: client/package-lock.json
+        # with:
+        #   cache: 'npm'
+        #   cache-dependency-path: client/package-lock.json
 
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-node-${{ hashFiles('**/client/package-lock.json') }}
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: ~/.cache/ms-playwright
+      #     key: ${{ runner.os }}-node-${{ hashFiles('**/client/package-lock.json') }}
 
       - name: "Install dependencies"
         run: make install
@@ -62,9 +62,9 @@ jobs:
       - name: "Run tests"
         run: make test-ci
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: playwright-results
-          path: client/test-results
+      # - name: Upload test results
+      #   if: always()
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: playwright-results
+      #     path: client/test-results

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -46,7 +46,11 @@ async def list_datasets(
         pagination = await bus.execute(query)
         return JSONResponse(jsonable_encoder(pagination))
 
-    query = GetAllDatasets(page=page)
+    query = GetAllDatasets(
+        page=page,
+        geographical_coverage__in=params.geographical_coverage,
+    )
+
     return await bus.execute(query)
 
 

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -4,12 +4,9 @@ from typing import List, Optional
 from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field
 
-from server.application.datasets.views import DatasetView
-from server.domain.common.pagination import Pagination
 from server.domain.common.types import ID
 from server.domain.datasets.entities import (
     DataFormat,
-    DatasetFilters,
     GeographicalCoverage,
     UpdateFrequency,
 )
@@ -22,7 +19,7 @@ class DatasetListParams:
         highlight: bool = False,
         page_number: int = 1,
         page_size: int = 10,
-        geographical_coverage: Optional[List[str]] = Query(None),
+        geographical_coverage: Optional[List[GeographicalCoverage]] = Query(None),
     ) -> None:
         self.q = q
         self.highlight = highlight

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -22,19 +22,13 @@ class DatasetListParams:
         highlight: bool = False,
         page_number: int = 1,
         page_size: int = 10,
-        filters_info: bool = False,
         geographical_coverage: Optional[List[str]] = Query(None),
     ) -> None:
         self.q = q
         self.highlight = highlight
         self.page_number = page_number
         self.page_size = page_size
-        self.filters_info = filters_info
         self.geographical_coverage = geographical_coverage
-
-
-class DatasetListResponse(Pagination[DatasetView]):
-    filters: Optional[DatasetFilters] = None
 
 
 class DatasetCreate(BaseModel):

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -12,11 +12,20 @@ from server.domain.datasets.entities import (
 )
 
 
-class DatasetListParams(BaseModel):
-    q: str = Query(None)
-    highlight: bool = Query(False)
-    page_number: int = Query(1)
-    page_size: int = Query(10)
+class DatasetListParams:
+    def __init__(
+        self,
+        q: Optional[str] = None,
+        highlight: bool = False,
+        page_number: int = 1,
+        page_size: int = 10,
+        geographical_coverage: Optional[List[str]] = Query(None),
+    ) -> None:
+        self.q = q
+        self.highlight = highlight
+        self.page_number = page_number
+        self.page_size = page_size
+        self.geographical_coverage = geographical_coverage
 
 
 class DatasetCreate(BaseModel):

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -4,9 +4,12 @@ from typing import List, Optional
 from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field
 
+from server.application.datasets.views import DatasetView
+from server.domain.common.pagination import Pagination
 from server.domain.common.types import ID
 from server.domain.datasets.entities import (
     DataFormat,
+    DatasetFilters,
     GeographicalCoverage,
     UpdateFrequency,
 )
@@ -19,13 +22,19 @@ class DatasetListParams:
         highlight: bool = False,
         page_number: int = 1,
         page_size: int = 10,
+        filters_info: bool = False,
         geographical_coverage: Optional[List[str]] = Query(None),
     ) -> None:
         self.q = q
         self.highlight = highlight
         self.page_number = page_number
         self.page_size = page_size
+        self.filters_info = filters_info
         self.geographical_coverage = geographical_coverage
+
+
+class DatasetListResponse(Pagination[DatasetView]):
+    filters: Optional[DatasetFilters] = None
 
 
 class DatasetCreate(BaseModel):

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -3,13 +3,13 @@ from server.domain.catalog_records.entities import CatalogRecord
 from server.domain.catalog_records.repositories import CatalogRecordRepository
 from server.domain.common.pagination import Pagination
 from server.domain.common.types import ID
-from server.domain.datasets.entities import Dataset
+from server.domain.datasets.entities import Dataset, DatasetFilters
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.tags.repositories import TagRepository
 
 from .commands import CreateDataset, DeleteDataset, UpdateDataset
-from .queries import GetAllDatasets, GetDatasetByID, SearchDatasets
+from .queries import GetAllDatasets, GetDatasetByID, GetDatasetFilters, SearchDatasets
 from .views import DatasetSearchView, DatasetView
 
 
@@ -57,6 +57,11 @@ async def update_dataset(command: UpdateDataset) -> None:
 async def delete_dataset(command: DeleteDataset) -> None:
     repository = resolve(DatasetRepository)
     await repository.delete(command.id)
+
+
+async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFilters:
+    repository = resolve(DatasetRepository)
+    return await repository.get_dataset_filters()
 
 
 async def get_all_datasets(query: GetAllDatasets) -> Pagination[DatasetView]:

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -3,14 +3,14 @@ from server.domain.catalog_records.entities import CatalogRecord
 from server.domain.catalog_records.repositories import CatalogRecordRepository
 from server.domain.common.pagination import Pagination
 from server.domain.common.types import ID
-from server.domain.datasets.entities import Dataset, DatasetFilters
+from server.domain.datasets.entities import Dataset, GeographicalCoverage
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.tags.repositories import TagRepository
 
 from .commands import CreateDataset, DeleteDataset, UpdateDataset
 from .queries import GetAllDatasets, GetDatasetByID, GetDatasetFilters, SearchDatasets
-from .views import DatasetSearchView, DatasetView
+from .views import DatasetFiltersView, DatasetSearchView, DatasetView
 
 
 async def create_dataset(command: CreateDataset, *, id_: ID = None) -> ID:
@@ -59,18 +59,16 @@ async def delete_dataset(command: DeleteDataset) -> None:
     await repository.delete(command.id)
 
 
-async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFilters:
-    repository = resolve(DatasetRepository)
-    return await repository.get_dataset_filters()
+async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFiltersView:
+    return DatasetFiltersView(
+        geographical_coverage=list(GeographicalCoverage),
+    )
 
 
 async def get_all_datasets(query: GetAllDatasets) -> Pagination[DatasetView]:
     repository = resolve(DatasetRepository)
 
-    datasets, count = await repository.get_all(
-        page=query.page,
-        geographical_coverage__in=query.geographical_coverage__in,
-    )
+    datasets, count = await repository.get_all(page=query.page, spec=query.spec)
 
     views = [DatasetView(**dataset.dict()) for dataset in datasets]
 

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -61,8 +61,14 @@ async def delete_dataset(command: DeleteDataset) -> None:
 
 async def get_all_datasets(query: GetAllDatasets) -> Pagination[DatasetView]:
     repository = resolve(DatasetRepository)
-    datasets, count = await repository.get_all(page=query.page)
+
+    datasets, count = await repository.get_all(
+        page=query.page,
+        geographical_coverage__in=query.geographical_coverage__in,
+    )
+
     views = [DatasetView(**dataset.dict()) for dataset in datasets]
+
     return Pagination(items=views, total_items=count, page_size=query.page.size)
 
 

--- a/server/application/datasets/queries.py
+++ b/server/application/datasets/queries.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from server.domain.common.pagination import Page, Pagination
 from server.domain.common.types import ID
-from server.domain.datasets.entities import GeographicalCoverage
+from server.domain.datasets.entities import DatasetFilters, GeographicalCoverage
 from server.seedwork.application.queries import Query
 
 from .views import DatasetSearchView, DatasetView
@@ -21,3 +21,7 @@ class SearchDatasets(Query[Pagination[DatasetSearchView]]):
     q: str
     page: Page = Page()
     highlight: bool = False
+
+
+class GetDatasetFilters(Query[DatasetFilters]):
+    pass

--- a/server/application/datasets/queries.py
+++ b/server/application/datasets/queries.py
@@ -1,16 +1,14 @@
-from typing import List, Optional
-
 from server.domain.common.pagination import Page, Pagination
 from server.domain.common.types import ID
-from server.domain.datasets.entities import DatasetFilters, GeographicalCoverage
+from server.domain.datasets.specifications import DatasetSpec
 from server.seedwork.application.queries import Query
 
-from .views import DatasetSearchView, DatasetView
+from .views import DatasetFiltersView, DatasetSearchView, DatasetView
 
 
 class GetAllDatasets(Query[Pagination[DatasetView]]):
     page: Page = Page()
-    geographical_coverage__in: Optional[List[GeographicalCoverage]] = None
+    spec: DatasetSpec = DatasetSpec()
 
 
 class GetDatasetByID(Query[DatasetView]):
@@ -23,5 +21,5 @@ class SearchDatasets(Query[Pagination[DatasetSearchView]]):
     highlight: bool = False
 
 
-class GetDatasetFilters(Query[DatasetFilters]):
+class GetDatasetFilters(Query[DatasetFiltersView]):
     pass

--- a/server/application/datasets/queries.py
+++ b/server/application/datasets/queries.py
@@ -1,5 +1,8 @@
+from typing import List, Optional
+
 from server.domain.common.pagination import Page, Pagination
 from server.domain.common.types import ID
+from server.domain.datasets.entities import GeographicalCoverage
 from server.seedwork.application.queries import Query
 
 from .views import DatasetSearchView, DatasetView
@@ -7,6 +10,7 @@ from .views import DatasetSearchView, DatasetView
 
 class GetAllDatasets(Query[Pagination[DatasetView]]):
     page: Page = Page()
+    geographical_coverage__in: Optional[List[GeographicalCoverage]] = None
 
 
 class GetDatasetByID(Query[DatasetView]):

--- a/server/application/datasets/views.py
+++ b/server/application/datasets/views.py
@@ -34,3 +34,7 @@ class DatasetView(BaseModel):
 
 class DatasetSearchView(DatasetView):
     headlines: Optional[DatasetHeadlines] = None
+
+
+class DatasetFiltersView(BaseModel):
+    geographical_coverage: List[GeographicalCoverage]

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -2,7 +2,7 @@ import datetime as dt
 import enum
 from typing import List, Optional
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from server.domain.tags.entities import Tag
 from server.seedwork.domain.entities import Entity
@@ -86,3 +86,7 @@ class Dataset(Entity):
         self.last_updated_at = last_updated_at
         self.published_url = published_url
         self.tags = tags
+
+
+class DatasetFilters(BaseModel):
+    geographical_coverage: List[GeographicalCoverage]

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -2,7 +2,7 @@ import datetime as dt
 import enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from server.domain.tags.entities import Tag
 from server.seedwork.domain.entities import Entity
@@ -86,7 +86,3 @@ class Dataset(Entity):
         self.last_updated_at = last_updated_at
         self.published_url = published_url
         self.tags = tags
-
-
-class DatasetFilters(BaseModel):
-    geographical_coverage: List[GeographicalCoverage]

--- a/server/domain/datasets/repositories.py
+++ b/server/domain/datasets/repositories.py
@@ -6,7 +6,7 @@ from server.seedwork.domain.repositories import Repository
 
 from ..common.pagination import Page
 from ..common.types import ID, id_factory
-from .entities import Dataset
+from .entities import Dataset, GeographicalCoverage
 
 
 class DatasetHeadlines(TypedDict):
@@ -21,7 +21,12 @@ class DatasetRepository(Repository):
     def make_id(self) -> ID:
         return id_factory()
 
-    async def get_all(self, page: Page = Page()) -> Tuple[List[Dataset], int]:
+    async def get_all(
+        self,
+        *,
+        page: Page = Page(),
+        geographical_coverage__in: List[GeographicalCoverage] = None,
+    ) -> Tuple[List[Dataset], int]:
         raise NotImplementedError  # pragma: no cover
 
     async def search(

--- a/server/domain/datasets/repositories.py
+++ b/server/domain/datasets/repositories.py
@@ -6,7 +6,7 @@ from server.seedwork.domain.repositories import Repository
 
 from ..common.pagination import Page
 from ..common.types import ID, id_factory
-from .entities import Dataset, GeographicalCoverage
+from .entities import Dataset, DatasetFilters, GeographicalCoverage
 
 
 class DatasetHeadlines(TypedDict):
@@ -20,6 +20,9 @@ SearchResult = Tuple[Dataset, Optional[DatasetHeadlines]]
 class DatasetRepository(Repository):
     def make_id(self) -> ID:
         return id_factory()
+
+    async def get_dataset_filters(self) -> DatasetFilters:
+        raise NotImplementedError  # pragma: no cover
 
     async def get_all(
         self,

--- a/server/domain/datasets/repositories.py
+++ b/server/domain/datasets/repositories.py
@@ -6,7 +6,8 @@ from server.seedwork.domain.repositories import Repository
 
 from ..common.pagination import Page
 from ..common.types import ID, id_factory
-from .entities import Dataset, DatasetFilters, GeographicalCoverage
+from .entities import Dataset
+from .specifications import DatasetSpec
 
 
 class DatasetHeadlines(TypedDict):
@@ -21,14 +22,8 @@ class DatasetRepository(Repository):
     def make_id(self) -> ID:
         return id_factory()
 
-    async def get_dataset_filters(self) -> DatasetFilters:
-        raise NotImplementedError  # pragma: no cover
-
     async def get_all(
-        self,
-        *,
-        page: Page = Page(),
-        geographical_coverage__in: List[GeographicalCoverage] = None,
+        self, *, page: Page = Page(), spec: DatasetSpec = DatasetSpec()
     ) -> Tuple[List[Dataset], int]:
         raise NotImplementedError  # pragma: no cover
 

--- a/server/domain/datasets/specifications.py
+++ b/server/domain/datasets/specifications.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from .entities import GeographicalCoverage
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    geographical_coverage__in: Optional[Sequence[GeographicalCoverage]] = None

--- a/server/infrastructure/datasets/module.py
+++ b/server/infrastructure/datasets/module.py
@@ -8,12 +8,14 @@ from server.application.datasets.handlers import (
     delete_dataset,
     get_all_datasets,
     get_dataset_by_id,
+    get_dataset_filters,
     search_datasets,
     update_dataset,
 )
 from server.application.datasets.queries import (
     GetAllDatasets,
     GetDatasetByID,
+    GetDatasetFilters,
     SearchDatasets,
 )
 from server.seedwork.application.modules import Module
@@ -30,4 +32,5 @@ class DatasetsModule(Module):
         GetAllDatasets: get_all_datasets,
         GetDatasetByID: get_dataset_by_id,
         SearchDatasets: search_datasets,
+        GetDatasetFilters: get_dataset_filters,
     }

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -163,7 +163,12 @@ class SqlDatasetRepository(DatasetRepository):
     def __init__(self, db: Database) -> None:
         self._db = db
 
-    async def get_all(self, page: Page = Page()) -> Tuple[List[Dataset], int]:
+    async def get_all(
+        self,
+        *,
+        page: Page = Page(),
+        geographical_coverage__in: List[GeographicalCoverage] = None,
+    ) -> Tuple[List[Dataset], int]:
         limit, offset = to_limit_offset(page)
 
         async with self._db.session() as session:
@@ -174,8 +179,15 @@ class SqlDatasetRepository(DatasetRepository):
                     selectinload(DatasetModel.tags),
                 )
                 .join(DatasetModel.catalog_record)
-                .order_by(CatalogRecordModel.created_at.desc())
             )
+
+            if geographical_coverage__in is not None:
+                stmt = stmt.where(
+                    DatasetModel.geographical_coverage.in_(geographical_coverage__in)
+                )
+
+            stmt = stmt.order_by(CatalogRecordModel.created_at.desc())
+
             count = await get_count_from(stmt, session)
             result = await session.execute(stmt.limit(limit).offset(offset))
             instances = result.scalars().all()

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -25,6 +25,7 @@ from server.domain.common.types import ID
 from server.domain.datasets.entities import (
     DataFormat,
     Dataset,
+    DatasetFilters,
     GeographicalCoverage,
     UpdateFrequency,
 )
@@ -162,6 +163,11 @@ def update_instance(
 class SqlDatasetRepository(DatasetRepository):
     def __init__(self, db: Database) -> None:
         self._db = db
+
+    async def get_dataset_filters(self) -> DatasetFilters:
+        return DatasetFilters(
+            geographical_coverage=list(GeographicalCoverage),
+        )
 
     async def get_all(
         self,

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -293,6 +293,32 @@ async def test_dataset_get_all_uses_reverse_chronological_order(
 
 
 @pytest.mark.asyncio
+async def test_dataset_filters_geographical_coverage(
+    client: httpx.AsyncClient, temp_user: TestUser
+) -> None:
+    bus = resolve(MessageBus)
+
+    pk = await bus.execute(
+        CREATE_ANY_DATASET.copy(
+            update={"geographical_coverage": GeographicalCoverage.NATIONAL}
+        )
+    )
+
+    params = {"geographical_coverage": GeographicalCoverage.REGION.value}
+    response = await client.get("/datasets/", params=params, auth=temp_user.auth)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 0
+
+    params = {"geographical_coverage": GeographicalCoverage.NATIONAL.value}
+    response = await client.get("/datasets/", params=params, auth=temp_user.auth)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 1
+    assert data["items"][0]["id"] == str(pk)
+
+
+@pytest.mark.asyncio
 class TestDatasetOptionalFields:
     @pytest.mark.parametrize(
         "field, default",

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -293,6 +293,29 @@ async def test_dataset_get_all_uses_reverse_chronological_order(
 
 
 @pytest.mark.asyncio
+async def test_dataset_get_all_filters_info(
+    client: httpx.AsyncClient, temp_user: TestUser
+) -> None:
+    response = await client.get(
+        "/datasets/", params={"filters_info": True}, auth=temp_user.auth
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert sorted(data["filters"]["geographical_coverage"]) == [
+        "department",
+        "epci",
+        "europe",
+        "municipality",
+        "national",
+        "national_full_territory",
+        "region",
+        "world",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_dataset_filters_geographical_coverage(
     client: httpx.AsyncClient, temp_user: TestUser
 ) -> None:
@@ -304,13 +327,18 @@ async def test_dataset_filters_geographical_coverage(
         )
     )
 
-    params = {"geographical_coverage": GeographicalCoverage.REGION.value}
+    params = {"geographical_coverage": [GeographicalCoverage.REGION.value]}
     response = await client.get("/datasets/", params=params, auth=temp_user.auth)
     assert response.status_code == 200
     data = response.json()
     assert len(data["items"]) == 0
 
-    params = {"geographical_coverage": GeographicalCoverage.NATIONAL.value}
+    params = {
+        "geographical_coverage": [
+            GeographicalCoverage.NATIONAL.value,
+            GeographicalCoverage.EUROPE.value,
+        ]
+    }
     response = await client.get("/datasets/", params=params, auth=temp_user.auth)
     assert response.status_code == 200
     data = response.json()

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -293,9 +293,7 @@ async def test_dataset_get_all_uses_reverse_chronological_order(
 
 
 @pytest.mark.asyncio
-async def test_dataset_filters(
-    client: httpx.AsyncClient, temp_user: TestUser
-) -> None:
+async def test_dataset_filters(client: httpx.AsyncClient, temp_user: TestUser) -> None:
     response = await client.get("/datasets/filters/", auth=temp_user.auth)
     assert response.status_code == 200
 

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -293,17 +293,15 @@ async def test_dataset_get_all_uses_reverse_chronological_order(
 
 
 @pytest.mark.asyncio
-async def test_dataset_get_all_filters_info(
+async def test_dataset_filters(
     client: httpx.AsyncClient, temp_user: TestUser
 ) -> None:
-    response = await client.get(
-        "/datasets/", params={"filters_info": True}, auth=temp_user.auth
-    )
+    response = await client.get("/datasets/filters/", auth=temp_user.auth)
     assert response.status_code == 200
 
     data = response.json()
 
-    assert sorted(data["filters"]["geographical_coverage"]) == [
+    assert sorted(data["geographical_coverage"]) == [
         "department",
         "epci",
         "europe",


### PR DESCRIPTION
Closes #271 

* Ajout d'un queryparam `?geographical_coverage` à l'endpoint `GET /datasets/`.
* Ajout d'un endpoint `GET /datasets/filters/` qui renvoie les valeurs possibles pour les différents filtres (pour l'instant uniquement `geographical_coverage`).

## Suites possibles

* Rassembler les commandes `GetAllDatasets` et `SearchDatasets` : actuellement on peut _soit_ passer `?q=...`, _soit_ passer `?geographical_coverage=...` (il n'y a pas d'erreur si on passe les 2, mais si on le fait alors `?geographical_coverage=...` n'est pas pris en compte car on appelle `SearchDatasets`). Il faut pouvoir faire les 2 indépendamment.