### PR TITLE
Fix typo in geographical_coverage string migration

### DIFF
--- a/server/migrations/versions/663792a4c86c_update_geographical_coverage_string.py
+++ b/server/migrations/versions/663792a4c86c_update_geographical_coverage_string.py
@@ -43,7 +43,7 @@ def upgrade():
             CASE
                 WHEN geographical_coverage = 'MUNICIPALITY' THEN 'Communale'
                 WHEN geographical_coverage = 'EPCI' THEN 'EPCI'
-                WHEN geographical_coverage = 'DEPARTEMENT' THEN 'Départementale'
+                WHEN geographical_coverage = 'DEPARTMENT' THEN 'Départementale'
                 WHEN geographical_coverage = 'REGION' THEN 'Régionale'
                 WHEN geographical_coverage= 'NATIONAL' THEN 'France'
                 WHEN geographical_coverage= 'NATIONAL_FULL_TERRITORY' THEN 'France entière'


### PR DESCRIPTION
`DEPARTEMENT` -> `DEPARTMENT`

En prod on a des datasets `DEPARTMENT` donc la migration échouait car `geographical_coverage` aurait été mis à `NULL` car aucune valeur ne correspondait.

<details>
<summary>Cliquer pour voir le traceback Ansible</summary>

```
Traceback (most recent call last):
  File "venv/bin/alembic", line 8, in <module>
    sys.exit(main())
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/config.py", line 590, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/config.py", line 584, in main
    self.run_cmd(cfg, options)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/config.py", line 561, in run_cmd
    fn(
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/command.py", line 322, in upgrade
    script.run_env()
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/script/base.py", line 569, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 94, in load_python_file
    module = load_module_py(module_id, path)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 110, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "server/migrations/env.py", line 102, in <module>
    asyncio.run(run_migrations_online())
  File "/root/.pyenv/versions/3.8.9/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/root/.pyenv/versions/3.8.9/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "server/migrations/env.py", line 96, in run_migrations_online
    await connection.run_sync(do_run_migrations)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/ext/asyncio/engine.py", line 546, in run_sync
    return await greenlet_spawn(fn, conn, *arg, **kw)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 128, in greenlet_spawn
    result = context.switch(value)
  File "server/migrations/env.py", line 76, in do_run_migrations
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/runtime/environment.py", line 853, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/runtime/migration.py", line 623, in run_migrations
    step.migration_fn(**kw)
  File "/root/catalogage/server/migrations/versions/663792a4c86c_update_geographical_coverage_string.py", line 39, in upgrade
    op.execute(
  File "<string>", line 8, in execute
  File "<string>", line 3, in execute
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/operations/ops.py", line 2414, in execute
    return operations.invoke(op)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/operations/base.py", line 394, in invoke
    return fn(self, operation)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/operations/toimpl.py", line 207, in execute_sql
    operations.migration_context.impl.execute(
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/ddl/impl.py", line 202, in execute
    self._exec(sql, execution_options)
  File "/root/catalogage/venv/lib/python3.8/site-packages/alembic/ddl/impl.py", line 195, in _exec
    return conn.execute(construct, multiparams)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/future/engine.py", line 280, in execute
    return self._execute_20(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1631, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/sql/elements.py", line 332, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1498, in _execute_clauseelement
    ret = self._execute_context(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1862, in _execute_context
    self._handle_dbapi_exception(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2043, in _handle_dbapi_exception
    util.raise_(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 208, in raise_
    raise exception
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1819, in _execute_context
    self.dialect.do_execute(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
    cursor.execute(statement, parameters)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 479, in execute
    self._adapt_connection.await_(
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 68, in await_only
    return current.driver.switch(awaitable)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 121, in greenlet_spawn
    value = await result
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 454, in _prepare_and_execute
    self._handle_exception(error)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 389, in _handle_exception
    self._adapt_connection._handle_exception(error)
  File "/root/catalogage/venv/lib/python3.8/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 682, in _handle_exception
    raise translated_error from error
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.NotNullViolationError'>: null value in column "geographical_coverage" violates not-null constraint
DETAIL:  Failing row contains (4dbece7c-b8b5-43de-8aeb-f1975e058644, Structures et lieux de diffusion labellisés ou conventionnés a..., Liste des structures et lieux de diffusion (orchestre national, ..., 'actuel':30 'aid':9 'anné':48 'centr':33 'convention':8,40 'dif..., data.snum@culture.gouv.fr, {florent.dubillot@culture.gouv.fr}, DRAC Pays de la Loire, YEARLY, 2021-01-15 00:11:00+00, null, Tableur interne service, null, null).
[SQL: 
        UPDATE dataset
        SET geographical_coverage =
            CASE
                WHEN geographical_coverage = 'MUNICIPALITY' THEN 'Communale'
                WHEN geographical_coverage = 'EPCI' THEN 'EPCI'
                WHEN geographical_coverage = 'DEPARTEMENT' THEN 'Départementale'
                WHEN geographical_coverage = 'REGION' THEN 'Régionale'
                WHEN geographical_coverage= 'NATIONAL' THEN 'France'
                WHEN geographical_coverage= 'NATIONAL_FULL_TERRITORY' THEN 'France entière'
                WHEN geographical_coverage= 'EUROPE' THEN 'Europe'
                WHEN geographical_coverage= 'WORLD' THEN 'Monde'
            END;
        ]
(Background on this error at: https://sqlalche.me/e/14/gkpj)
make: *** [Makefile:52: migrate] Error 1
```

</details>

J'ai revérifié que le `CASE WHEN` reprend exactement les valeurs de l'enum.