### PR TITLE
Add soft-delete

### DIFF
--- a/server/infrastructure/deletion/helpers.py
+++ b/server/infrastructure/deletion/helpers.py
@@ -1,0 +1,74 @@
+import json
+from typing import Any
+
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy import cast, delete, func, insert, literal, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.domain.common.types import id_factory
+
+from .models import DeletedRecordModel
+
+
+async def soft_delete(session: AsyncSession, instance: Any) -> None:
+    model = type(instance)
+
+    await _soft_delete_tablelike(
+        session,
+        model,
+        table_name=model.__tablename__,
+        where=model.id == instance.id,
+        pk_jsonb={"id": instance.id},
+    )
+
+
+async def soft_delete_table(
+    session: AsyncSession,
+    table: Any,
+    where: Any,
+    pk_jsonb: Any,
+) -> None:
+    await _soft_delete_tablelike(
+        session,
+        table,
+        table_name=table.name,
+        where=where,
+        pk_jsonb=pk_jsonb,
+    )
+
+
+async def _soft_delete_tablelike(
+    session: AsyncSession,
+    tablelike: Any,
+    table_name: str,
+    where: Any,
+    pk_jsonb: Any,
+) -> None:
+    # Prefer soft-deleting by moving rows to an archival table, to avoid pitfalls and
+    # drawbacks of the more common "deleted_at = now()" style.
+    #
+    # This style:
+    # * Does not pollute tables with a `.deleted_at` column or queries with a
+    #  `WHERE deleted_at is NULL` check.
+    # * Enforces foreign keys: soft-deleting without deleting related rows beforehand
+    #   is an error.
+    # * Allows physical deletion by deleting a time window of deleted records.
+    #
+    # See: https://brandur.org/soft-deletion
+    # See: https://news.ycombinator.com/item?id=32156009
+    # See "Conclusion" here: https://blog.miguelgrinberg.com/post/implementing-the-soft-delete-pattern-with-flask-and-sqlalchemy  # noqa: E501
+
+    deleted_cte = delete(tablelike).where(where).returning(tablelike).cte("deleted_cte")
+
+    upsert = insert(DeletedRecordModel).from_select(
+        ["id", "original_table", "original_pk", "data"],
+        select(
+            literal(id_factory()),
+            literal(table_name),
+            cast(literal(json.dumps(jsonable_encoder(pk_jsonb))), JSONB),
+            func.to_jsonb(deleted_cte.table_valued()),
+        ),
+    )
+
+    await session.execute(upsert)

--- a/server/infrastructure/deletion/models.py
+++ b/server/infrastructure/deletion/models.py
@@ -1,0 +1,23 @@
+import datetime as dt
+import uuid
+
+from sqlalchemy import Column, DateTime, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from ..database import Base
+
+
+class DeletedRecordModel(Base):
+    """
+    A table of deleted records, for archival, auditing and troubleshooting purposes.
+    """
+
+    __tablename__ = "deleted_record"
+
+    id: uuid.UUID = Column(UUID(as_uuid=True), primary_key=True)
+    deleted_at: dt.datetime = Column(
+        DateTime(timezone=True), server_default=func.clock_timestamp(), nullable=False
+    )
+    original_table = Column(String(), nullable=False)
+    original_pk: dict = Column(JSONB(), nullable=False)
+    data: dict = Column(JSONB(), nullable=False)

--- a/server/migrations/versions/d96fa1116f66_add_deleted_record.py
+++ b/server/migrations/versions/d96fa1116f66_add_deleted_record.py
@@ -1,0 +1,39 @@
+"""add-deleted_record
+
+Revision ID: d96fa1116f66
+Revises: d9ea6ea6708f
+Create Date: 2022-07-20 13:14:31.542990
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "d96fa1116f66"
+down_revision = "d9ea6ea6708f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "deleted_record",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("clock_timestamp()"),
+            nullable=False,
+        ),
+        sa.Column("original_table", sa.String(), nullable=False),
+        sa.Column(
+            "original_pk", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("deleted_record")


### PR DESCRIPTION
À réfléchir.

Pour l'instant, la suppression de données (jeux de données, utilisateurs) est définitive.

Pour des besoins d'audit ou de débogage, cela peut être problématique en cas d'erreur utilisateur (suppression d'une donnée importante) ou de dev (mauvaise configuration de cascades SQL qui supprime une vaste quantité de données -- déjà vu par le passé, c'est pas la joie...).

Une solution classique est la "soft-deletion" : archiver les données pendant un temps plutôt que les supprimer définitivement tout de suite.

Cette PR l'implémente avec une table `deleted_record` où sont archivées les entrées supprimées. Pour l'instant cela concerne les jeux de données (Suppression par un admin) ou les utilisateurs (il y a un endpoint `DELETE /users/{id}/` mais je ne suis pas sûr qu'il soit utilisé ; peut-être à retirer).