### PR TITLE
Split datasets.repositories module

### DIFF
--- a/server/infrastructure/catalog_records/repositories.py
+++ b/server/infrastructure/catalog_records/repositories.py
@@ -13,7 +13,7 @@ from server.domain.common.types import ID
 from ..database import Base, Database
 
 if TYPE_CHECKING:
-    from ..datasets.repositories import DatasetModel
+    from ..datasets.models import DatasetModel
 
 
 class CatalogRecordModel(Base):

--- a/server/infrastructure/datasets/models.py
+++ b/server/infrastructure/datasets/models.py
@@ -1,0 +1,96 @@
+import uuid
+from typing import List
+
+from sqlalchemy import (
+    Column,
+    Computed,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Table,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR, UUID
+from sqlalchemy.orm import Mapped, relationship
+
+from server.domain.datasets.entities import (
+    DataFormat,
+    GeographicalCoverage,
+    UpdateFrequency,
+)
+
+from ..catalog_records.repositories import CatalogRecordModel
+from ..database import Base, mapper_registry
+from ..tags.repositories import TagModel, dataset_tag
+
+# Association table
+# See: https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#many-to-many
+dataset_dataformat = Table(
+    "dataset_dataformat",
+    mapper_registry.metadata,
+    Column("dataset_id", ForeignKey("dataset.id"), primary_key=True),
+    Column("dataformat_id", ForeignKey("dataformat.id"), primary_key=True),
+)
+
+
+class DataFormatModel(Base):
+    __tablename__ = "dataformat"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(Enum(DataFormat, name="dataformat_enum"), nullable=False, unique=True)
+
+    datasets: List["DatasetModel"] = relationship(
+        "DatasetModel",
+        back_populates="formats",
+        secondary=dataset_dataformat,
+    )
+
+
+class DatasetModel(Base):
+    __tablename__ = "dataset"
+
+    id: uuid.UUID = Column(UUID(as_uuid=True), primary_key=True)
+
+    catalog_record: "CatalogRecordModel" = relationship(
+        "CatalogRecordModel",
+        back_populates="dataset",
+        cascade="delete",
+        lazy="joined",
+        uselist=False,
+    )
+
+    title = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    service = Column(String, nullable=False)
+    geographical_coverage = Column(
+        Enum(GeographicalCoverage, enum="geographical_coverage_enum"), nullable=False
+    )
+    formats: List[DataFormatModel] = relationship(
+        "DataFormatModel",
+        back_populates="datasets",
+        secondary=dataset_dataformat,
+    )
+    technical_source = Column(String)
+    producer_email = Column(String, nullable=False)
+    contact_emails = Column(ARRAY(String), server_default="{}", nullable=False)
+    update_frequency = Column(Enum(UpdateFrequency, enum="update_frequency_enum"))
+    last_updated_at = Column(DateTime(timezone=True))
+    published_url = Column(String)
+    tags: List["TagModel"] = relationship(
+        "TagModel", back_populates="datasets", secondary=dataset_tag
+    )
+
+    search_tsv: Mapped[str] = Column(
+        TSVECTOR,
+        Computed("to_tsvector('french', title || ' ' || description)", persisted=True),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_dataset_search_tsv",
+            search_tsv,
+            postgresql_using="GIN",
+        ),
+    )

--- a/server/infrastructure/datasets/transformers.py
+++ b/server/infrastructure/datasets/transformers.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from server.domain.datasets.entities import Dataset
+
+from ..catalog_records.repositories import make_entity as make_catalog_record_entity
+from ..tags.repositories import TagModel
+from ..tags.repositories import make_entity as make_tag_entity
+from .models import CatalogRecordModel, DataFormatModel, DatasetModel
+
+
+def make_entity(instance: DatasetModel) -> Dataset:
+    kwargs = {
+        "catalog_record": make_catalog_record_entity(instance.catalog_record),
+        "formats": [fmt.name for fmt in instance.formats],
+        "tags": [make_tag_entity(tag) for tag in instance.tags],
+    }
+
+    kwargs.update(
+        (field, getattr(instance, field))
+        for field in Dataset.__fields__
+        if field not in kwargs
+    )
+
+    return Dataset(**kwargs)
+
+
+def make_instance(
+    entity: Dataset,
+    catalog_record: CatalogRecordModel,
+    formats: List[DataFormatModel],
+    tags: List[TagModel],
+) -> DatasetModel:
+    instance = DatasetModel(
+        **entity.dict(exclude={"catalog_record", "formats", "tags"}),
+    )
+
+    instance.catalog_record = catalog_record
+    instance.formats = formats
+    instance.tags = tags
+
+    return instance
+
+
+def update_instance(
+    instance: DatasetModel,
+    entity: Dataset,
+    formats: List[DataFormatModel],
+    tags: List[TagModel],
+) -> None:
+    for field in set(Dataset.__fields__) - {"id", "catalog_record", "formats", "tags"}:
+        setattr(instance, field, getattr(entity, field))
+
+    instance.formats = formats
+    instance.tags = tags

--- a/server/infrastructure/tags/repositories.py
+++ b/server/infrastructure/tags/repositories.py
@@ -12,7 +12,7 @@ from server.domain.tags.repositories import TagRepository
 from server.infrastructure.database import Base, Database, mapper_registry
 
 if TYPE_CHECKING:
-    from ..datasets.repositories import DatasetModel
+    from ..datasets.models import DatasetModel
 
 
 dataset_tag = Table(

--- a/tests/infrastructure/test_datasets.py
+++ b/tests/infrastructure/test_datasets.py
@@ -9,7 +9,7 @@ from server.config.di import resolve
 from server.domain.catalog_records.repositories import CatalogRecordRepository
 from server.domain.datasets.entities import DataFormat, GeographicalCoverage
 from server.infrastructure.database import Database
-from server.infrastructure.datasets.repositories import DatasetModel
+from server.infrastructure.datasets.models import DatasetModel
 from server.infrastructure.tags.repositories import TagModel, dataset_tag
 from server.seedwork.application.messages import MessageBus
 


### PR DESCRIPTION
En préparation de #280, cette PR décompose le module `infrastructure/datasets/repositories.py` en plusieurs morceaux :

* `repositories.py`
* `models.py`
* `transformers.py`

En effet, dans #280 je crée un fichier à part pour la requête (complexe) de recherche filtrée. Celle-ci a besoin de `DatasetModel` ou encore `make_entity`, et elle est ensuite utilisée dans `SqlDatasetRepository`. Donc sans cette décomposition, on se retrouverait avec des imports circulaires.

Je pense qu'il est généralement préférable de n'avoir que le repository dans `repositories.py`. On pourrait donc envisager appliquer cette structure à `catalog_records`, `tags`, ou `user`...
