### PR TITLE
Fix OpenAPI docs security scheme binding

### DIFF
--- a/server/api/app.py
+++ b/server/api/app.py
@@ -15,13 +15,7 @@ origins = [
 
 
 class App(FastAPI):
-    def openapi(self) -> dict:
-        # Tweak the OpenAPI schema.
-        schema = super().openapi()
-        schema.setdefault("components", {}).setdefault("securitySchemes", {}).update(
-            auth_backend.get_openapi_security_definitions()
-        )
-        return schema
+    pass
 
 
 def create_app(settings: Settings = None) -> App:

--- a/server/api/auth/backends/token.py
+++ b/server/api/auth/backends/token.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple
 
-from fastapi.encoders import jsonable_encoder
-from fastapi.openapi.models import HTTPBearer
+from fastapi.security.http import HTTPBearer
 from starlette.authentication import (
     AuthCredentials,
     AuthenticationBackend,
@@ -22,8 +21,7 @@ class TokenAuthBackend(AuthenticationBackend):
     Authenticate users based on their API token: 'Authorization: Bearer <api_token>'
     """
 
-    def get_openapi_security_definitions(self) -> dict:
-        return {"Bearer": jsonable_encoder(HTTPBearer())}
+    security = HTTPBearer(scheme_name="Bearer", auto_error=False)
 
     async def authenticate(
         self, conn: HTTPConnection

--- a/server/api/auth/dependencies.py
+++ b/server/api/auth/dependencies.py
@@ -1,17 +1,52 @@
-from fastapi import HTTPException
+from fastapi import Depends, HTTPException
+from fastapi.security.base import SecurityBase
 
 from server.domain.auth.entities import UserRole
 
+from ..resources import auth_backend
 from ..types import APIRequest
 
 
 class IsAuthenticated:
-    def __call__(self, request: APIRequest) -> None:
+    """
+    Require requests to be authenticated.
+
+    Usage:
+        @router.get(
+            ...,
+            dependencies=[
+                Depends(IsAuthenticated()),
+            ],
+        )
+    """
+
+    def __call__(
+        self,
+        request: APIRequest,
+        # Make FastAPI generated API docs register the security scheme,
+        # and attach it to any route that has `Depends(IsAuthenticated())`.
+        _: SecurityBase = Depends(auth_backend.security),
+    ) -> None:
         if not request.user.is_authenticated:
             raise HTTPException(401, detail="Invalid credentials")
 
 
-class HasRole(IsAuthenticated):
+class HasRole:
+    """
+    An add-on to `IsAuthenticated()` which requires to authenticated user to
+    have specific roles.
+
+    Usage:
+
+        @router.get(
+            ...,
+            dependencies=[
+                Depends(IsAuthenticated()),
+                Depends(HasRole(...)),
+            ],
+        )
+    """
+
     def __init__(self, *roles: UserRole) -> None:
         self._roles = roles
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,10 +21,15 @@ async def test_openapi(client: httpx.AsyncClient) -> None:
     assert response.status_code == 200
     schema = response.json()
 
+    # HTTP Bearer security scheme must be registered.
     bearer_scheme = schema["components"]["securitySchemes"].get("Bearer")
     assert bearer_scheme is not None
     assert bearer_scheme["type"] == "http"
     assert bearer_scheme["scheme"] == "bearer"
+
+    # Authenticated endpoints must be tied to the HTTP Bearer scheme.
+    # We just take an exmaple endpoint here.
+    assert {"Bearer": []} in schema["paths"]["/auth/users/"]["post"]["security"]
 
 
 @pytest.mark.parametrize("origin", ["http://localhost:3000"])


### PR DESCRIPTION
Cf https://staging.catalogue.multi.coop/api/docs

Dans #298 je pensais avoir correctement relié le backend d'authentification à la doc d'API (OpenAPI), mais ce n'est pas le cas. En effet, remplir `securitySchemes` ne suffit pas : il faut que le champ `security` soit défini sur chaque [`Operation`](https://spec.openapis.org/oas/latest.html#operation-object). Dès lors, le bouton "Authorize :lock:" qui permet d'entrer un api_token s'affiche, mais les endpoints ne sont pas protégés (on le voit à l'absence d'icône "verrou" :lock:), donc lors d'une requête à un endpoint via le bouton "Try it out", le token n'est pas envoyé, et on reçoit toujours des 401.

La solution est de laisser la main à FastAPI, et ajouter le security scheme comme une dépendance de `IsAuthenticated`.