### PR TITLE
Fix search page pagination

### DIFF
--- a/client/src/lib/util/pagination.spec.ts
+++ b/client/src/lib/util/pagination.spec.ts
@@ -1,0 +1,12 @@
+import { getPageFromParams, makePageParam } from "./pagination";
+
+describe("pagination", () => {
+  test("makePageParam", () => {
+    expect(makePageParam(1)).toEqual(["page", "1"]);
+  });
+
+  test("getPageFromParams", () => {
+    expect(getPageFromParams(new URLSearchParams())).toBe(1);
+    expect(getPageFromParams(new URLSearchParams("page=3"))).toBe(3);
+  });
+});

--- a/client/src/lib/util/pagination.ts
+++ b/client/src/lib/util/pagination.ts
@@ -51,3 +51,11 @@ export const makePagination = (options: PaginationOptions): Pagination => {
     lastPage,
   };
 };
+
+export const makePageParam = (page: number): [string, string] => {
+  return ["page", page.toString()];
+};
+
+export const getPageFromParams = (searchParams: URLSearchParams): number => {
+  return +(searchParams.get("page") || 1);
+};

--- a/client/src/lib/util/pagination.ts
+++ b/client/src/lib/util/pagination.ts
@@ -57,5 +57,5 @@ export const makePageParam = (page: number): [string, string] => {
 };
 
 export const getPageFromParams = (searchParams: URLSearchParams): number => {
-  return +(searchParams.get("page") || 1);
+  return parseInt(searchParams.get("page") || "1");
 };

--- a/client/src/routes/fiches/_PaginationContainer.svelte
+++ b/client/src/routes/fiches/_PaginationContainer.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  import { page as pageStore } from "$app/stores";
   import Pagination from "src/lib/components/Pagination/Pagination.svelte";
+  import { makePageParam } from "$lib/util/pagination";
+  import { patchQueryString } from "$lib/util/urls";
+
   export let currentPage: number;
   export let totalPages: number;
-  export let getPageLink: (page: number) => string;
+
+  $: getPageLink = (page: number): string => {
+    return patchQueryString($pageStore.url.searchParams, [makePageParam(page)]);
+  };
 </script>
 
 <div class="pagination-container fr-mt-2w ">

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -3,9 +3,10 @@
   import { get } from "svelte/store";
   import { apiToken } from "$lib/stores/auth";
   import { getDatasets } from "$lib/repositories/datasets";
+  import { getPageFromParams } from "$lib/util/pagination";
 
   export const load: Load = async ({ fetch, url }) => {
-    const page = +(url.searchParams.get("page") || 1);
+    const page = getPageFromParams(url.searchParams);
 
     const paginatedDatasets = await getDatasets({
       fetch,
@@ -24,10 +25,9 @@
 
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import { page as pageStore } from "$app/stores";
   import type { Dataset } from "src/definitions/datasets";
-  import type { GetPageLink, Paginated } from "src/definitions/pagination";
-  import { patchQueryString, toQueryString } from "$lib/util/urls";
+  import type { Paginated } from "src/definitions/pagination";
+  import { toQueryString } from "$lib/util/urls";
   import { Maybe } from "$lib/util/maybe";
   import DatasetList from "$lib/components/DatasetList/DatasetList.svelte";
   import SearchForm from "$lib/components/SearchForm/SearchForm.svelte";
@@ -42,13 +42,6 @@
     const queryString = toQueryString([["q", q]]);
     const href = `${paths.datasetSearch}${queryString}`;
     goto(href);
-  };
-
-  const getPageLink: GetPageLink = (page) => {
-    const queryString = patchQueryString($pageStore.url.searchParams, [
-      ["page", page.toString()],
-    ]);
-    return `${queryString}`;
   };
 </script>
 
@@ -76,9 +69,8 @@
         <DatasetList datasets={paginatedDatasets.items} />
 
         <PaginationContainer
-          {getPageLink}
-          totalPages={paginatedDatasets.totalPages}
           {currentPage}
+          totalPages={paginatedDatasets.totalPages}
         />
       {/if}
     </div>

--- a/client/src/tests/e2e/search.spec.ts
+++ b/client/src/tests/e2e/search.spec.ts
@@ -70,7 +70,7 @@ test.describe("Search", () => {
     expect(items.length).toBeGreaterThanOrEqual(1);
     expect(items[0].title).toBe(dataset.title);
 
-    await expect(page).toHaveURL("/fiches/search?q=title");
+    await expect(page).toHaveURL("/fiches/search?q=title&page=1");
     await page.locator(`text=/${items.length} résultat(s)?/i`).waitFor();
     await page.locator(`:has-text('${dataset.title}')`).first().waitFor();
 
@@ -88,6 +88,22 @@ test.describe("Search", () => {
     const { items: secondCallItems } = await secondResponse.json();
     expect(secondCallItems.length).toBe(0);
 
-    await expect(page).toHaveURL("/fiches/search?q=noresultsexpected");
+    await expect(page).toHaveURL("/fiches/search?q=noresultsexpected&page=1");
+  });
+
+  test("Visits the search page directly and sees results", async ({
+    page,
+    dataset,
+  }) => {
+    await page.goto(`/fiches/search?q=${dataset.title}`);
+    const search = page.locator("form [name=q]");
+    expect(await search.inputValue()).toBe(dataset.title);
+    await page.locator(`text=/résultat(s)?/i`).waitFor();
+    await page.locator(`:has-text('${dataset.title}')`).first().waitFor();
+  });
+
+  test("Sees the pagination", async ({ page }) => {
+    await page.goto("/fiches/search");
+    await page.locator("[data-testid='pagination-list']").waitFor();
   });
 });


### PR DESCRIPTION
Closes #331 

Correctifs suite à #326 

Bugs rencontrés:

* Si on fait une recherche depuis la page d'accueil, le titre "N résultats" n'est pas affiché
* Si on fait une recherche retournant plusieurs pages, changer de page retire le terme de recherche, car les liens de pagination ne contiennent pas le terme de recherche
* Si on accède à la page directement via par ex http://localhost:8000/fiches/search?q=nom, la barre de recherche n'est pas pré-remplie avec le terme "nom" 
* Si on fait une nouvelle recherche, on reste sur la page précédente (par ex la page 3), au lieu de montrer la page 1.

TODO

* [x] Corriger bugs
* [x] Tests E2E