### PR TITLE
Allow distinguishing when DatasetForm is created without initial values

### DIFF
--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -22,7 +22,7 @@
   import TextareaField from "../TextareaField/TextareaField.svelte";
   import { toSelectOptions } from "src/lib/transformers/form";
   import { handleSelectChange } from "src/lib/util/form";
-  import { type DropMaybe, Maybe, type AddMaybe } from "$lib/util/maybe";
+  import { type DropMaybe, Maybe } from "$lib/util/maybe";
   import TagSelector from "../TagSelector/TagSelector.svelte";
   import type { Tag } from "src/definitions/tag";
 
@@ -31,20 +31,7 @@
   export let loading = false;
   export let tags: Tag[] = [];
 
-  export let initial: AddMaybe<DatasetFormData, "geographicalCoverage"> = {
-    title: "",
-    description: "",
-    service: "",
-    formats: [],
-    producerEmail: "",
-    contactEmails: [$user?.email || ""],
-    geographicalCoverage: null, // Allow select null option upon creation
-    lastUpdatedAt: null,
-    updateFrequency: null,
-    technicalSource: "",
-    url: null,
-    tags: [],
-  };
+  export let initial: DatasetFormData | null = null;
 
   const dispatch =
     createEventDispatcher<{ save: DatasetFormData; touched: boolean }>();
@@ -69,22 +56,22 @@
   );
 
   const initialValues: DatasetFormValues = {
-    title: initial.title,
-    description: initial.description,
-    service: initial.service,
+    title: initial?.title || "",
+    description: initial?.description || "",
+    service: initial?.service || "",
     dataFormats: dataFormatChoices.map(
-      ({ value }) => !!initial.formats.find((v) => v === value)
+      ({ value }) => !!(initial?.formats || []).find((v) => v === value)
     ),
-    producerEmail: initial.producerEmail,
-    contactEmails: initial.contactEmails,
-    lastUpdatedAt: initial.lastUpdatedAt
+    producerEmail: initial?.producerEmail || "",
+    contactEmails: initial?.contactEmails || [$user?.email || ""],
+    lastUpdatedAt: initial?.lastUpdatedAt
       ? formatHTMLDate(initial.lastUpdatedAt)
       : null,
-    geographicalCoverage: initial.geographicalCoverage,
-    updateFrequency: initial.updateFrequency,
-    technicalSource: initial.technicalSource,
-    url: initial.url,
-    tags: initial.tags,
+    geographicalCoverage: initial?.geographicalCoverage || null,
+    updateFrequency: initial?.updateFrequency || null,
+    technicalSource: initial?.technicalSource || null,
+    url: initial?.url || null,
+    tags: initial?.tags || [],
   };
 
   // Handle this value manually.
@@ -339,7 +326,7 @@
   <div class="form--content fr-mb-8w">
     <TagSelector
       error={typeof $errors.tags === "string" ? $errors.tags : ""}
-      selectedTags={initial.tags}
+      selectedTags={initialValues.tags}
       on:change={handleTagsChange}
       name="tags"
       {tags}


### PR DESCRIPTION
Extrait de #311, cf https://github.com/etalab/catalogage-donnees/pull/311#discussion_r913682754

Le `DatasetForm` est utilisé dans 2 contextes:

* Création : `<DatasetForm ... />`
* Edition : `<DatasetForm initial={dataset} ... />`

Vue cette syntaxe, on devrait pouvoir facilement distinguer entre ces 2 contextes par `initial === null`.

Mais actuellement le paramètre `initial` vaut par défaut un objet qui remplit les valeurs par défaut des champs (ex : email de l'utilisateur courant pour `contactEmails`).

Cette PR migre donc vers `let initial = null` et déplace l'initialisation du formulaire vers `initialValues` (qui jusqu'ici se contentait de recopier les valeurs de `initial`).