### PR TITLE
Add license field to API

### DIFF
--- a/client/src/lib/transformers/dataset.ts
+++ b/client/src/lib/transformers/dataset.ts
@@ -29,7 +29,9 @@ export const transformKeysToUnderscoreCase = (object: {
 export const toPayload = (
   data: Partial<Record<keyof Dataset, any>>
 ): { [K: string]: unknown } => {
-  return transformKeysToUnderscoreCase(omit(data, ["catalogRecord"]));
+  const payload = transformKeysToUnderscoreCase(omit(data, ["catalogRecord"]));
+  payload.license = null;
+  return payload;
 };
 
 export const toDataset = (item: any): Dataset => {

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -47,6 +47,7 @@ async def list_datasets(
             format__in=params.format,
             technical_source__in=params.technical_source,
             tag__id__in=params.tag_id,
+            license=params.license,
         ),
     )
 

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -27,6 +27,7 @@ class DatasetListParams:
         format_: Optional[List[DataFormat]] = Query(None, alias="format"),
         technical_source: Optional[List[str]] = Query(None),
         tag_id: Optional[List[ID]] = Query(None),
+        license: Optional[str] = Query(None),
     ) -> None:
         self.q = q
         self.page_number = page_number
@@ -36,6 +37,7 @@ class DatasetListParams:
         self.format = format_
         self.technical_source = technical_source
         self.tag_id = tag_id
+        self.license = license
 
 
 class DatasetCreate(CreateDatasetValidationMixin, BaseModel):
@@ -50,6 +52,7 @@ class DatasetCreate(CreateDatasetValidationMixin, BaseModel):
     update_frequency: Optional[UpdateFrequency] = None
     last_updated_at: Optional[dt.datetime] = None
     url: Optional[str] = None
+    license: Optional[str] = None
     tag_ids: List[ID] = Field(default_factory=list)
 
 
@@ -65,4 +68,5 @@ class DatasetUpdate(UpdateDatasetValidationMixin, BaseModel):
     update_frequency: Optional[UpdateFrequency] = Field(...)
     last_updated_at: Optional[dt.datetime] = Field(...)
     url: Optional[str] = Field(...)
+    license: Optional[str] = Field(...)
     tag_ids: List[ID]

--- a/server/api/licenses/__init__.py
+++ b/server/api/licenses/__init__.py
@@ -1,0 +1,5 @@
+from .routes import router
+
+__all__ = [
+    "router",
+]

--- a/server/api/licenses/routes.py
+++ b/server/api/licenses/routes.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+
+from server.application.licenses.queries import GetLicenseSet
+from server.config.di import resolve
+from server.seedwork.application.messages import MessageBus
+
+from ..auth.dependencies import IsAuthenticated
+
+router = APIRouter(prefix="/licenses", tags=["licenses"])
+
+
+@router.get(
+    "/",
+    dependencies=[Depends(IsAuthenticated())],
+    response_model=List[str],
+)
+async def list_licenses() -> List[str]:
+    bus = resolve(MessageBus)
+    return await bus.execute(GetLicenseSet())

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -5,7 +5,7 @@ from starlette.responses import RedirectResponse
 from server.config import Settings
 from server.config.di import resolve
 
-from . import auth, datasets, tags
+from . import auth, datasets, licenses, tags
 
 router = APIRouter()
 
@@ -20,3 +20,4 @@ def index(
 router.include_router(auth.router)
 router.include_router(datasets.router)
 router.include_router(tags.router)
+router.include_router(licenses.router)

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -26,6 +26,7 @@ class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
     update_frequency: Optional[UpdateFrequency] = None
     last_updated_at: Optional[dt.datetime] = None
     url: Optional[str] = None
+    license: Optional[str] = None
     tag_ids: List[ID] = Field(default_factory=list)
 
 
@@ -42,6 +43,7 @@ class UpdateDataset(UpdateDatasetValidationMixin, Command[None]):
     update_frequency: Optional[UpdateFrequency] = Field(...)
     last_updated_at: Optional[dt.datetime] = Field(...)
     url: Optional[str] = Field(...)
+    license: Optional[str] = Field(...)
     tag_ids: List[ID]
 
 

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -1,3 +1,4 @@
+from server.application.licenses.queries import GetLicenseSet
 from server.application.tags.queries import GetAllTags
 from server.config.di import resolve
 from server.domain.catalog_records.entities import CatalogRecord
@@ -68,6 +69,7 @@ async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFiltersView:
     services = await repository.get_service_set()
     technical_sources = await repository.get_technical_source_set()
     tags = await bus.execute(GetAllTags())
+    licenses = await bus.execute(GetLicenseSet())
 
     return DatasetFiltersView(
         geographical_coverage=list(GeographicalCoverage),
@@ -75,6 +77,7 @@ async def get_dataset_filters(query: GetDatasetFilters) -> DatasetFiltersView:
         format=list(DataFormat),
         technical_source=list(technical_sources),
         tag_id=tags,
+        license=["*", *licenses],
     )
 
 

--- a/server/application/datasets/views.py
+++ b/server/application/datasets/views.py
@@ -29,6 +29,7 @@ class DatasetView(BaseModel):
     update_frequency: Optional[UpdateFrequency]
     last_updated_at: Optional[dt.datetime]
     url: Optional[str]
+    license: Optional[str]
     tags: List[TagView]
 
     # Extras
@@ -41,3 +42,4 @@ class DatasetFiltersView(BaseModel):
     format: List[DataFormat]
     technical_source: List[str]
     tag_id: List[TagView]
+    license: List[str]

--- a/server/application/licenses/handlers.py
+++ b/server/application/licenses/handlers.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from server.config.di import resolve
+from server.domain.datasets.repositories import DatasetRepository
+from server.domain.licenses.entities import BUILTIN_LICENSE_SUGGESTIONS
+
+from .queries import GetLicenseSet
+
+
+async def get_license_set(query: GetLicenseSet) -> List[str]:
+    repository = resolve(DatasetRepository)
+    stored_licenses = await repository.get_license_set()
+    return sorted(BUILTIN_LICENSE_SUGGESTIONS | stored_licenses)

--- a/server/application/licenses/queries.py
+++ b/server/application/licenses/queries.py
@@ -1,0 +1,7 @@
+from typing import List
+
+from server.seedwork.application.queries import Query
+
+
+class GetLicenseSet(Query[List[str]]):
+    pass

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -82,6 +82,7 @@ from .settings import Settings
 MODULES = [
     "server.infrastructure.datasets.module.DatasetsModule",
     "server.infrastructure.tags.module.TagsModule",
+    "server.infrastructure.licenses.module.LicensesModule",
     "server.infrastructure.auth.module.AuthModule",
 ]
 

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -54,6 +54,7 @@ class Dataset(Entity):
     update_frequency: Optional[UpdateFrequency] = None
     last_updated_at: Optional[dt.datetime] = None
     url: Optional[str] = None
+    license: Optional[str] = None
     tags: List[Tag] = Field(default_factory=list)
 
     class Config:
@@ -72,6 +73,7 @@ class Dataset(Entity):
         update_frequency: Optional[UpdateFrequency],
         last_updated_at: Optional[dt.datetime],
         url: Optional[str],
+        license: Optional[str],
         tags: List[Tag],
     ) -> None:
         self.title = title
@@ -85,4 +87,5 @@ class Dataset(Entity):
         self.update_frequency = update_frequency
         self.last_updated_at = last_updated_at
         self.url = url
+        self.license = license
         self.tags = tags

--- a/server/domain/datasets/repositories.py
+++ b/server/domain/datasets/repositories.py
@@ -37,6 +37,9 @@ class DatasetRepository(Repository):
     async def get_technical_source_set(self) -> Set[str]:
         raise NotImplementedError  # pragma: no cover
 
+    async def get_license_set(self) -> Set[str]:
+        raise NotImplementedError  # pragma: no cover
+
     async def insert(self, entity: Dataset) -> ID:
         raise NotImplementedError  # pragma: no cover
 

--- a/server/domain/datasets/specifications.py
+++ b/server/domain/datasets/specifications.py
@@ -14,3 +14,4 @@ class DatasetSpec:
     format__in: Optional[Sequence[DataFormat]] = None
     technical_source__in: Optional[Sequence[str]] = None
     tag__id__in: Optional[Sequence[ID]] = None
+    license: Optional[str] = None

--- a/server/domain/licenses/entities.py
+++ b/server/domain/licenses/entities.py
@@ -1,0 +1,5 @@
+# See: https://www.data.gouv.fr/fr/pages/legal/licences/
+BUILTIN_LICENSE_SUGGESTIONS = {
+    "Licence Ouverte",
+    "ODC Open Database License",
+}

--- a/server/infrastructure/datasets/models.py
+++ b/server/infrastructure/datasets/models.py
@@ -78,6 +78,7 @@ class DatasetModel(Base):
     update_frequency = Column(Enum(UpdateFrequency, enum="update_frequency_enum"))
     last_updated_at = Column(DateTime(timezone=True))
     url = Column(String)
+    license = Column(String)
     tags: List["TagModel"] = relationship(
         "TagModel", back_populates="datasets", secondary=dataset_tag
     )

--- a/server/infrastructure/datasets/queries/get_all.py
+++ b/server/infrastructure/datasets/queries/get_all.py
@@ -78,6 +78,12 @@ class GetAllQuery:
             joinclauses.append((DatasetModel.tags, {"isouter": True}))
             whereclauses.append(TagModel.id.in_(tag_ids))
 
+        if (license := spec.license) is not None:
+            if license == "*":
+                whereclauses.append(DatasetModel.license.is_not(None))
+            else:
+                whereclauses.append(DatasetModel.license == license)
+
         stmt = select(DatasetModel, *columns).join(DatasetModel.catalog_record)
 
         for target, kwargs in joinclauses:

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -81,6 +81,14 @@ class SqlDatasetRepository(DatasetRepository):
             result = await session.execute(stmt)
             return set(result.scalars())
 
+    async def get_license_set(self) -> Set[str]:
+        async with self._db.session() as session:
+            stmt = select(DatasetModel.license.distinct()).where(
+                DatasetModel.license.is_not(None)
+            )
+            result = await session.execute(stmt)
+            return set(result.scalars())
+
     async def _get_catalog_record(
         self, session: AsyncSession, id_: ID
     ) -> CatalogRecordModel:

--- a/server/infrastructure/licenses/module.py
+++ b/server/infrastructure/licenses/module.py
@@ -1,0 +1,9 @@
+from server.application.licenses.handlers import get_license_set
+from server.application.licenses.queries import GetLicenseSet
+from server.seedwork.application.modules import Module
+
+
+class LicensesModule(Module):
+    query_handlers = {
+        GetLicenseSet: get_license_set,
+    }

--- a/server/migrations/versions/1cd8f59f2f0f_add_dataset_license.py
+++ b/server/migrations/versions/1cd8f59f2f0f_add_dataset_license.py
@@ -1,0 +1,23 @@
+"""add-dataset-license
+
+Revision ID: 1cd8f59f2f0f
+Revises: b3dac4035ce9
+Create Date: 2022-06-29 16:09:21.170267
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1cd8f59f2f0f"
+down_revision = "b3dac4035ce9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("dataset", sa.Column("license", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("dataset", "license")

--- a/server/seedwork/application/modules.py
+++ b/server/seedwork/application/modules.py
@@ -5,8 +5,8 @@ from .types import CommandHandlers, QueryHandlers
 
 
 class Module:
-    command_handlers: ClassVar[CommandHandlers]
-    query_handlers: ClassVar[QueryHandlers]
+    command_handlers: ClassVar[CommandHandlers] = {}
+    query_handlers: ClassVar[QueryHandlers] = {}
 
 
 def load_modules(paths: List[str]) -> List[Module]:

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -113,6 +113,7 @@ async def test_dataset_crud(
             update_frequency=UpdateFrequency.WEEKLY,
             last_updated_at=last_updated_at,
             url=None,
+            license="Licence Ouverte",
             tag_ids=[],
         )
     )
@@ -138,6 +139,7 @@ async def test_dataset_crud(
         "update_frequency": "weekly",
         "last_updated_at": last_updated_at.isoformat(),
         "url": None,
+        "license": "Licence Ouverte",
         "tags": [],
         "headlines": None,
     }
@@ -300,6 +302,7 @@ class TestDatasetOptionalFields:
             pytest.param("producer_email", None),
             pytest.param("update_frequency", None),
             pytest.param("last_updated_at", None),
+            pytest.param("license", None),
         ],
     )
     async def test_optional_fields_missing_uses_defaults(
@@ -379,6 +382,7 @@ class TestDatasetUpdate:
             "update_frequency",
             "last_updated_at",
             "url",
+            "license",
             "tag_ids",
         ]
         errors = response.json()["detail"]
@@ -438,23 +442,26 @@ class TestDatasetUpdate:
 
         other_last_updated_at = fake.date_time_tz()
 
+        payload = to_payload(
+            UpdateDatasetFactory.build(
+                title="Other title",
+                description="Other description",
+                service="Other service",
+                geographical_coverage=GeographicalCoverage.REGION,
+                formats=[DataFormat.DATABASE],
+                technical_source="Other information system",
+                producer_email="other.service@mydomain.org",
+                contact_emails=["other.person@mydomain.org"],
+                update_frequency=UpdateFrequency.WEEKLY,
+                last_updated_at=other_last_updated_at.isoformat(),
+                url="https://data.gouv.fr/datasets/other",
+                license="ODC Open Database License",
+                tag_ids=[],
+            )
+        )
+
         response = await client.put(
-            f"/datasets/{dataset_id}/",
-            json={
-                "title": "Other title",
-                "description": "Other description",
-                "service": "Other service",
-                "geographical_coverage": "region",
-                "formats": ["database"],
-                "technical_source": "Other information system",
-                "producer_email": "other.service@mydomain.org",
-                "contact_emails": ["other.person@mydomain.org"],
-                "update_frequency": "weekly",
-                "last_updated_at": other_last_updated_at.isoformat(),
-                "url": "https://data.gouv.fr/datasets/other",
-                "tag_ids": [],
-            },
-            auth=temp_user.auth,
+            f"/datasets/{dataset_id}/", json=payload, auth=temp_user.auth
         )
         assert response.status_code == 200
 
@@ -474,6 +481,7 @@ class TestDatasetUpdate:
             "update_frequency": "weekly",
             "last_updated_at": other_last_updated_at.isoformat(),
             "url": "https://data.gouv.fr/datasets/other",
+            "license": "ODC Open Database License",
             "tags": [],
             "headlines": None,
         }
@@ -492,6 +500,7 @@ class TestDatasetUpdate:
         assert dataset.update_frequency == UpdateFrequency.WEEKLY
         assert dataset.last_updated_at == other_last_updated_at
         assert dataset.url == "https://data.gouv.fr/datasets/other"
+        assert dataset.license == "ODC Open Database License"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_licenses.py
+++ b/tests/api/test_licenses.py
@@ -1,0 +1,33 @@
+import httpx
+import pytest
+
+from server.config.di import resolve
+from server.seedwork.application.messages import MessageBus
+
+from ..factories import CreateDatasetFactory
+from ..helpers import TestUser
+
+
+@pytest.mark.asyncio
+async def test_license_list(client: httpx.AsyncClient, temp_user: TestUser) -> None:
+    bus = resolve(MessageBus)
+
+    response = await client.get("/licenses/", auth=temp_user.auth)
+    assert response.status_code == 200
+    assert response.json() == ["Licence Ouverte", "ODC Open Database License"]
+
+    await bus.execute(CreateDatasetFactory.build(license="Autre licence"))
+
+    response = await client.get("/licenses/", auth=temp_user.auth)
+    assert response.status_code == 200
+    assert response.json() == [
+        "Autre licence",
+        "Licence Ouverte",
+        "ODC Open Database License",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_license_list_permissions(client: httpx.AsyncClient) -> None:
+    response = await client.get("/licenses/")
+    assert response.status_code == 401

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,6 +12,7 @@ from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.tags.commands import CreateTag
 from server.domain.common import datetime as dtutil
 from server.domain.datasets.entities import DataFormat
+from server.domain.licenses.entities import BUILTIN_LICENSE_SUGGESTIONS
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -58,6 +59,7 @@ class CreateDatasetFactory(Factory[CreateDataset]):
         lambda: [fake.ascii_free_email() for _ in range(random.randint(1, 3))]
     )
     url = Use(lambda: fake.url() if random.random() < 0.5 else None)
+    license = Use(random.choice, [None, *BUILTIN_LICENSE_SUGGESTIONS])
     tag_ids = Use(lambda: [])
 
 

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -58,6 +58,7 @@ datasets:
       update_frequency: null
       last_updated_at: null
       url: "https://www.data.gouv.fr/fr/datasets/donnees-brutes-de-l-inventaire-forestier/"
+      license: Licence Ouverte
       tag_ids:
         - "9c1549a5-02ef-43a9-aa20-6babdce0b733"
 
@@ -77,6 +78,7 @@ datasets:
       update_frequency: null
       last_updated_at: null
       url: "https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/"
+      license: Autre (Open)
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
 
@@ -96,6 +98,7 @@ datasets:
       update_frequency: null
       last_updated_at: null
       url: "https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/"
+      license: Licence Ouverte
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
 
@@ -115,4 +118,5 @@ datasets:
       update_frequency: null
       last_updated_at: null
       url: "https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/"
+      license: Licence Ouverte
       tag_ids: []


### PR DESCRIPTION
Extrait de #311 

Pour alléger #311 et pouvoir merger la partie back, cette PR se concentre sur l'ajout du champ `license` à l'API. En effet dans #311 je dois encore m'occuper des tests E2E mais la partie back est sèche.