### PR TITLE
Add "make randomdatasets" script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ initdata: #- Initialize data
 initdatareset: #- Initialize data, resetting any changed target entities
 	${bin}python -m tools.initdata --reset tools/initdata.yml
 
+randomdatasets: #- Add 500 random datasets
+	${bin}python -m tools.addrandomdatasets 500
+
 id: #- Generate an ID suitable for use in database entities
 	${bin}python -m tools.makeid
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ sqlalchemy[asyncio,mypy]==1.4.39
 fastapi-debug-toolbar==0.2.1
 
 # Tooling
+aiometer==0.3.0
 asgi-lifespan==1.0.1
 black==22.3.0
 click==8.1.3
@@ -29,4 +30,5 @@ pytest-asyncio==0.18.3
 pytest-cov==3.0.0
 pyyaml==6.0
 sqlalchemy-utils==0.38.2
+tqdm==4.64.0
 types-pyyaml==6.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ sqlalchemy[asyncio,mypy]==1.4.39
 fastapi-debug-toolbar==0.2.1
 
 # Tooling
-aiometer==0.3.0
 asgi-lifespan==1.0.1
 black==22.3.0
 click==8.1.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ async def warmup_db() -> None:
 
 
 @pytest_asyncio.fixture
-async def tags(transaction: None) -> List[TagView]:
+async def tags() -> List[TagView]:
     bus = resolve(MessageBus)
 
     for name in [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,12 +48,11 @@ def test_database() -> Iterator[None]:
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def transaction() -> AsyncIterator[None]:
+async def autorollback_db() -> AsyncIterator[None]:
     db = resolve(Database)
 
-    async with db.transaction() as tx:
+    async with db.autorollback():
         yield
-        await tx.rollback()
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -21,7 +21,7 @@ class DateTimeTZProvider(BaseProvider):
         return self.generator.date_time(dtutil.UTC)
 
 
-fake = faker.Faker()
+fake = faker.Faker(["fr_FR"])
 fake.add_provider(DateTimeTZProvider)
 
 
@@ -46,7 +46,18 @@ class CreateTagFactory(Factory[CreateTag]):
 class CreateDatasetFactory(Factory[CreateDataset]):
     __model__ = CreateDataset
 
+    title = Use(fake.sentence)
+    description = Use(fake.text)
+    service = Use(fake.company)
     formats = Use(lambda: random.choices(list(DataFormat), k=random.randint(1, 3)))
+    technical_source = Use(
+        lambda: fake.sentence(nb_words=3) if random.random() < 0.5 else None
+    )
+    producer_email = Use(fake.ascii_free_email)
+    contact_emails = Use(
+        lambda: [fake.ascii_free_email() for _ in range(random.randint(1, 3))]
+    )
+    published_url = Use(lambda: fake.url() if random.random() < 0.5 else None)
     tag_ids = Use(lambda: [])
 
 

--- a/tests/tools/test_addrandomdatasets.py
+++ b/tests/tools/test_addrandomdatasets.py
@@ -1,0 +1,22 @@
+import pytest
+
+from server.application.datasets.queries import GetAllDatasets
+from server.config.di import resolve
+from server.infrastructure.database import Database
+from server.seedwork.application.messages import MessageBus
+from tools import addrandomdatasets
+
+
+@pytest.mark.asyncio
+async def test_addrandomdatasets() -> None:
+    bus = resolve(MessageBus)
+    db = resolve(Database)
+
+    async with db.autorollback():
+        pagination = await bus.execute(GetAllDatasets())
+        assert pagination.total_items == 0
+
+        await addrandomdatasets.main(n=100)
+
+        pagination = await bus.execute(GetAllDatasets())
+        assert pagination.total_items == 100

--- a/tests/tools/test_addrandomdatasets.py
+++ b/tests/tools/test_addrandomdatasets.py
@@ -2,21 +2,19 @@ import pytest
 
 from server.application.datasets.queries import GetAllDatasets
 from server.config.di import resolve
-from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
 from tools import addrandomdatasets
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("tags")
 async def test_addrandomdatasets() -> None:
     bus = resolve(MessageBus)
-    db = resolve(Database)
 
-    async with db.autorollback():
-        pagination = await bus.execute(GetAllDatasets())
-        assert pagination.total_items == 0
+    pagination = await bus.execute(GetAllDatasets())
+    assert pagination.total_items == 0
 
-        await addrandomdatasets.main(n=100)
+    await addrandomdatasets.main(n=20)
 
-        pagination = await bus.execute(GetAllDatasets())
-        assert pagination.total_items == 100
+    pagination = await bus.execute(GetAllDatasets())
+    assert pagination.total_items == 20

--- a/tools/addrandomdatasets.py
+++ b/tools/addrandomdatasets.py
@@ -7,10 +7,10 @@ import aiometer
 import click
 from tqdm import tqdm
 
+from server.application.tags.queries import GetAllTags
 from server.config.di import bootstrap, resolve
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateDatasetFactory
-from server.application.tags.queries import GetAllTags
 
 success = functools.partial(click.style, fg="bright_green")
 

--- a/tools/addrandomdatasets.py
+++ b/tools/addrandomdatasets.py
@@ -1,0 +1,37 @@
+import argparse
+import asyncio
+import functools
+
+import aiometer
+import click
+from tqdm import tqdm
+
+from server.config.di import bootstrap, resolve
+from server.seedwork.application.messages import MessageBus
+from tests.factories import CreateDatasetFactory
+
+success = functools.partial(click.style, fg="bright_green")
+
+
+async def main(n: int) -> None:
+    bus = resolve(MessageBus)
+
+    with tqdm(total=n, unit="dataset") as progress:
+
+        async def task() -> None:
+            await bus.execute(CreateDatasetFactory.build())
+            progress.update()
+
+        tasks = [task for _ in range(n)]
+        await aiometer.run_all(tasks, max_at_once=20)
+
+    print(f"{success('created')}: {n} datasets")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("n", type=int)
+    args = parser.parse_args()
+
+    bootstrap()
+    asyncio.run(main(n=args.n))

--- a/tools/addrandomdatasets.py
+++ b/tools/addrandomdatasets.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import functools
+import random
 
 import aiometer
 import click
@@ -9,6 +10,7 @@ from tqdm import tqdm
 from server.config.di import bootstrap, resolve
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateDatasetFactory
+from server.application.tags.queries import GetAllTags
 
 success = functools.partial(click.style, fg="bright_green")
 
@@ -16,10 +18,13 @@ success = functools.partial(click.style, fg="bright_green")
 async def main(n: int) -> None:
     bus = resolve(MessageBus)
 
+    tag_id_set = [tag.id for tag in await bus.execute(GetAllTags())]
+
     with tqdm(total=n, unit="dataset") as progress:
 
         async def task() -> None:
-            await bus.execute(CreateDatasetFactory.build())
+            tag_ids = random.choices(tag_id_set, k=random.randint(1, 3))
+            await bus.execute(CreateDatasetFactory.build(tag_ids=tag_ids))
             progress.update()
 
         tasks = [task for _ in range(n)]


### PR DESCRIPTION
Cette PR ajoute un script qui permet de générer 500 jeux de données aléatoires d'un coup.

On pourra l'utiliser pour tester fonctionnellement l'UI des filtres de façon plus réaliste (le initdata ne génère que 3 datasets par défaut).

Motivé par https://github.com/etalab/catalogage-donnees/pull/312#issuecomment-1171366481

TODO

* [x] Tester sur staging