### PR TITLE
Fix "Response content longer than Content-Length" error when deleting dataset

### DIFF
--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
+from starlette.responses import Response
 
 from server.application.datasets.commands import (
     CreateDataset,
@@ -109,6 +110,7 @@ async def update_dataset(id: ID, data: DatasetUpdate) -> DatasetView:
     "/{id}/",
     dependencies=[Depends(IsAuthenticated()), Depends(HasRole(UserRole.ADMIN))],
     status_code=204,
+    response_class=Response,
 )
 async def delete_dataset(id: ID) -> None:
     bus = resolve(MessageBus)


### PR DESCRIPTION
**Description**

Cette PR corrige un bug qui faisait renvoyer `null` (la valeur JSON) au lieu d'aucun contenu à l'endpoint `DELETE /datasets/<id>/`, qui est une `204 No Content` et devrait donc n'avoir aucun corps de réponse.

**Motivation**

Le serveur affiche une `RuntimeError` lorsqu'on appelle l'endpoint de suppression de dataset :

```
INFO:     127.0.0.1:40052 - "DELETE / HTTP/1.1" 204 No Content
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 372, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/exceptions.py", line 93, in __call__
    raise exc
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/routing.py", line 68, in app
    await response(scope, receive, send)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/responses.py", line 162, in __call__
    await send({"type": "http.response.body", "body": self.body})
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/exceptions.py", line 79, in sender
    await send(message)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/starlette/middleware/errors.py", line 159, in _send
    await send(message)
  File "/home/florimond/dev/prj-catalogue/catalogage-donnees/venv/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 501, in send
    raise RuntimeError("Response content longer than Content-Length")
RuntimeError: Response content longer than Content-Length
```

C'est un "bug d'utilisation" assez courant de FastAPI on dirait, voir par ex : https://github.com/tiangolo/fastapi/issues/4939

Résumer : se contenter de renvoyer `None` mais en fait FastAPI passe celà à `JSONResponse`, or `json.dumps(None) -> "null"`. Il faut donc utiliser `response_class=Response`.

**Context**

Vu en lançant les tests E2E en local.

On ne le voit pas lors des tests d'intégration backend car ils sont lancés sur l'application, sans lancer de serveur web (or c'est à cet endroit que la violation du protocole HTTP est détectée).

On pourrait envisager de lancer les tests d'intégration avec un véritable serveur Uvicorn...