### PR TITLE
Extract base layout

### DIFF
--- a/client/src/routes/__layout-base.svelte
+++ b/client/src/routes/__layout-base.svelte
@@ -33,6 +33,4 @@
   <link rel="manifest" href={manifest} crossorigin="use-credentials" />
 </svelte:head>
 
-<main id="contenu">
-  <slot />
-</main>
+<slot />

--- a/client/src/routes/__layout-blank@base.svelte
+++ b/client/src/routes/__layout-blank@base.svelte
@@ -1,0 +1,3 @@
+<main id="contenu">
+  <slot />
+</main>

--- a/client/src/routes/__layout@base.svelte
+++ b/client/src/routes/__layout@base.svelte
@@ -1,47 +1,19 @@
-<script lang="ts" context="module">
-  import type { Load } from "@sveltejs/kit";
-  import { authGuard } from "$lib/auth/guard";
-
-  export const load: Load = async ({ url }) => {
-    return authGuard(url);
-  };
-</script>
-
 <script lang="ts">
   import Header from "$lib/components/Header/Header.svelte";
   import Footer from "$lib/components/Footer/Footer.svelte";
   import { onMount } from "svelte";
-  import "../app.css";
-
-  // DSFR Assets
-  import appleTouchFavicon from "@gouvfr/dsfr/dist/favicon/apple-touch-icon.png";
-  import svgFavicon from "@gouvfr/dsfr/dist/favicon/favicon.svg";
-  import icoFavicon from "@gouvfr/dsfr/dist/favicon/favicon.ico";
-  import manifest from "@gouvfr/dsfr/dist/favicon/manifest.webmanifest";
   import LayoutProviders from "$lib/providers/LayoutProviders.svelte";
   import { user } from "$lib/stores/auth";
   import { checkLogin } from "$lib/repositories/auth";
   import { Maybe } from "$lib/util/maybe";
 
   onMount(async () => {
-    // Load the DSFR asynchronously, and only on the browser (not in SSR).
-    await import("@gouvfr/dsfr/dist/dsfr/dsfr.module.min.js");
-
     if (Maybe.Some($user)) {
       // Ensure user session is still valid.
       await checkLogin({ fetch, apiToken: $user.apiToken });
     }
   });
 </script>
-
-<svelte:head>
-  <link rel="apple-touch-icon" href={appleTouchFavicon} />
-  <!-- 180×180 -->
-  <link rel="icon" href={svgFavicon} type="image/svg+xml" />
-  <link rel="shortcut icon" href={icoFavicon} type="image/x-icon" />
-  <!-- 32×32 -->
-  <link rel="manifest" href={manifest} crossorigin="use-credentials" />
-</svelte:head>
 
 <LayoutProviders>
   <div class="fr-skiplinks">


### PR DESCRIPTION
En regardant à #292 j'ai remarqué que le code de chargement des icônes et autres assets était dupliqué entre les layouts `blank` et celui par défaut.

Dans cette PR je propose de mettre ça dans un layout `base` dont `blank` et le layout par défaut héritent.