### PR TITLE
Fix server.seedwork not being a package

### DIFF
--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -1,8 +1,5 @@
-from typing import Union
-
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
-from fastapi.responses import JSONResponse
 
 from server.application.datasets.commands import (
     CreateDataset,
@@ -35,7 +32,7 @@ router.include_router(filters.router)
 )
 async def list_datasets(
     params: DatasetListParams = Depends(),
-) -> Union[JSONResponse, Pagination[DatasetView]]:
+) -> Pagination[DatasetView]:
     bus = resolve(MessageBus)
 
     page = Page(number=params.page_number, size=params.page_size)

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -71,9 +71,9 @@ async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFiltersView:
 
     return DatasetFiltersView(
         geographical_coverage=list(GeographicalCoverage),
-        service=services,
+        service=list(services),
         format=list(DataFormat),
-        technical_source=technical_sources,
+        technical_source=list(technical_sources),
         tag_id=[tag.id for tag in tags],
     )
 

--- a/server/application/tags/queries.py
+++ b/server/application/tags/queries.py
@@ -1,13 +1,14 @@
 from typing import List
 
 from server.domain.common.types import ID
-from server.domain.tags.entities import Tag
 from server.seedwork.application.queries import Query
 
+from .views import TagView
 
-class GetAllTags(Query[List[Tag]]):
+
+class GetAllTags(Query[List[TagView]]):
     pass
 
 
-class GetTagByID(Query[Tag]):
+class GetTagByID(Query[TagView]):
     id: ID

--- a/server/infrastructure/catalog_records/repositories.py
+++ b/server/infrastructure/catalog_records/repositories.py
@@ -1,4 +1,4 @@
-import uuid
+import datetime as dt
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Column, DateTime, ForeignKey, func, select
@@ -19,13 +19,13 @@ if TYPE_CHECKING:
 class CatalogRecordModel(Base):
     __tablename__ = "catalog_record"
 
-    id: uuid.UUID = Column(UUID(as_uuid=True), primary_key=True)
+    id: ID = Column(UUID(as_uuid=True), primary_key=True)
     dataset_id: ID = Column(UUID(as_uuid=True), ForeignKey("dataset.id"))
     dataset: "DatasetModel" = relationship(
         "DatasetModel",
         back_populates="catalog_record",
     )
-    created_at = Column(
+    created_at: dt.datetime = Column(
         DateTime(timezone=True), server_default=func.clock_timestamp(), nullable=False
     )
 

--- a/server/infrastructure/datasets/transformers.py
+++ b/server/infrastructure/datasets/transformers.py
@@ -9,7 +9,7 @@ from .models import CatalogRecordModel, DataFormatModel, DatasetModel
 
 
 def make_entity(instance: DatasetModel) -> Dataset:
-    kwargs = {
+    kwargs: dict = {
         "catalog_record": make_catalog_record_entity(instance.catalog_record),
         "formats": [fmt.name for fmt in instance.formats],
         "tags": [make_tag_entity(tag) for tag in instance.tags],

--- a/server/infrastructure/tags/module.py
+++ b/server/infrastructure/tags/module.py
@@ -9,7 +9,7 @@ class TagsModule(Module):
         CreateTag: create_tag,
     }
 
-    query_handlers: dict = {
+    query_handlers = {
         GetAllTags: get_all_tags,
         GetTagByID: get_tag_by_id,
     }

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -2,6 +2,7 @@ from typing import List
 
 import httpx
 import pytest
+from pydantic import EmailStr
 
 from server.application.auth.queries import GetUserByEmail
 from server.config.di import resolve
@@ -178,7 +179,7 @@ async def test_delete_user(
     response = await client.delete(f"/auth/users/{temp_user.id}/", auth=admin_user.auth)
     assert response.status_code == 204
 
-    query = GetUserByEmail(email=temp_user.email)
+    query = GetUserByEmail(email=EmailStr(temp_user.email))
     with pytest.raises(UserDoesNotExist):
         await bus.execute(query)
 

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -191,11 +191,11 @@ async def test_search_results_change_when_data_changes(
     assert dataset["id"] == str(pk)
 
     # Same on description
-    command = UpdateDatasetFactory.build(
+    update_command = UpdateDatasetFactory.build(
         description="Jeu de données spécial",
         **update_command.dict(exclude={"description"})
     )
-    await bus.execute(command)
+    await bus.execute(update_command)
     response = await client.get(
         "/datasets/",
         params={"q": "spécial"},
@@ -206,8 +206,8 @@ async def test_search_results_change_when_data_changes(
     assert dataset["id"] == str(pk)
 
     # Deleted dataset is not returned in search results anymore
-    command = DeleteDataset(id=pk)
-    await bus.execute(command)
+    delete_command = DeleteDataset(id=pk)
+    await bus.execute(delete_command)
     response = await client.get(
         "/datasets/",
         params={"q": "modifié"},

--- a/tests/infrastructure/test_datasets.py
+++ b/tests/infrastructure/test_datasets.py
@@ -2,35 +2,24 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import contains_eager
 
-from server.application.datasets.commands import CreateDataset, DeleteDataset
+from server.application.datasets.commands import DeleteDataset
 from server.application.datasets.queries import GetDatasetByID
-from server.application.tags.commands import CreateTag
 from server.config.di import resolve
 from server.domain.catalog_records.repositories import CatalogRecordRepository
-from server.domain.datasets.entities import DataFormat, GeographicalCoverage
 from server.infrastructure.database import Database
 from server.infrastructure.datasets.models import DatasetModel
 from server.infrastructure.tags.repositories import TagModel, dataset_tag
 from server.seedwork.application.messages import MessageBus
+
+from ..factories import CreateDatasetFactory, CreateTagFactory
 
 
 @pytest.mark.asyncio
 async def test_dataset_cascades() -> None:
     bus = resolve(MessageBus)
 
-    tag_architecture_id = await bus.execute(CreateTag(name="Architecture"))
-
-    dataset_id = await bus.execute(
-        CreateDataset(
-            title="Title",
-            description="Description",
-            service="Example service",
-            geographical_coverage=GeographicalCoverage.NATIONAL,
-            formats=[DataFormat.WEBSITE, DataFormat.API],
-            contact_emails=["person@mydomain.org"],
-            tag_ids=[str(tag_architecture_id)],
-        )
-    )
+    tag_id = await bus.execute(CreateTagFactory.build(name="Architecture"))
+    dataset_id = await bus.execute(CreateDatasetFactory.build(tag_ids=[tag_id]))
 
     dataset = await bus.execute(GetDatasetByID(id=dataset_id))
 
@@ -47,7 +36,7 @@ async def test_dataset_cascades() -> None:
             .join(dataset_tag, isouter=True)
             .join(DatasetModel, isouter=True)
             .options(contains_eager(TagModel.datasets))
-            .where(TagModel.id == tag_architecture_id)
+            .where(TagModel.id == tag_id)
         )
         result = await session.execute(stmt)
         tag = result.unique().scalar_one()

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from server.application.auth.queries import Login
 from server.application.datasets.commands import UpdateDataset
 from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
 from server.config.di import resolve
+from server.domain.common.types import ID
 from server.seedwork.application.messages import MessageBus
 from tools import initdata
 
@@ -117,7 +119,7 @@ async def test_repo_initdata(
     captured = capsys.readouterr()
     assert captured.out.count("created") == num_entities
 
-    pk = "16b398af-f8c7-48b9-898a-18ad3404f528"
+    pk = ID(uuid.UUID("16b398af-f8c7-48b9-898a-18ad3404f528"))
     dataset = await bus.execute(GetDatasetByID(id=pk))
     assert dataset.title == "Données brutes de l'inventaire forestier"
 

--- a/tools/changepassword.py
+++ b/tools/changepassword.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 
 import click
-from pydantic import SecretStr
+from pydantic import EmailStr, SecretStr
 
 from server.application.auth.commands import ChangePassword
 from server.config.di import bootstrap, resolve
@@ -40,7 +40,7 @@ async def main() -> None:
     user = await _prompt_user()
     password = _prompt_password()
 
-    await bus.execute(ChangePassword(email=user.email, password=password))
+    await bus.execute(ChangePassword(email=EmailStr(user.email), password=password))
 
 
 if __name__ == "__main__":

--- a/tools/initdata.py
+++ b/tools/initdata.py
@@ -108,26 +108,26 @@ async def handle_dataset(item: dict, reset: bool = False) -> None:
     existing_dataset = await repository.get_by_id(id_)
 
     if existing_dataset is not None:
-        command = UpdateDataset(id=id_, **item["params"])
+        update_command = UpdateDataset(id=id_, **item["params"])
 
         changed = any(
-            getattr(command, k) != _get_dataset_attr(existing_dataset, k)
+            getattr(update_command, k) != _get_dataset_attr(existing_dataset, k)
             for k in item["params"]
         )
 
         if changed and reset:
-            await bus.execute(command)
-            print(f"{warn('reset')}: {command!r}")
+            await bus.execute(update_command)
+            print(f"{warn('reset')}: {update_command!r}")
             return
 
         dataset_repr = f"Dataset(id={id_!r}, title={item['params']['title']!r}, ...)"
         print(f"{info('ok')}: {dataset_repr}")
         return
 
-    command = CreateDataset(**item["params"])
+    create_command = CreateDataset(**item["params"])
 
-    await bus.execute(command, id_=id_)
-    print(f"{success('created')}: {command!r}")
+    await bus.execute(create_command, id_=id_)
+    print(f"{success('created')}: {create_command!r}")
 
 
 async def main(path: pathlib.Path, reset: bool = False, no_input: bool = False) -> None:


### PR DESCRIPTION
Il manquait `__init__.py` dans `server/seedwork/`, donc ce dossier n'était pas reconnu comme un _package Python_. Cette PR le rajoute, et corrige des erreurs de typages qui s'étaient glissées car `mypy` traitait alors `seedwork` silencieusement comme un `Any`.