### PR TITLE
Add license field

### DIFF
--- a/client/src/definitions/datasetFilters.ts
+++ b/client/src/definitions/datasetFilters.ts
@@ -8,6 +8,7 @@ export type DatasetFiltersInfo = {
   format: string[];
   technicalSource: string[];
   tagId: Tag[];
+  license: string[];
 };
 
 export type DatasetFiltersValue = {
@@ -16,6 +17,7 @@ export type DatasetFiltersValue = {
   format: string | null;
   technicalSource: string | null;
   tagId: string | null;
+  license: string | null;
 };
 
 export type DatasetFiltersOptions = {

--- a/client/src/definitions/datasets.ts
+++ b/client/src/definitions/datasets.ts
@@ -49,6 +49,7 @@ export type Dataset = {
   geographicalCoverage: GeographicalCoverage;
   technicalSource: string | null;
   url: string | null;
+  license: string | null;
   tags: Tag[];
 };
 

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -91,11 +91,20 @@ describe("Test the dataset form", () => {
 
   test('The "url" field is present', async () => {
     const { getByLabelText } = render(DatasetForm);
-    const url = getByLabelText("Page open data", {
+    const url = getByLabelText("Lien vers les données", {
       exact: false,
     });
     expect(url).toBeInTheDocument();
     expect(url).not.toBeRequired();
+  });
+
+  test('The "license" field is present', async () => {
+    const { getByLabelText } = render(DatasetForm);
+    const license = getByLabelText("Licence de réutilisation", {
+      exact: false,
+    });
+    expect(license).toBeInTheDocument();
+    expect(license).not.toBeRequired();
   });
 
   test("The submit button is present", () => {
@@ -127,6 +136,7 @@ describe("Test the dataset form", () => {
       geographicalCoverage: "europe",
       technicalSource: "foo/bar",
       url: "https://data.gouv.fr/datasets/example",
+      license: "Licence Ouverte",
       tags: [fakeTag],
     };
     const props = { initial };
@@ -181,12 +191,18 @@ describe("Test the dataset form", () => {
     }) as HTMLSelectElement;
     expect(technicalSource.value).toBe("foo/bar");
 
-    const url = getByLabelText("Page open data", {
+    const url = getByLabelText("Lien vers les données", {
       exact: false,
     }) as HTMLSelectElement;
     expect(url.value).toBe("https://data.gouv.fr/datasets/example");
+
     const tags = getAllByText(fakeTag.name);
     expect(tags).toHaveLength(1);
+
+    const license = getByLabelText("Licence de réutilisation", {
+      exact: false,
+    }) as HTMLInputElement;
+    expect(license.value).toBe("Licence Ouverte");
   });
 
   test("Null or empty fields are correctly submitted as null", async () => {
@@ -202,6 +218,7 @@ describe("Test the dataset form", () => {
       geographicalCoverage: "europe",
       technicalSource: "foo/bar",
       url: "",
+      license: null,
       tags: [buildFakeTag()],
     };
     const props = { initial };
@@ -232,6 +249,7 @@ describe("Test the dataset form", () => {
     expect(submittedValue.updateFrequency).toBe(null);
     expect(submittedValue.producerEmail).toBe(null);
     expect(submittedValue.url).toBe(null);
+    expect(submittedValue.license).toBe(null);
   });
 
   describe("Authenticated tests", () => {

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -4,10 +4,13 @@
   import { createForm } from "svelte-forms-lib";
   import type {
     DataFormat,
+    Dataset,
     DatasetFormData,
     GeographicalCoverage,
     UpdateFrequency,
   } from "src/definitions/datasets";
+  import type { SelectOption } from "src/definitions/form";
+  import type { Tag } from "src/definitions/tag";
   import {
     DATA_FORMAT_LABELS,
     UPDATE_FREQUENCY_LABELS,
@@ -24,12 +27,13 @@
   import { handleSelectChange } from "src/lib/util/form";
   import { type DropMaybe, Maybe } from "$lib/util/maybe";
   import TagSelector from "../TagSelector/TagSelector.svelte";
-  import type { Tag } from "src/definitions/tag";
+  import LicenseField from "./_LicenseField.svelte";
 
   export let submitLabel = "Publier la fiche de données";
   export let loadingLabel = "Publication en cours...";
   export let loading = false;
   export let tags: Tag[] = [];
+  export let licenses: string[] = [];
 
   export let initial: DatasetFormData | null = null;
 
@@ -48,6 +52,7 @@
     updateFrequency: UpdateFrequency | null;
     technicalSource: string | null;
     url: string | null;
+    license: string | null;
     tags: Tag[];
   };
 
@@ -71,11 +76,17 @@
     updateFrequency: initial?.updateFrequency || null,
     technicalSource: initial?.technicalSource || null,
     url: initial?.url || null,
+    license: initial?.license || null,
     tags: initial?.tags || [],
   };
 
   // Handle this value manually.
   const dataFormatsValue = initialValues.dataFormats;
+
+  const isOpenDataOptions: SelectOption<boolean>[] = [
+    { label: "Oui", value: true },
+    { label: "Non", value: false },
+  ];
 
   const { form, errors, handleChange, handleSubmit, updateValidateField } =
     createForm({
@@ -105,6 +116,7 @@
           .required("Ce champs est requis"),
         technicalSource: yup.string().nullable(),
         url: yup.string().nullable(),
+        license: yup.string().nullable(),
         tags: yup
           .array()
           .of(
@@ -137,6 +149,7 @@
 
         // Ensure "" becomes null.
         const url = values.url ? values.url : null;
+        const license = values.license ? values.license : null;
 
         const data: DatasetFormData = {
           ...values,
@@ -145,6 +158,7 @@
           contactEmails,
           lastUpdatedAt,
           url,
+          license,
         };
 
         dispatch("save", data);
@@ -405,17 +419,24 @@
     />
   </div>
 
-  <h2 id="ouverture" class="fr-mt-6w fr-mb-5w">Ouverture</h2>
+  <h2 id="acces-aux-donnees" class="fr-mt-6w fr-mb-5w">Accès aux données</h2>
 
   <div class="form--content fr-mb-8w">
     <InputField
       name="url"
-      label="Page open data"
-      hintText="Si le jeu de données est publié en open data, saisissez ici le lien de la page web associée."
+      label="Lien vers les données"
+      hintText="Saisissez ici le lien de la page web associée au jeu de données."
       value={$form.url}
       error={$errors.url}
       on:input={handleFieldChange}
       on:blur={handleFieldChange}
+    />
+
+    <LicenseField
+      value={$form.license}
+      error={$errors.license}
+      suggestions={licenses}
+      on:input={(ev) => updateValidateField("license", ev.detail)}
     />
   </div>
 

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -4,12 +4,10 @@
   import { createForm } from "svelte-forms-lib";
   import type {
     DataFormat,
-    Dataset,
     DatasetFormData,
     GeographicalCoverage,
     UpdateFrequency,
   } from "src/definitions/datasets";
-  import type { SelectOption } from "src/definitions/form";
   import type { Tag } from "src/definitions/tag";
   import {
     DATA_FORMAT_LABELS,
@@ -52,7 +50,7 @@
     updateFrequency: UpdateFrequency | null;
     technicalSource: string | null;
     url: string | null;
-    license: string | null;
+    license: string;
     tags: Tag[];
   };
 
@@ -76,17 +74,12 @@
     updateFrequency: initial?.updateFrequency || null,
     technicalSource: initial?.technicalSource || null,
     url: initial?.url || null,
-    license: initial?.license || null,
+    license: initial?.license || "",
     tags: initial?.tags || [],
   };
 
   // Handle this value manually.
   const dataFormatsValue = initialValues.dataFormats;
-
-  const isOpenDataOptions: SelectOption<boolean>[] = [
-    { label: "Oui", value: true },
-    { label: "Non", value: false },
-  ];
 
   const { form, errors, handleChange, handleSubmit, updateValidateField } =
     createForm({

--- a/client/src/lib/components/DatasetForm/_LicenseField.spec.ts
+++ b/client/src/lib/components/DatasetForm/_LicenseField.spec.ts
@@ -21,7 +21,15 @@ describe("License field", () => {
     expect(options.length).toBe(0);
   });
 
-  test("should show suggestions on click", async () => {
+  test("should not show suggestions initially", async () => {
+    const { queryAllByRole } = render(LicenseField, {
+      props: { suggestions: ["Licence Ouverte", "ODC Open Database License"] },
+    });
+    const options = queryAllByRole("option");
+    expect(options.length).toBe(0);
+  });
+
+  test("should show suggestions on focusing the input", async () => {
     const { getByRole, getAllByRole } = render(LicenseField, {
       props: { suggestions: ["Licence Ouverte", "ODC Open Database License"] },
     });
@@ -59,12 +67,9 @@ describe("License field", () => {
     const suggestions = getAllByRole("option");
     expect(suggestions.length).toBe(2);
 
+    let value = "";
+    component.$on("input", (event) => (value = event.detail));
     await fireEvent.click(suggestions[0]);
-
-    const value = await new Promise<string>((resolve) => {
-      component.$on("input", (event) => resolve(event.detail));
-    });
-
     expect(value).toBe("Licence Ouverte");
   });
 

--- a/client/src/lib/components/DatasetForm/_LicenseField.spec.ts
+++ b/client/src/lib/components/DatasetForm/_LicenseField.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+
+import { render, fireEvent } from "@testing-library/svelte";
+import LicenseField from "./_LicenseField.svelte";
+
+describe("License field", () => {
+  test("should have an input", () => {
+    const { getByRole } = render(LicenseField);
+    const input = getByRole("combobox");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("autocomplete", "off");
+  });
+
+  test("should show nothing on click if no suggestions", async () => {
+    const { getByRole, queryAllByRole } = render(LicenseField);
+    await fireEvent.focus(getByRole("combobox"));
+    const options = queryAllByRole("option");
+    expect(options.length).toBe(0);
+  });
+
+  test("should show suggestions on click", async () => {
+    const { getByRole, getAllByRole } = render(LicenseField, {
+      props: { suggestions: ["Licence Ouverte", "ODC Open Database License"] },
+    });
+    await fireEvent.focus(getByRole("combobox"));
+    const suggestions = getAllByRole("option");
+    expect(suggestions.length).toBe(2);
+    expect(suggestions[0]).toHaveTextContent("Licence Ouverte");
+    expect(suggestions[1]).toHaveTextContent("ODC Open Database License");
+  });
+
+  test("should filter suggestions by input value", async () => {
+    const { getByRole, getAllByRole } = render(LicenseField, {
+      props: { suggestions: ["Licence Ouverte", "ODC Open Database License"] },
+    });
+
+    const input = getByRole("combobox");
+
+    await fireEvent.focus(input);
+    await fireEvent.input(input, { target: { value: "ouv" } });
+    expect(input).toHaveValue("ouv");
+
+    const suggestions = getAllByRole("option");
+    expect(suggestions.length).toBe(1);
+    expect(suggestions[0]).toHaveTextContent("Licence Ouverte");
+  });
+
+  test("should choose a suggestion", async () => {
+    const { getByRole, getAllByRole, component } = render(LicenseField, {
+      props: { suggestions: ["Licence Ouverte", "ODC Open Database License"] },
+    });
+
+    const input = getByRole("combobox");
+    await fireEvent.focus(input);
+
+    const suggestions = getAllByRole("option");
+    expect(suggestions.length).toBe(2);
+
+    await fireEvent.click(suggestions[0]);
+
+    const value = await new Promise<string>((resolve) => {
+      component.$on("input", (event) => resolve(event.detail));
+    });
+
+    expect(value).toBe("Licence Ouverte");
+  });
+
+  test("should show error", async () => {
+    const { getByRole } = render(LicenseField, {
+      props: { error: "Unexpected error" },
+    });
+    const input = getByRole("combobox");
+    expect(input).toHaveAccessibleDescription("Unexpected error");
+  });
+});

--- a/client/src/lib/components/DatasetForm/_LicenseField.svelte
+++ b/client/src/lib/components/DatasetForm/_LicenseField.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import { Maybe } from "$lib/util/maybe";
   import { escape } from "$lib/util/string";
   import { clickOutside } from "$lib/actions/clickOutside";
 
-  export let value: string | null = null;
+  export let value = "";
   export let error = "";
   export let suggestions: string[] = [];
 
@@ -12,12 +11,9 @@
 
   const dispatch = createEventDispatcher<{ input: string }>();
 
-  $: regexp = Maybe.map(value, (v) => new RegExp(escape(v), "i"));
-  $: filteredSuggestions = showSuggestions
-    ? suggestions.filter((item) =>
-        Maybe.Some(regexp) ? Maybe.Some(item.match(regexp)) : true
-      )
-    : [];
+  $: filteredSuggestions = suggestions.filter((item) =>
+    item.match(new RegExp(escape(value), "i"))
+  );
 
   const onInput = (ev: Event & { currentTarget: HTMLInputElement }) => {
     dispatch("input", ev.currentTarget.value);
@@ -54,7 +50,7 @@
     type="text"
     id="license"
     name="license"
-    {value}
+    bind:value
     role="combobox"
     autocomplete="off"
     aria-controls="license-results"
@@ -71,22 +67,24 @@
     role="listbox"
     aria-label="Licences"
   >
-    {#each filteredSuggestions as item}
-      <li
-        id="license-{item}"
-        class="dropdown--list-item"
-        role="option"
-        tabindex="0"
-        on:click={() => onSelectItem(item)}
-        on:keydown={(ev) => {
-          if (ev.key === "Enter") {
-            onSelectItem(item);
-          }
-        }}
-      >
-        {item}
-      </li>
-    {/each}
+    {#if showSuggestions}
+      {#each filteredSuggestions as item}
+        <li
+          id="license-{item}"
+          class="dropdown--list-item"
+          role="option"
+          tabindex="0"
+          on:click={() => onSelectItem(item)}
+          on:keydown={(ev) => {
+            if (ev.key === "Enter") {
+              onSelectItem(item);
+            }
+          }}
+        >
+          {item}
+        </li>
+      {/each}
+    {/if}
   </ul>
 
   {#if error}

--- a/client/src/lib/components/DatasetForm/_LicenseField.svelte
+++ b/client/src/lib/components/DatasetForm/_LicenseField.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { Maybe } from "$lib/util/maybe";
+  import { escape } from "$lib/util/string";
+  import { clickOutside } from "$lib/actions/clickOutside";
+
+  export let value: string | null = null;
+  export let error = "";
+  export let suggestions: string[] = [];
+
+  let showSuggestions = false;
+
+  const dispatch = createEventDispatcher<{ input: string }>();
+
+  $: regexp = Maybe.map(value, (v) => new RegExp(escape(v), "i"));
+  $: filteredSuggestions = showSuggestions
+    ? suggestions.filter((item) =>
+        Maybe.Some(regexp) ? Maybe.Some(item.match(regexp)) : true
+      )
+    : [];
+
+  const onInput = (ev: Event & { currentTarget: HTMLInputElement }) => {
+    dispatch("input", ev.currentTarget.value);
+  };
+
+  const onSelectItem = (item: string) => {
+    showSuggestions = false;
+    dispatch("input", item);
+  };
+</script>
+
+<div
+  class="fr-input-group dropdown fr-my-4w"
+  class:fr-input-group--error={error}
+  use:clickOutside={{ callback: () => (showSuggestions = false) }}
+>
+  <label class="fr-label" for="license">
+    Licence de réutilisation
+    <span class="fr-hint-text" id="license-desc-hint">
+      Indiquez la <a
+        href="https://www.data.gouv.fr/fr/pages/legal/licences"
+        target="blank"
+        rel="noreferrer"
+        title="Voir les licences de réutilisation sur data.gouv.fr"
+      >
+        licence de réutilisation
+      </a> associée au jeu de données.
+    </span>
+  </label>
+
+  <input
+    class="fr-input"
+    class:fr-input--error={error}
+    type="text"
+    id="license"
+    name="license"
+    {value}
+    role="combobox"
+    autocomplete="off"
+    aria-controls="license-results"
+    aria-autocomplete="list"
+    aria-expanded={showSuggestions}
+    aria-describedby={error ? "license-desc-error" : null}
+    on:input={onInput}
+    on:focus={() => (showSuggestions = true)}
+  />
+
+  <ul
+    id="license-results"
+    class="fr-raw-list dropdown--list"
+    role="listbox"
+    aria-label="Licences"
+  >
+    {#each filteredSuggestions as item}
+      <li
+        id="license-{item}"
+        class="dropdown--list-item"
+        role="option"
+        tabindex="0"
+        on:click={() => onSelectItem(item)}
+        on:keydown={(ev) => {
+          if (ev.key === "Enter") {
+            onSelectItem(item);
+          }
+        }}
+      >
+        {item}
+      </li>
+    {/each}
+  </ul>
+
+  {#if error}
+    <p id="license-desc-error" class="fr-error-text">
+      {error}
+    </p>
+  {/if}
+</div>
+
+<style>
+  .dropdown {
+    position: relative;
+  }
+
+  .dropdown--list {
+    position: absolute;
+    width: 100%;
+    max-height: 32vh;
+    overflow: scroll;
+    background-color: var(--grey-1000-75);
+    border: 1px solid var(--background-contrast-grey);
+    box-shadow: 0 0 10px var(--grey-925);
+    z-index: 10;
+  }
+
+  .dropdown--list-item {
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    margin: 0;
+    border-top: 1px solid var(--background-contrast-grey);
+  }
+
+  .dropdown--list-item:hover {
+    background-color: var(--background-contrast-grey);
+  }
+</style>

--- a/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
+++ b/client/src/lib/components/DatasetListItem/DatasetListItem.svelte
@@ -25,9 +25,9 @@
         .join(", "),
     },
     {
-      label: "Ouverture",
-      icon: dataset.url ? "fr-icon-x-open-data" : "fr-icon-x-restricted-data",
-      value: dataset.url ? "Open data" : "Restreint",
+      label: "Licence",
+      icon: "fr-icon-x-open-data",
+      value: Maybe.Some(dataset.license) ? dataset.license : "-",
     },
   ];
 </script>

--- a/client/src/lib/repositories/licenses.ts
+++ b/client/src/lib/repositories/licenses.ts
@@ -1,0 +1,17 @@
+import type { Fetch } from "src/definitions/fetch";
+import { getApiUrl, getHeaders, makeApiRequest } from "../fetch";
+import { Maybe } from "../util/maybe";
+
+type GetLicenses = (opts: {
+  fetch: Fetch;
+  apiToken: string;
+}) => Promise<Maybe<string[]>>;
+
+export const getLicenses: GetLicenses = async ({ fetch, apiToken }) => {
+  const url = `${getApiUrl()}/licenses/`;
+  const request = new Request(url, {
+    headers: getHeaders(apiToken),
+  });
+  const response = await makeApiRequest(fetch, request);
+  return Maybe.map(response, (response) => response.json());
+};

--- a/client/src/lib/transformers/dataset.ts
+++ b/client/src/lib/transformers/dataset.ts
@@ -19,9 +19,7 @@ export const transformKeysToUnderscoreCase = (object: {
 export const toPayload = (
   data: Partial<Record<keyof Dataset, any>>
 ): { [K: string]: unknown } => {
-  const payload = transformKeysToUnderscoreCase(omit(data, ["catalogRecord"]));
-  payload.license = null;
-  return payload;
+  return transformKeysToUnderscoreCase(omit(data, ["catalogRecord"]));
 };
 
 export const toDataset = (item: any): Dataset => {

--- a/client/src/lib/transformers/datasetFilters.spec.ts
+++ b/client/src/lib/transformers/datasetFilters.spec.ts
@@ -26,6 +26,7 @@ describe("transformers -- Dataset filters", () => {
         name: "monTag2",
       },
     ],
+    license: ["*", "Licence Ouverte"],
   };
 
   const value: DatasetFiltersValue = {
@@ -34,6 +35,7 @@ describe("transformers -- Dataset filters", () => {
     service: null,
     technicalSource: "Serveur GIS",
     tagId: null,
+    license: "Licence Ouverte",
   };
 
   test("toFiltersParams", () => {
@@ -43,6 +45,7 @@ describe("transformers -- Dataset filters", () => {
       ["format", "file_gis"],
       ["technical_source", "Serveur GIS"],
       ["tag_id", null],
+      ["license", "Licence Ouverte"],
     ];
 
     expect(toFiltersParams(value)).toEqual(params);
@@ -51,7 +54,7 @@ describe("transformers -- Dataset filters", () => {
   test("getFiltersValueFromParams", () => {
     const queryString = toQueryString(toFiltersParams(value));
     expect(queryString).toBe(
-      "?geographical_coverage=epci&format=file_gis&technical_source=Serveur+GIS"
+      "?geographical_coverage=epci&format=file_gis&technical_source=Serveur+GIS&license=Licence+Ouverte"
     );
     expect(toFiltersValue(new URLSearchParams(queryString))).toEqual(value);
   });
@@ -77,6 +80,10 @@ describe("transformers -- Dataset filters", () => {
       tagId: [
         { label: "monTag1", value: "xyz-555-666" },
         { label: "monTag2", value: "abc-111-2226" },
+      ],
+      license: [
+        { label: "Toutes les licences", value: "*" },
+        { label: "Licence Ouverte", value: "Licence Ouverte" },
       ],
     };
 

--- a/client/src/lib/transformers/datasetFilters.ts
+++ b/client/src/lib/transformers/datasetFilters.ts
@@ -12,7 +12,7 @@ import type { QueryParamRecord } from "src/definitions/url";
 import { Maybe } from "../util/maybe";
 
 export const toFiltersInfo = (data: any): DatasetFiltersInfo => {
-  const { geographical_coverage, tag_id, technical_source, ...rest } = data;
+  const { geographical_coverage, technical_source, tag_id, ...rest } = data;
   return {
     geographicalCoverage: geographical_coverage,
     technicalSource: technical_source,
@@ -32,14 +32,21 @@ export const toFiltersValue = (
     format: searchParams.get("format"),
     technicalSource: searchParams.get("technical_source"),
     tagId: searchParams.get("tag_id"),
+    license: searchParams.get("license"),
   };
 };
 
 export const toFiltersParams = (
   value: DatasetFiltersValue
 ): QueryParamRecord => {
-  const { geographicalCoverage, service, format, technicalSource, tagId } =
-    value;
+  const {
+    geographicalCoverage,
+    service,
+    format,
+    technicalSource,
+    tagId,
+    license,
+  } = value;
 
   return [
     ["geographical_coverage", geographicalCoverage],
@@ -47,6 +54,7 @@ export const toFiltersParams = (
     ["format", format],
     ["technical_source", technicalSource],
     ["tag_id", tagId],
+    ["license", license],
   ];
 };
 
@@ -68,6 +76,10 @@ export const toFiltersOptions = (
       value,
     })),
     tagId: info.tagId.map((tag) => ({ label: tag.name, value: tag.id })),
+    license: info.license.map((value) => ({
+      label: value === "*" ? "Toutes les licences" : value,
+      value,
+    })),
   };
 };
 
@@ -84,5 +96,8 @@ export const toFiltersButtonTexts = (
     format: Maybe.map(value.format, (v) => DATA_FORMAT_LABELS[v]),
     technicalSource: value.technicalSource,
     tagId: Maybe.map(value.tagId, (v) => tagIdToName[v]),
+    license: Maybe.map(value.license, (v) =>
+      v === "*" ? "Toutes les licences" : v
+    ),
   };
 };

--- a/client/src/lib/util/string.spec.ts
+++ b/client/src/lib/util/string.spec.ts
@@ -1,0 +1,8 @@
+import { escape } from "./string";
+
+test("escape", () => {
+  expect(escape("test")).toBe("test");
+  expect(escape("Autre (ouverte)")).toBe("Autre \\(ouverte\\)");
+  const s = "Autre (ouverte) test";
+  expect(s.match(new RegExp(escape("Autre (ouverte)"), "i"))).toBeTruthy();
+});

--- a/client/src/lib/util/string.ts
+++ b/client/src/lib/util/string.ts
@@ -1,0 +1,4 @@
+export const escape = (value: string): string => {
+  // See: https://stackoverflow.com/a/3561711
+  return value.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+};

--- a/client/src/routes/fiches/[id]/_AsideItem.svelte
+++ b/client/src/routes/fiches/[id]/_AsideItem.svelte
@@ -14,7 +14,13 @@
       {label}
     </div>
     <div>
-      {Maybe.Some(value) ? value : "-"}
+      {#if Maybe.Some(value)}
+        <slot>
+          {value}
+        </slot>
+      {:else}
+        -
+      {/if}
     </div>
   </div>
 </div>

--- a/client/src/routes/fiches/[id]/index.spec.ts
+++ b/client/src/routes/fiches/[id]/index.spec.ts
@@ -45,23 +45,30 @@ describe("Dataset detail description", () => {
     expect(description).toHaveTextContent(dataset.description);
   });
 
-  test("The open data link is not present if the access is restricted", async () => {
-    const { queryByText } = render(index, { dataset });
-    const seeDataLink = queryByText("Voir les données", {
-      exact: false,
+  test("The url link button is present if a url is set", async () => {
+    const { getByText, queryByText, rerender } = render(index, {
+      dataset: { ...dataset, url: null },
     });
-    expect(seeDataLink).not.toBeInTheDocument();
+    let urlLink = queryByText("Voir les données", { exact: false });
+    expect(urlLink).not.toBeInTheDocument();
+    rerender({
+      props: { dataset: { ...dataset, url: "https://example.org" } },
+    });
+    urlLink = getByText("Voir les données", { exact: false });
+    expect(urlLink).toBeInTheDocument();
+    expect(urlLink).toHaveAttribute("href", "https://example.org");
   });
 
-  test("The open data link is present if the access is open", async () => {
-    const { queryByText } = render(index, {
-      dataset: getFakeDataset({
-        url: "http://foo.com",
-      }),
+  test("The license is shown if it is set", async () => {
+    const { getByText, queryByText, rerender } = render(index, {
+      dataset: { ...dataset, license: null },
     });
-    const seeDataLink = queryByText("Voir les données", {
-      exact: false,
+    let license = queryByText("Licence Ouverte", { exact: false });
+    expect(license).not.toBeInTheDocument();
+    rerender({
+      props: { dataset: { ...dataset, license: "Licence Ouverte" } },
     });
-    expect(seeDataLink).toBeInTheDocument();
+    license = getByText("Licence Ouverte", { exact: false });
+    expect(license).toBeInTheDocument();
   });
 });

--- a/client/src/routes/fiches/[id]/index.svelte
+++ b/client/src/routes/fiches/[id]/index.svelte
@@ -87,28 +87,6 @@
 
     <div class="fr-grid-row fr-grid-row--gutters">
       <aside class="fr-col-md-4">
-        <h6 class="fr-mb-2w">Ouverture</h6>
-
-        <AsideItem
-          icon="fr-icon-x-open-data"
-          label="Accessibilité aux données"
-          value={dataset.url ? "Ouverte" : "Restreinte"}
-        />
-        {#if dataset.url}
-          <a
-            class="fr-btn fr-btn--icon-right fr-icon-external-link-line"
-            href={dataset.url}
-            target="_blank"
-          >
-            Voir les données
-          </a>
-        {:else}
-          <p class="fr-text--xs fr-text-mention--grey fr-mb-0">
-            Veuillez prendre contact avec le producteur afin d'obtenir l'accès
-            au jeu de données.
-          </p>
-        {/if}
-
         <h6 class="fr-mt-4w fr-mb-2w">Informations générales</h6>
 
         <AsideItem
@@ -138,6 +116,28 @@
             dataset.updateFrequency,
             (v) => UPDATE_FREQUENCY_LABELS[v]
           )}
+        />
+
+        <h6 class="fr-mb-2w">Accès aux données</h6>
+
+        <AsideItem
+          icon="fr-icon-global-line"
+          label="Lien vers les données"
+          value={dataset.url}
+        >
+          <a
+            class="fr-btn fr-btn--icon-right fr-icon-external-link-line"
+            href={dataset.url}
+            target="_blank"
+          >
+            Voir les données
+          </a>
+        </AsideItem>
+
+        <AsideItem
+          icon="fr-icon-x-open-data"
+          label="Licence de réutilisation"
+          value={dataset.license}
         />
       </aside>
 

--- a/client/src/routes/fiches/_FilterPanel.svelte
+++ b/client/src/routes/fiches/_FilterPanel.svelte
@@ -60,6 +60,17 @@
       options={filtersOptions.service}
     />
   </div>
+
+  <div class="fr-mb-2w">
+    <SearchableSelect
+      label="Licence de réutilisation"
+      buttonPlaceholder="Rechercher..."
+      inputPlaceholder="Rechercher..."
+      buttonText={buttonTexts.license || "Rechercher..."}
+      on:clickItem={(e) => handleSelectFilter("license", e)}
+      options={filtersOptions.license}
+    />
+  </div>
 </section>
 
 <section>

--- a/client/src/tests/e2e/contribuer.spec.ts
+++ b/client/src/tests/e2e/contribuer.spec.ts
@@ -19,6 +19,7 @@ test.describe("Basic form submission", () => {
     const technicalSourceText = "foo/bar";
     const urlText = "https://data.gouv.fr/datasets/example";
     const tagName = "services des eaux";
+    const licenseText = "Licence Ouverte";
 
     await page.goto("/contribuer");
 
@@ -84,11 +85,15 @@ test.describe("Basic form submission", () => {
       label: UPDATE_FREQUENCY_LABELS.daily,
     });
 
-    // "Ouverture" section
+    // "Accès aux données" section
 
     const url = page.locator("form [name=url]");
     await url.fill(urlText);
     expect(await url.inputValue()).toBe(urlText);
+
+    const license = page.locator("form [name=license]");
+    await license.fill(licenseText);
+    expect(await license.inputValue()).toBe(licenseText);
 
     // "Mots clés" section
 
@@ -110,7 +115,9 @@ test.describe("Basic form submission", () => {
       button.click(),
     ]);
     expect(
-      page.locator("a.fr-sidemenu__link", { hasText: "Ouverture" }).first()
+      page
+        .locator("a.fr-sidemenu__link", { hasText: "Accès aux données" })
+        .first()
     ).toHaveAttribute("aria-current", "page");
     expect(request.method()).toBe("POST");
     expect(response.status()).toBe(201);
@@ -127,6 +134,7 @@ test.describe("Basic form submission", () => {
     expect(json.last_updated_at).toEqual("2000-05-05T00:00:00+00:00");
     expect(json.service).toBe(serviceText);
     expect(json.url).toBe(urlText);
+    expect(json.license).toBe(licenseText);
 
     const hasTag = json.tags.findIndex((item) => item.name === tagName) !== -1;
     expect(hasTag).toBeTruthy();
@@ -148,7 +156,7 @@ test.describe("Basic form submission", () => {
 
     // Scroll to bottom.
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-    await expect(activeSidebarItem).toHaveText("Ouverture");
+    await expect(activeSidebarItem).toHaveText("Accès aux données");
 
     // Move to a particular section using click.
     // Purposefully test a small-size section: it should become active

--- a/client/src/tests/e2e/search.spec.ts
+++ b/client/src/tests/e2e/search.spec.ts
@@ -138,9 +138,10 @@ test.describe("Search filters", () => {
     await filterPanel.locator("text=Sources et formats").waitFor();
     await filterPanel.locator("text=Mots-clés thématiques").waitFor();
 
-    expect(await filterPanel.locator("button").count()).toBe(5);
+    expect(await filterPanel.locator("button").count()).toBe(6);
     await filterPanel.locator("text=Couverture géographique").waitFor();
     await filterPanel.locator("text=Service producteur de la donnée").waitFor();
+    await filterPanel.locator("text=Licence de réutilisation").waitFor();
     await filterPanel.locator("text=Format de mise à disposition").waitFor();
     await filterPanel.locator("text=Système d'information source").waitFor();
     await filterPanel.locator("text=Mot-clé").waitFor();

--- a/client/src/tests/factories/dataset.ts
+++ b/client/src/tests/factories/dataset.ts
@@ -16,6 +16,7 @@ export const getFakeDataset = (dataset: Partial<Dataset> = {}): Dataset => {
     lastUpdatedAt: dataset.lastUpdatedAt || new Date(),
     geographicalCoverage: dataset.geographicalCoverage || "europe",
     url: dataset.url || null,
+    license: dataset.license || null,
     tags: dataset.tags || [buildFakeTag()],
   };
 };
@@ -35,6 +36,7 @@ export const getFakeDataSetFormData = (
     lastUpdatedAt: datasetFormData.lastUpdatedAt || new Date(),
     geographicalCoverage: datasetFormData.geographicalCoverage || "europe",
     url: datasetFormData.url || null,
+    license: datasetFormData.license || null,
     tags: datasetFormData.tags || [buildFakeTag()],
   };
 };


### PR DESCRIPTION
Closes #287 

TODO

* [x] Back #337 
* [x] Ajouter champ "Licence de réutilisation" au formulaire de contribution/édition
* [x] Brancher l'affichage sur le champ "licence de réutilisation" : list item
* [x] Filtre licence
* [x] Tests unitaires
* [x] Tests E2E

## Checklist critères d'acceptation

* [x] (Must have) Le champ "Licence" est présent dans le formulaire de contribution
* [x] (Must have) Des licences par défaut sont suggérées (...)
* [x] (Must have) (...) mais il est possible d'entrer une valeur quelconque
* [x] (Must have) La licence est visible sur la page d'une fiche de données
* [x] (Must have) Un filtre licence est disponible dans la recherche avancée
  * [x] (Should have) Le filtre licence a une option "Toutes les licences" pour voir les jeux de données "en open data" (quelle que soit la licence)