### PR TITLE
Run CI on any PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: ["master"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Cette PR modifie la config GitHub Actions de sorte que la CI se lance aussi sur des PR qui visent d'autres branches que `master`.

En effet actuellement la CI n'est pas lancée pour les PR qui visent une autre PR (enchaînement de PR dépendantes entre elles).