### PR TITLE
Add catalog and legacy organization

### DIFF
--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -1,10 +1,13 @@
 from pydantic import EmailStr, SecretStr
 
 from server.domain.common.types import ID
+from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
 
 class CreateUser(Command[ID]):
+    organization_siret: Siret = LEGACY_ORGANIZATION_SIRET
     email: EmailStr
     password: SecretStr
 

--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -35,6 +35,7 @@ async def create_user(
 
     user = User(
         id=id_,
+        organization_siret=command.organization_siret,
         email=email,
         password_hash=password_hash,
         role=role,

--- a/server/application/auth/views.py
+++ b/server/application/auth/views.py
@@ -2,16 +2,19 @@ from pydantic import BaseModel
 
 from server.domain.auth.entities import UserRole
 from server.domain.common.types import ID
+from server.domain.organizations.types import Siret
 
 
 class UserView(BaseModel):
     id: ID
+    organization_siret: Siret
     email: str
     role: UserRole
 
 
 class AuthenticatedUserView(BaseModel):
     id: ID
+    organization_siret: Siret
     email: str
     role: UserRole
     api_token: str

--- a/server/application/catalog_records/views.py
+++ b/server/application/catalog_records/views.py
@@ -3,8 +3,10 @@ import datetime as dt
 from pydantic import BaseModel
 
 from server.domain.common.types import ID
+from server.domain.organizations.types import Siret
 
 
 class CatalogRecordView(BaseModel):
     id: ID
+    organization_siret: Siret
     created_at: dt.datetime

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -5,12 +5,15 @@ from pydantic import EmailStr, Field
 
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
+from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
 from .validation import CreateDatasetValidationMixin, UpdateDatasetValidationMixin
 
 
 class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
+    organization_siret: Siret = LEGACY_ORGANIZATION_SIRET
     title: str
     description: str
     service: str

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -25,7 +25,10 @@ async def create_dataset(command: CreateDataset, *, id_: ID = None) -> ID:
         id_ = repository.make_id()
 
     catalog_record_id = await catalog_record_repository.insert(
-        CatalogRecord(id=catalog_record_repository.make_id())
+        CatalogRecord(
+            id=catalog_record_repository.make_id(),
+            organization_siret=command.organization_siret,
+        )
     )
     catalog_record = await catalog_record_repository.get_by_id(catalog_record_id)
     assert catalog_record is not None

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -86,6 +86,7 @@ MODULES = [
     "server.infrastructure.tags.module.TagsModule",
     "server.infrastructure.licenses.module.LicensesModule",
     "server.infrastructure.organizations.module.OrganizationsModule",
+    "server.infrastructure.catalogs.module.CatalogsModule",
     "server.infrastructure.auth.module.AuthModule",
 ]
 

--- a/server/domain/auth/entities.py
+++ b/server/domain/auth/entities.py
@@ -3,6 +3,7 @@ import enum
 from server.seedwork.domain.entities import Entity
 
 from ..common.types import ID
+from ..organizations.types import Siret
 
 
 class UserRole(enum.Enum):
@@ -12,6 +13,7 @@ class UserRole(enum.Enum):
 
 class User(Entity):
     id: ID
+    organization_siret: Siret
     email: str
     password_hash: str
     role: UserRole

--- a/server/domain/catalog_records/entities.py
+++ b/server/domain/catalog_records/entities.py
@@ -6,8 +6,10 @@ from server.seedwork.domain.entities import Entity
 
 from ..common import datetime as dtutil
 from ..common.types import ID
+from ..organizations.types import Siret
 
 
 class CatalogRecord(Entity):
     id: ID
+    organization_siret: Siret
     created_at: dt.datetime = Field(default_factory=dtutil.now)

--- a/server/domain/catalogs/entities.py
+++ b/server/domain/catalogs/entities.py
@@ -1,0 +1,7 @@
+from server.seedwork.domain.entities import Entity
+
+from ..organizations.types import Siret
+
+
+class Catalog(Entity):
+    organization_siret: Siret

--- a/server/domain/organizations/entities.py
+++ b/server/domain/organizations/entities.py
@@ -6,3 +6,9 @@ from .types import Siret
 class Organization(Entity):
     name: str
     siret: Siret
+
+
+# A fake SIRET used for the organization that holds legacy users and whose catalog holds
+# legacy datasets. "Legacy" means "before the multi-org system powered by DataPass.
+# Going forward SIRET numbers will come from DataPass via the user's organization(s).
+LEGACY_ORGANIZATION_SIRET = Siret("000 000 000 00000")

--- a/server/infrastructure/catalog_records/repositories.py
+++ b/server/infrastructure/catalog_records/repositories.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, DateTime, func, select
+from sqlalchemy import CHAR, Column, DateTime, ForeignKey, func, select
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import relationship
@@ -9,10 +9,12 @@ from sqlalchemy.orm import relationship
 from server.domain.catalog_records.entities import CatalogRecord
 from server.domain.catalog_records.repositories import CatalogRecordRepository
 from server.domain.common.types import ID
+from server.domain.organizations.types import Siret
 
 from ..database import Base, Database
 
 if TYPE_CHECKING:
+    from ..catalogs.models import CatalogModel
     from ..datasets.models import DatasetModel
 
 
@@ -23,17 +25,27 @@ class CatalogRecordModel(Base):
     created_at: dt.datetime = Column(
         DateTime(timezone=True), server_default=func.clock_timestamp(), nullable=False
     )
+    organization_siret: Siret = Column(
+        CHAR(14),
+        ForeignKey("catalog.organization_siret"),
+        nullable=False,
+    )
+
+    catalog: "CatalogModel" = relationship(
+        "CatalogModel",
+        back_populates="catalog_records",
+    )
 
     dataset: "DatasetModel" = relationship(
         "DatasetModel",
         back_populates="catalog_record",
-        cascade="delete",
     )
 
 
 def make_entity(instance: CatalogRecordModel) -> CatalogRecord:
     return CatalogRecord(
         id=instance.id,
+        organization_siret=instance.organization_siret,
         created_at=instance.created_at,
     )
 

--- a/server/infrastructure/catalogs/models.py
+++ b/server/infrastructure/catalogs/models.py
@@ -1,0 +1,37 @@
+import datetime as dt
+from typing import TYPE_CHECKING, List
+
+from sqlalchemy import CHAR, Column, DateTime, ForeignKey, func
+from sqlalchemy.orm import relationship
+
+from server.domain.organizations.types import Siret
+
+from ..database import Base
+
+if TYPE_CHECKING:
+    from ..catalog_records.repositories import CatalogRecordModel
+    from ..organizations.models import OrganizationModel
+
+
+class CatalogModel(Base):
+    __tablename__ = "catalog"
+
+    organization_siret: Siret = Column(
+        CHAR(14),
+        ForeignKey("organization.siret"),
+        primary_key=True,
+    )
+    organization: "OrganizationModel" = relationship(
+        "OrganizationModel",
+        back_populates="catalog",
+    )
+    created_at: dt.datetime = Column(
+        DateTime(timezone=True),
+        server_default=func.clock_timestamp(),
+        nullable=False,
+    )
+
+    catalog_records: List["CatalogRecordModel"] = relationship(
+        "CatalogRecordModel",
+        back_populates="catalog",
+    )

--- a/server/infrastructure/catalogs/module.py
+++ b/server/infrastructure/catalogs/module.py
@@ -1,0 +1,7 @@
+from server.seedwork.application.modules import Module
+
+from . import models  # noqa  # Trigger SQLAlchemy table discovery.
+
+
+class CatalogsModule(Module):
+    pass

--- a/server/infrastructure/organizations/models.py
+++ b/server/infrastructure/organizations/models.py
@@ -1,8 +1,15 @@
+from typing import TYPE_CHECKING, List
+
 from sqlalchemy import CHAR, Column, String
+from sqlalchemy.orm import relationship
 
 from server.domain.organizations.types import Siret
 
 from ..database import Base
+
+if TYPE_CHECKING:
+    from ..auth.repositories import UserModel
+    from ..catalogs.models import CatalogModel
 
 
 class OrganizationModel(Base):
@@ -10,3 +17,14 @@ class OrganizationModel(Base):
 
     siret: Siret = Column(CHAR(14), primary_key=True)
     name: str = Column(String(), nullable=False)
+
+    catalog: "CatalogModel" = relationship(
+        "CatalogModel",
+        back_populates="organization",
+        uselist=False,
+    )
+
+    users: List["UserModel"] = relationship(
+        "UserModel",
+        back_populates="organization",
+    )

--- a/server/migrations/versions/4e40358ad25c_add_catalog.py
+++ b/server/migrations/versions/4e40358ad25c_add_catalog.py
@@ -1,0 +1,34 @@
+"""add-catalog
+
+Revision ID: 4e40358ad25c
+Revises: da164fd0fa6f
+Create Date: 2022-07-19 15:03:34.512545
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4e40358ad25c"
+down_revision = "da164fd0fa6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "catalog",
+        sa.Column("organization_siret", sa.CHAR(length=14), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("clock_timestamp()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["organization_siret"], ["organization.siret"]),
+        sa.PrimaryKeyConstraint("organization_siret"),
+    )
+
+
+def downgrade():
+    op.drop_table("catalog")

--- a/server/migrations/versions/f2ef4eef61e3_create_legacy_organization.py
+++ b/server/migrations/versions/f2ef4eef61e3_create_legacy_organization.py
@@ -1,0 +1,66 @@
+"""create-legacy-organization
+
+Revision ID: f2ef4eef61e3
+Revises: 4e40358ad25c
+Create Date: 2022-07-20 16:43:10.140605
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2ef4eef61e3"
+down_revision = "4e40358ad25c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create initial organization.
+    op.execute(
+        "INSERT INTO organization (siret, name) "
+        "VALUES ('00000000000000', 'Organisation par défaut');"
+    )
+
+    # Add all users to it.
+    op.add_column("user", sa.Column("organization_siret", sa.CHAR(14)))
+    op.execute("UPDATE \"user\" SET organization_siret = '00000000000000';")
+    op.alter_column("user", "organization_siret", nullable=False)
+    op.create_foreign_key(
+        "user_organization_siret_fkey",
+        "user",
+        "organization",
+        ["organization_siret"],
+        ["siret"],
+    )
+
+    # Create its catalog.
+    op.execute("INSERT INTO catalog (organization_siret) VALUES ('00000000000000');")
+
+    # Add all catalog records to it.
+    op.add_column("catalog_record", sa.Column("organization_siret", sa.CHAR(14)))
+    op.execute("UPDATE catalog_record SET organization_siret = '00000000000000';")
+    op.alter_column("catalog_record", "organization_siret", nullable=False)
+    op.create_foreign_key(
+        "catalog_record_organization_siret_fkey",
+        "catalog_record",
+        "catalog",
+        ["organization_siret"],
+        ["organization_siret"],
+    )
+
+
+def downgrade():
+    # Drop link between users and legacy organization.
+    op.drop_constraint("user_organization_siret_fkey", "user", type_="foreignkey")
+    op.drop_column("user", "organization_siret")
+
+    # Drop link between catalog records and legacy organization.
+    op.drop_constraint(
+        "catalog_record_organization_siret_fkey", "catalog_record", type_="foreignkey"
+    )
+    op.drop_column("catalog_record", "organization_siret")
+
+    # Delete legacy catalog, then legacy organization.
+    op.execute("DELETE FROM catalog WHERE organization_siret = '00000000000000';")
+    op.execute("DELETE FROM organization WHERE siret = '00000000000000';")

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -8,6 +8,7 @@ from server.application.auth.queries import GetUserByEmail
 from server.config.di import resolve
 from server.domain.auth.exceptions import UserDoesNotExist
 from server.domain.common.types import id_factory
+from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
 from server.seedwork.application.messages import MessageBus
 
 from ..helpers import TestUser
@@ -86,7 +87,12 @@ async def test_create_user(
     user = response.json()
     id_ = user["id"]
     assert isinstance(id_, str)
-    assert user == {"id": id_, "email": "john@doe.com", "role": "USER"}
+    assert user == {
+        "id": id_,
+        "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+        "email": "john@doe.com",
+        "role": "USER",
+    }
 
 
 @pytest.mark.asyncio
@@ -106,6 +112,7 @@ async def test_login(client: httpx.AsyncClient, temp_user: TestUser) -> None:
     user = response.json()
     assert user == {
         "id": str(temp_user.id),
+        "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
         "email": temp_user.email,
         "role": temp_user.role.value,
         "api_token": temp_user.api_token,

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -11,6 +11,7 @@ from server.config.di import resolve
 from server.domain.common.types import id_factory
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.datasets.exceptions import DatasetDoesNotExist
+from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateDatasetFactory
 
@@ -123,7 +124,10 @@ async def test_dataset_crud(
 
     assert data == {
         "id": pk,
-        "catalog_record": data["catalog_record"],
+        "catalog_record": {
+            **data["catalog_record"],
+            "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+        },
         "title": "Example title",
         "description": "Example description",
         "service": "Example service",
@@ -461,7 +465,10 @@ class TestDatasetUpdate:
         data = response.json()
         assert data == {
             "id": str(dataset_id),
-            "catalog_record": data["catalog_record"],
+            "catalog_record": {
+                **data["catalog_record"],
+                "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+            },
             "title": "Other title",
             "description": "Other description",
             "service": "Other service",

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,6 +14,7 @@ from server.application.tags.commands import CreateTag
 from server.domain.common import datetime as dtutil
 from server.domain.datasets.entities import DataFormat
 from server.domain.licenses.entities import BUILTIN_LICENSE_SUGGESTIONS
+from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -40,6 +41,8 @@ class Factory(ModelFactory[T]):
 class CreateUserFactory(Factory[CreateUser]):
     __model__ = CreateUser
 
+    organization_siret = Use(lambda: LEGACY_ORGANIZATION_SIRET)
+
 
 class CreateTagFactory(Factory[CreateTag]):
     __model__ = CreateTag
@@ -48,6 +51,7 @@ class CreateTagFactory(Factory[CreateTag]):
 class CreateDatasetFactory(Factory[CreateDataset]):
     __model__ = CreateDataset
 
+    organization_siret = Use(lambda: LEGACY_ORGANIZATION_SIRET)
     title = Use(fake.sentence)
     description = Use(fake.text)
     service = Use(fake.company)

--- a/tests/infrastructure/test_catalogs.py
+++ b/tests/infrastructure/test_catalogs.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import EmailStr
+
+from server.application.auth.queries import GetUserByEmail
+from server.application.datasets.queries import GetDatasetByID
+from server.config.di import resolve
+from server.domain.organizations.types import Siret
+from server.infrastructure.catalogs.models import CatalogModel
+from server.infrastructure.database import Database
+from server.infrastructure.organizations.repositories import OrganizationModel
+from server.seedwork.application.messages import MessageBus
+
+from ..factories import CreateDatasetFactory, CreateUserFactory
+
+
+@pytest.mark.asyncio
+async def test_catalog_creation_and_relationships() -> None:
+    bus = resolve(MessageBus)
+    db = resolve(Database)
+
+    siret = Siret("123 456 789 12345")
+
+    # Create an organization...
+    async with db.session() as session:
+        session.add(OrganizationModel(siret=siret, name="Example organization"))
+        await session.commit()
+
+    # And its catalog...
+    async with db.session() as session:
+        session.add(CatalogModel(organization_siret=siret))
+        await session.commit()
+
+    # Add a user to the organization...
+    email = "test@mydomain.org"
+    await bus.execute(CreateUserFactory.build(organization_siret=siret, email=email))
+
+    user = await bus.execute(GetUserByEmail(email=EmailStr("test@mydomain.org")))
+    assert user.organization_siret == siret
+
+    # Add a dataset to the catalog...
+    dataset_id = await bus.execute(CreateDatasetFactory.build(organization_siret=siret))
+
+    dataset = await bus.execute(GetDatasetByID(id=dataset_id))
+    assert dataset.catalog_record.organization_siret == siret


### PR DESCRIPTION
Closes #356 

TODO

* [x] Migration pour créer la table `Catalog`
* [x] Migration pour créer et remplir l'organisation "legacy"
* [x] Tests back basiques
* [x] Validation manuelle du rollback de migrations : `make migrate` puis `alembic downgrade head-2`.
* [x] Tester sur staging

## Description

* Cette PR ajoute une entité `Catalog` qui fait le lien entre 1 `Organization` et N `CatalogRecord`.
* Une migration est créée pour cette table `catalog`.
* Une migration de données est créée pour ajouter une organization "legacy" dont le SIRET (factice) est 000 000 000 00000, ainsi que son catalogue. Elle y rattache tous les utilisateurs et les jeux de données existants.
* La création de jeux de données ou d'utilisateurs se fait systématiquement sur l'orga "legacy" pour l'instant.

## Impact sur les environnements déployés

D'une manière générale, aucun changement UI (cf les tests E2E qui passent sans modif). Toutes les données existantes sont conservées.

Sur https://catalogue.multi.coop, les utilisateurs existants (nous ou le MC) seront donc rattachés en coulisses à l'orga "legacy", de même pour les jeux de données qui seront rattachés au catalogue de l'orga factice.
 
## Perspectives pour la suite

Une fois qu'une organisation sera créée via le repo de config (cf #334) et l'intégration DataPass réalisée (cf #124) :

* Pour les utilisateurs, le SIRET de l'orga cible proviendra de DataPass

Une fois qu'un catalogue sera créé via le repo de config (cf #284) :

* Pour les jeux de données, le SIRET de l'orga cible sera envoyé avec la requête (champ de formulaire "Nom de l'organisation" grisé et configuré sur l'orga de l'utilisateur).

## Checklist critères d'acceptation

NB : aucune modification frontend, cette PR prépare seulement le terrain en back

Voici les critères de #284 que cette PR remplit :

* :heavy_check_mark: Une organisation peut avoir 0 ou 1 catalogue. Une organisation peut exister sans catalogue (i.e. un catalogue peut être créé au moment de ou après la création de son organisation).
* :heavy_check_mark: Une organisation est identifiée par un numéro SIRET.
* :heavy_check_mark: A sa création, un catalogue ne contient aucune entrée (fiche jeu de données). Les fiches doivent être créées par les contributeurs dans l'outil. (L'import d'un catalogue avec l'interface n'est pas un must have de ce ticket.)