### PR TITLE
Extract and test server configuration

### DIFF
--- a/server/infrastructure/server.py
+++ b/server/infrastructure/server.py
@@ -1,0 +1,66 @@
+from typing import Callable, Union
+
+import uvicorn
+import uvicorn.supervisors
+
+from server.config.di import resolve
+from server.config.settings import Settings
+
+
+def get_server_config(
+    app: Union[str, Callable], settings: Settings = None
+) -> uvicorn.Config:
+    if settings is None:
+        settings = resolve(Settings)
+
+    kwargs = dict(
+        host=settings.host,
+        port=settings.port,
+    )
+
+    if settings.server_mode == "local":
+        kwargs.update(
+            # Enable hot reload.
+            reload=True,
+            reload_dirs=["server"],
+        )
+    elif settings.server_mode == "live":
+        kwargs.update(
+            # Pass any proxy headers, so that Uvicorn sees information about the
+            # connecting client, rather than the connecting Nginx proxy.
+            # See: https://www.uvicorn.org/deployment/#running-behind-nginx
+            proxy_headers=True,
+            # Match Nginx mount path.
+            root_path="/api",
+        )
+
+    return uvicorn.Config(app, **kwargs)
+
+
+class Server(uvicorn.Server):
+    pass
+
+
+def run(app: Union[str, Callable]) -> int:
+    """
+    Run the API server.
+
+    This is a simplified version of `uvicorn.run()`.
+    """
+    config = get_server_config(app)
+    server = Server(config)
+
+    if config.should_reload:
+        sock = config.bind_socket()
+        reloader = uvicorn.supervisors.ChangeReload(
+            config, target=server.run, sockets=[sock]
+        )
+        reloader.run()
+        return 0
+
+    server.run()
+
+    if not server.started:
+        return 3
+
+    return 0

--- a/server/main.py
+++ b/server/main.py
@@ -1,37 +1,12 @@
+import sys
+
 from .api.app import create_app
 from .config.di import bootstrap
+from .infrastructure.server import run
 
 bootstrap()
 
 app = create_app()
 
 if __name__ == "__main__":
-    import uvicorn
-
-    from .config.di import resolve
-    from .config.settings import Settings
-
-    settings = resolve(Settings)
-
-    kwargs: dict = {
-        "host": settings.host,
-        "port": settings.port,
-    }
-
-    if settings.server_mode == "local":
-        kwargs.update(
-            # Enable hot reload.
-            reload=True,
-            reload_dirs=["server"],
-        )
-    elif settings.server_mode == "live":
-        kwargs.update(
-            # Pass any proxy headers, so that Uvicorn sees information about the
-            # connecting client, rather than the connecting Nginx proxy.
-            # See: https://www.uvicorn.org/deployment/#running-behind-nginx
-            proxy_headers=True,
-            # Match Nginx mount path.
-            root_path="/api",
-        )
-
-    uvicorn.run("server.main:app", **kwargs)
+    sys.exit(run("server.main:app"))

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,0 +1,25 @@
+from server.config import Settings
+from server.config.di import resolve
+from server.infrastructure.server import get_server_config
+
+
+def test_server_config_local() -> None:
+    settings = resolve(Settings).copy(update={"server_mode": "local"})
+
+    config = get_server_config("server.main:app", settings)
+
+    assert config.host == "localhost"
+    assert config.port == 3579
+    assert config.should_reload
+    assert config.root_path == ""
+
+
+def test_server_config_live() -> None:
+    settings = resolve(Settings).copy(update={"server_mode": "live"})
+
+    config = get_server_config("server.main:app", settings)
+
+    assert config.host == "localhost"
+    assert config.port == 3579
+    assert config.proxy_headers
+    assert config.root_path == "/api"


### PR DESCRIPTION
Cette PR extrait une partie de #304, à la fois pour alléger cette PR et aussi vu mon commentaire ici :

> On ne le voit pas lors des tests d'intégration backend car ils sont lancés sur l'application, sans lancer de serveur web (or c'est à cet endroit que la violation du protocole HTTP est détectée).
> On pourrait envisager de lancer les tests d'intégration avec un véritable serveur Uvicorn...

En extrayant cette fonction, on pourra plus facilement tester avec un "vrai" serveur d'API, grâce à https://github.com/encode/uvicorn/pull/1497...

TODO

- [x] Tester sur staging
