### PR TITLE
Swap 1-1 relationship between dataset and catalog_record

### DIFF
--- a/server/infrastructure/catalog_records/repositories.py
+++ b/server/infrastructure/catalog_records/repositories.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, func, select
+from sqlalchemy import Column, DateTime, func, select
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import relationship
@@ -20,13 +20,14 @@ class CatalogRecordModel(Base):
     __tablename__ = "catalog_record"
 
     id: ID = Column(UUID(as_uuid=True), primary_key=True)
-    dataset_id: ID = Column(UUID(as_uuid=True), ForeignKey("dataset.id"))
+    created_at: dt.datetime = Column(
+        DateTime(timezone=True), server_default=func.clock_timestamp(), nullable=False
+    )
+
     dataset: "DatasetModel" = relationship(
         "DatasetModel",
         back_populates="catalog_record",
-    )
-    created_at: dt.datetime = Column(
-        DateTime(timezone=True), server_default=func.clock_timestamp(), nullable=False
+        cascade="delete",
     )
 
 

--- a/server/infrastructure/datasets/models.py
+++ b/server/infrastructure/datasets/models.py
@@ -49,11 +49,15 @@ class DatasetModel(Base):
 
     id: uuid.UUID = Column(UUID(as_uuid=True), primary_key=True)
 
+    catalog_record_id: uuid.UUID = Column(
+        UUID(as_uuid=True),
+        ForeignKey("catalog_record.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     catalog_record: "CatalogRecordModel" = relationship(
         "CatalogRecordModel",
         back_populates="dataset",
         cascade="delete",
-        lazy="joined",
         uselist=False,
     )
 

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Set, Tuple
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import contains_eager, selectinload
 
 from server.domain.common.pagination import Page
 from server.domain.common.types import ID
@@ -48,8 +48,10 @@ class SqlDatasetRepository(DatasetRepository):
     ) -> Optional[DatasetModel]:
         stmt = (
             select(DatasetModel)
+            .join(DatasetModel.catalog_record)
             .where(DatasetModel.id == id)
             .options(
+                contains_eager(DatasetModel.catalog_record),
                 selectinload(DatasetModel.formats),
                 selectinload(DatasetModel.tags),
             )

--- a/server/migrations/versions/da164fd0fa6f_swap_dataset_catalog_record_fk.py
+++ b/server/migrations/versions/da164fd0fa6f_swap_dataset_catalog_record_fk.py
@@ -1,0 +1,74 @@
+"""swap-dataset-catalog_record-fk
+
+Revision ID: da164fd0fa6f
+Revises: d9ea6ea6708f
+Create Date: 2022-07-19 16:25:43.333190
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "da164fd0fa6f"
+down_revision = "d9ea6ea6708f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop old FK constraint.
+    op.drop_constraint(
+        "catalog_record_dataset_id_fkey",
+        "catalog_record",
+        type_="foreignkey",
+    )
+
+    # Add and fill new FK column and constraint.
+    op.add_column(
+        "dataset",
+        sa.Column("catalog_record_id", postgresql.UUID(as_uuid=True)),
+    )
+    op.execute(
+        "UPDATE dataset SET catalog_record_id = catalog_record.id "
+        "FROM dataset AS d JOIN catalog_record ON d.id = catalog_record.dataset_id "
+        "WHERE d.id = dataset.id;"
+    )
+    op.alter_column("dataset", "catalog_record_id", nullable=False)
+    op.create_foreign_key(
+        "dataset_catalog_record_id_fkey",
+        "dataset",
+        "catalog_record",
+        ["catalog_record_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Drop old FK column.
+    op.drop_column("catalog_record", "dataset_id")
+
+
+def downgrade():
+    # Drop new FK constraint.
+    op.drop_constraint("dataset_catalog_record_id_fkey", "dataset", type_="foreignkey")
+
+    # Bring back and fill old FK column and constraint.
+    op.add_column(
+        "catalog_record",
+        sa.Column("dataset_id", postgresql.UUID(), autoincrement=False, nullable=True),
+    )
+    op.execute(
+        "UPDATE catalog_record SET dataset_id = dataset.id "
+        "FROM catalog_record AS cr JOIN dataset ON cr.id = dataset.catalog_record_id "
+        "WHERE cr.id = catalog_record.id;"
+    )
+    op.create_foreign_key(
+        "catalog_record_dataset_id_fkey",
+        "catalog_record",
+        "dataset",
+        ["dataset_id"],
+        ["id"],
+    )
+
+    # Drop new FK column.
+    op.drop_column("dataset", "catalog_record_id")


### PR DESCRIPTION
Extrait de #351 

La relation entre `dataset` et `catalog_record` était jusqu'ici dans le sens `catalog_record -> dataset` (via `catalog_record.dataset_id`), de sorte que dans #351 on se retrouve avec cette structure:

```
user -> organization <- catalog <- catalog_record -> dataset
```

C'est problématique car on ne peut alors pas faire appliquer de cascade jusqu'à `dataset` lorsqu'un `catalog` ou une `organization` est supprimée. Pour l'instant, la cascade "supprimer le catalog_record lorsqu'un dataset est supprimé" est appliquée par SQLAlchemy. Mais quand une `organization` est supprimée par exemple, la cascade se déroule en BDD (car on traverse plusieurs relations).

Cette PR inverse donc le sens pour s'aligner sur le sens qui sera employé pour remonter jusqu'à l'organisation : `dataset -> catalog_record` (via `dataset.catalog_record_id`)

```
user -> organization <- catalog <- catalog_record <- dataset
```
