### PR TITLE
Ensure get_all query for when datasets have many formats

### DIFF
--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -39,7 +39,7 @@ class SqlDatasetRepository(DatasetRepository):
             result = await session.stream(stmt.limit(limit).offset(offset))
             items = [
                 (make_entity(query.instance(row)), query.extras(row))
-                async for row in result.unique()
+                async for row in result
             ]
             return items, count
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import TYPE_CHECKING, AsyncIterator, Iterator
+from typing import TYPE_CHECKING, AsyncIterator, Iterator, List
 
 import httpx
 import pytest
@@ -11,11 +11,14 @@ from asgi_lifespan import LifespanManager
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from server.application.datasets.queries import GetAllDatasets
+from server.application.tags.queries import GetAllTags
+from server.application.tags.views import TagView
 from server.config import Settings
 from server.config.di import bootstrap, resolve
 from server.domain.auth.entities import UserRole
 from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
+from tests.factories import CreateTagFactory
 
 from .helpers import TestUser, create_client, create_test_user
 
@@ -59,6 +62,21 @@ async def warmup_db() -> None:
     # occur during tests and interfere with time measurements.
     bus = resolve(MessageBus)
     await bus.execute(GetAllDatasets())
+
+
+@pytest_asyncio.fixture
+async def tags(transaction: None) -> List[TagView]:
+    bus = resolve(MessageBus)
+
+    for name in [
+        "Monument historique",
+        "Lieu culturel",
+        "Musée de France",
+        "Statistiques",
+    ]:
+        await bus.execute(CreateTagFactory.build(name=name))
+
+    return await bus.execute(GetAllTags())
 
 
 @pytest.fixture(scope="session")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,6 +11,7 @@ from server.application.auth.commands import CreateUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.tags.commands import CreateTag
 from server.domain.common import datetime as dtutil
+from server.domain.datasets.entities import DataFormat
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -41,15 +42,11 @@ class CreateUserFactory(Factory[CreateUser]):
 class CreateTagFactory(Factory[CreateTag]):
     __model__ = CreateTag
 
-    name = Use(
-        random.choice,
-        ("Monument historique", "Lieu culturel", "Musée de France", "Statistiques"),
-    )
-
 
 class CreateDatasetFactory(Factory[CreateDataset]):
     __model__ = CreateDataset
 
+    formats = Use(lambda: random.choices(list(DataFormat), k=random.randint(1, 3)))
     tag_ids = Use(lambda: [])
 
 


### PR DESCRIPTION
Découvert en travaillant sur https://github.com/etalab/catalogage-donnees/pull/312#issuecomment-1171366481

La requête GetAllDatasets faisait une jointure incorrecte sur les formats et les tags, pousant à appeler result.unique() ce qui réduisait le nombre de résultats au nb de formats ou de tags distincts, c'est-à-dire maximum 6 (nombre de formats dans l'enum en base). C'était visible dans la pagination : pour une taille de page de 10 et plus de 10 datasets au total en base, la requête pouvait retourner 6 items au lieu de 10.

Cette PR corrige la requête et ajoute des formats et/ou tags aux cas de test de pagination.

TODO:

* [x] Tester sur staging pour voir si ça résout #313 
  * En effet c'est bieeeen plus rapide... 