### PR TITLE
Bump backend dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # App
 argon2-cffi==21.3.0
 asyncpg==0.25.0
-alembic==1.7.7
-fastapi==0.75.2
+alembic==1.8.0
+fastapi==0.78.0
 gunicorn==20.1.0
 punq==0.6.2
 pydantic[email]==1.9.0
 uvicorn[standard]==0.17.6
-sqlalchemy[asyncio,mypy]==1.4.35
+sqlalchemy[asyncio,mypy]==1.4.39
 
 # Debug
 fastapi-debug-toolbar==0.2.1
@@ -15,17 +15,17 @@ fastapi-debug-toolbar==0.2.1
 # Tooling
 asgi-lifespan==1.0.1
 black==22.3.0
-click==8.1.2
-faker==13.13.0
+click==8.1.3
+faker==13.14.0
 flake8==4.0.1
 httpx==0.23.0
 isort==5.10.1
-mypy==0.942
-psycopg2-binary==2.9.2
+mypy==0.961
+psycopg2-binary==2.9.3
 pydantic-factories==1.3.0
 pytest==7.1.2
 pytest-asyncio==0.18.3
 pytest-cov==3.0.0
 pyyaml==6.0
 sqlalchemy-utils==0.38.2
-types-pyyaml==6.0.7
+types-pyyaml==6.0.9


### PR DESCRIPTION
Cette PR met à jour les diverses dépendances du back vers les versions les plus récentes.

Uvicorn n'est pas mis à jour vers 0.18.1 car il y a un problème avec le logging : https://github.com/encode/uvicorn/pull/1543