### PR TITLE
Add tags filter

### DIFF
--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -56,6 +56,7 @@ async def list_datasets(
         spec=DatasetSpec(
             search_term=params.q,
             geographical_coverage__in=params.geographical_coverage,
+            tag__id__in=params.tag_id,
         ),
     )
 

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -19,11 +19,13 @@ class DatasetListParams:
         page_number: int = 1,
         page_size: int = 10,
         geographical_coverage: Optional[List[GeographicalCoverage]] = Query(None),
+        tag_id: Optional[List[ID]] = Query(None),
     ) -> None:
         self.q = q
         self.page_number = page_number
         self.page_size = page_size
         self.geographical_coverage = geographical_coverage
+        self.tag_id = tag_id
 
 
 class DatasetCreate(BaseModel):

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -1,3 +1,4 @@
+from server.application.tags.queries import GetAllTags
 from server.config.di import resolve
 from server.domain.catalog_records.entities import CatalogRecord
 from server.domain.catalog_records.repositories import CatalogRecordRepository
@@ -7,6 +8,7 @@ from server.domain.datasets.entities import Dataset, GeographicalCoverage
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.tags.repositories import TagRepository
+from server.seedwork.application.messages import MessageBus
 
 from .commands import CreateDataset, DeleteDataset, UpdateDataset
 from .queries import GetAllDatasets, GetDatasetByID, GetDatasetFilters
@@ -60,8 +62,13 @@ async def delete_dataset(command: DeleteDataset) -> None:
 
 
 async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFiltersView:
+    bus = resolve(MessageBus)
+
+    tags = await bus.execute(GetAllTags())
+
     return DatasetFiltersView(
         geographical_coverage=list(GeographicalCoverage),
+        tag_id=[tag.id for tag in tags],
     )
 
 

--- a/server/application/datasets/views.py
+++ b/server/application/datasets/views.py
@@ -37,3 +37,4 @@ class DatasetView(BaseModel):
 
 class DatasetFiltersView(BaseModel):
     geographical_coverage: List[GeographicalCoverage]
+    tag_id: List[ID]

--- a/server/domain/datasets/specifications.py
+++ b/server/domain/datasets/specifications.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
+from server.domain.common.types import ID
+
 from .entities import GeographicalCoverage
 
 
@@ -8,3 +10,4 @@ from .entities import GeographicalCoverage
 class DatasetSpec:
     search_term: Optional[str] = None
     geographical_coverage__in: Optional[Sequence[GeographicalCoverage]] = None
+    tag__id__in: Optional[Sequence[ID]] = None

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -39,7 +39,7 @@ class SqlDatasetRepository(DatasetRepository):
             result = await session.stream(stmt.limit(limit).offset(offset))
             items = [
                 (make_entity(query.instance(row)), query.extras(row))
-                async for row in result
+                async for row in result.unique()
             ]
             return items, count
 

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -295,10 +295,16 @@ async def test_dataset_get_all_uses_reverse_chronological_order(
 
 @pytest.mark.asyncio
 async def test_dataset_filters(client: httpx.AsyncClient, temp_user: TestUser) -> None:
+    bus = resolve(MessageBus)
+
+    tag_id = await bus.execute(CreateTag(name="example"))
+
     response = await client.get("/datasets/filters/", auth=temp_user.auth)
     assert response.status_code == 200
 
     data = response.json()
+
+    assert set(data) == {"geographical_coverage", "tag_id"}
 
     assert sorted(data["geographical_coverage"]) == [
         "department",
@@ -310,6 +316,8 @@ async def test_dataset_filters(client: httpx.AsyncClient, temp_user: TestUser) -
         "region",
         "world",
     ]
+
+    assert data["tag_id"] == [str(tag_id)]
 
 
 @pytest.mark.asyncio
@@ -355,13 +363,13 @@ async def test_dataset_filters_tags(
         CREATE_ANY_DATASET.copy(update={"tag_ids": [architecture_id]})
     )
 
-    params = {"tag_ids": [str(id_factory())]}
+    params = {"tag_id": [str(id_factory())]}
     response = await client.get("/datasets/", params=params, auth=temp_user.auth)
     assert response.status_code == 200
     data = response.json()
     assert len(data["items"]) == 0
 
-    params = {"tag_ids": [str(architecture_id)]}
+    params = {"tag_id": [str(architecture_id)]}
     response = await client.get("/datasets/", params=params, auth=temp_user.auth)
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
Suite de #272 (découpé à partir de #269)

Cette PR:

* Ajoute un filtre `tag_id` permettant de ne retenir que les jeux de données comportant certains tags.
* Ajoute les informations sur ce filtre dans un champ `tag_id: <list>` dans l'endpoint `GET /datasets/filters`.

Utilisation : passer un query parameter `tag_id` autant de fois qu'il y a de tags acceptés

```
?tag_id=...&tag_id=...
```