### PR TITLE
Split User into Account and PasswordUser

### DIFF
--- a/server/api/auth/backends/token.py
+++ b/server/api/auth/backends/token.py
@@ -8,9 +8,9 @@ from starlette.authentication import (
 )
 from starlette.requests import HTTPConnection
 
-from server.application.auth.queries import GetUserByAPIToken
+from server.application.auth.queries import GetAccountByAPIToken
 from server.config.di import resolve
-from server.domain.auth.exceptions import UserDoesNotExist
+from server.domain.auth.exceptions import AccountDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
 from ..models import ApiUser
@@ -44,11 +44,11 @@ class TokenAuthBackend(AuthenticationBackend):
 
         bus = resolve(MessageBus)
 
-        query = GetUserByAPIToken(api_token=api_token)
+        query = GetAccountByAPIToken(api_token=api_token)
 
         try:
-            user = await bus.execute(query)
-        except UserDoesNotExist:
+            account = await bus.execute(query)
+        except AccountDoesNotExist:
             raise AuthenticationError()
 
-        return AuthCredentials(scopes=["authenticated"]), ApiUser(user)
+        return AuthCredentials(scopes=["authenticated"]), ApiUser(account)

--- a/server/api/auth/models.py
+++ b/server/api/auth/models.py
@@ -2,29 +2,29 @@ from typing import Optional
 
 from starlette.authentication import BaseUser
 
-from server.application.auth.views import UserView
+from server.application.auth.views import AccountView
 
 
 class ApiUser(BaseUser):
-    def __init__(self, user: Optional[UserView]) -> None:
-        self._user = user
+    def __init__(self, account: Optional[AccountView]) -> None:
+        self._account = account
 
     @property
-    def obj(self) -> UserView:
-        if self._user is None:
+    def account(self) -> AccountView:
+        if self._account is None:
             raise RuntimeError(
-                "Cannot access .obj, as the user is anonymous. "
+                "Cannot access .account, as the user is anonymous. "
                 "Hint: did you forget to check for .is_authenticated?"
             )
 
-        return self._user
+        return self._account
 
     # Implement the 'BaseUser' interface.
 
     @property
     def is_authenticated(self) -> bool:
-        return self._user is not None
+        return self._account is not None
 
     @property
     def display_name(self) -> str:
-        return self._user.email if self._user is not None else ""
+        return self._account.email if self._account is not None else ""

--- a/server/api/auth/permissions.py
+++ b/server/api/auth/permissions.py
@@ -130,7 +130,7 @@ class HasRole(BasePermission):
                 "Hint: use IsAuthenticated() & HasRole(...)"
             )
 
-        return request.user.obj.role in self._roles
+        return request.user.account.role in self._roles
 
 
 def _patch_openapi_security_params(*permissions: BasePermission) -> Callable:

--- a/server/api/auth/schemas.py
+++ b/server/api/auth/schemas.py
@@ -3,12 +3,12 @@ from typing import Literal
 from pydantic import BaseModel, EmailStr, SecretStr
 
 
-class UserCreate(BaseModel):
+class PasswordUserCreate(BaseModel):
     email: EmailStr
     password: SecretStr
 
 
-class UserLogin(BaseModel):
+class PasswordUserLogin(BaseModel):
     email: EmailStr
     password: SecretStr
 

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -6,14 +6,14 @@ from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
 
-class CreateUser(Command[ID]):
+class CreatePasswordUser(Command[ID]):
     organization_siret: Siret = LEGACY_ORGANIZATION_SIRET
     email: EmailStr
     password: SecretStr
 
 
-class DeleteUser(Command[None]):
-    id: ID
+class DeletePasswordUser(Command[None]):
+    account_id: ID
 
 
 class ChangePassword(Command[None]):

--- a/server/application/auth/queries.py
+++ b/server/application/auth/queries.py
@@ -1,17 +1,17 @@
 from pydantic import EmailStr, SecretStr
 
-from server.application.auth.views import AuthenticatedUserView, UserView
+from server.application.auth.views import AccountView, AuthenticatedAccountView
 from server.seedwork.application.queries import Query
 
 
-class Login(Query[AuthenticatedUserView]):
+class LoginPasswordUser(Query[AuthenticatedAccountView]):
     email: EmailStr
     password: SecretStr
 
 
-class GetUserByEmail(Query[UserView]):
+class GetAccountByEmail(Query[AccountView]):
     email: EmailStr
 
 
-class GetUserByAPIToken(Query[UserView]):
+class GetAccountByAPIToken(Query[AccountView]):
     api_token: str

--- a/server/application/auth/views.py
+++ b/server/application/auth/views.py
@@ -5,14 +5,14 @@ from server.domain.common.types import ID
 from server.domain.organizations.types import Siret
 
 
-class UserView(BaseModel):
+class AccountView(BaseModel):
     id: ID
     organization_siret: Siret
     email: str
     role: UserRole
 
 
-class AuthenticatedUserView(BaseModel):
+class AuthenticatedAccountView(BaseModel):
     id: ID
     organization_siret: Siret
     email: str

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -60,14 +60,17 @@ Or in any custom scripts as seems fit.
 """
 
 from server.application.auth.passwords import PasswordEncoder
-from server.domain.auth.repositories import UserRepository
+from server.domain.auth.repositories import AccountRepository, PasswordUserRepository
 from server.domain.catalog_records.repositories import CatalogRecordRepository
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.organizations.repositories import OrganizationRepository
 from server.domain.tags.repositories import TagRepository
 from server.infrastructure.adapters.messages import MessageBusAdapter
 from server.infrastructure.auth.passwords import Argon2PasswordEncoder
-from server.infrastructure.auth.repositories import SqlUserRepository
+from server.infrastructure.auth.repositories import (
+    SqlAccountRepository,
+    SqlPasswordUserRepository,
+)
 from server.infrastructure.catalog_records.repositories import (
     SqlCatalogRecordRepository,
 )
@@ -133,7 +136,8 @@ def configure(container: "Container") -> None:
 
     # Repositories
 
-    container.register_instance(UserRepository, SqlUserRepository(db))
+    container.register_instance(AccountRepository, SqlAccountRepository(db))
+    container.register_instance(PasswordUserRepository, SqlPasswordUserRepository(db))
     container.register_instance(CatalogRecordRepository, SqlCatalogRecordRepository(db))
     container.register_instance(DatasetRepository, SqlDatasetRepository(db))
     container.register_instance(TagRepository, SqlTagRepository(db))

--- a/server/domain/auth/entities.py
+++ b/server/domain/auth/entities.py
@@ -11,19 +11,24 @@ class UserRole(enum.Enum):
     ADMIN = "ADMIN"
 
 
-class User(Entity):
+class Account(Entity):
     id: ID
     organization_siret: Siret
     email: str
-    password_hash: str
     role: UserRole
     api_token: str
-
-    def update_password(self, password_hash: str) -> None:
-        self.password_hash = password_hash
 
     def update_api_token(self, api_token: str) -> None:
         self.api_token = api_token
 
     class Config:
         orm_mode = True
+
+
+class PasswordUser(Entity):
+    account_id: ID
+    account: Account
+    password_hash: str
+
+    def update_password(self, password_hash: str) -> None:
+        self.password_hash = password_hash

--- a/server/domain/auth/exceptions.py
+++ b/server/domain/auth/exceptions.py
@@ -1,8 +1,8 @@
 from ..common.exceptions import DoesNotExist
 
 
-class UserDoesNotExist(DoesNotExist):
-    entity_name = "User"
+class AccountDoesNotExist(DoesNotExist):
+    entity_name = "Account"
 
 
 class EmailAlreadyExists(Exception):

--- a/server/domain/auth/repositories.py
+++ b/server/domain/auth/repositories.py
@@ -3,23 +3,28 @@ from typing import Optional
 from server.seedwork.domain.repositories import Repository
 
 from ..common.types import ID, id_factory
-from .entities import User
+from .entities import Account, PasswordUser
 
 
-class UserRepository(Repository):
+class AccountRepository(Repository):
     def make_id(self) -> ID:
         return id_factory()
 
-    async def get_by_email(self, email: str) -> Optional[User]:
+    async def get_by_email(self, email: str) -> Optional[Account]:
         raise NotImplementedError  # pragma: no cover
 
-    async def get_by_api_token(self, api_token: str) -> Optional[User]:
+    async def get_by_api_token(self, api_token: str) -> Optional[Account]:
         raise NotImplementedError  # pragma: no cover
 
-    async def insert(self, entity: User) -> ID:
+
+class PasswordUserRepository(Repository):
+    async def get_by_email(self, email: str) -> Optional[PasswordUser]:
         raise NotImplementedError  # pragma: no cover
 
-    async def update(self, entity: User) -> None:
+    async def insert(self, entity: PasswordUser) -> ID:
+        raise NotImplementedError  # pragma: no cover
+
+    async def update(self, entity: PasswordUser) -> None:
         raise NotImplementedError  # pragma: no cover
 
     async def delete(self, id: ID) -> None:

--- a/server/infrastructure/auth/module.py
+++ b/server/infrastructure/auth/module.py
@@ -1,25 +1,33 @@
-from server.application.auth.commands import ChangePassword, CreateUser, DeleteUser
+from server.application.auth.commands import (
+    ChangePassword,
+    CreatePasswordUser,
+    DeletePasswordUser,
+)
 from server.application.auth.handlers import (
     change_password,
-    create_user,
-    delete_user,
-    get_user_by_api_token,
-    get_user_by_email,
-    login,
+    create_password_user,
+    delete_password_user,
+    get_account_by_api_token,
+    get_account_by_email,
+    login_password_user,
 )
-from server.application.auth.queries import GetUserByAPIToken, GetUserByEmail, Login
+from server.application.auth.queries import (
+    GetAccountByAPIToken,
+    GetAccountByEmail,
+    LoginPasswordUser,
+)
 from server.seedwork.application.modules import Module
 
 
 class AuthModule(Module):
     command_handlers = {
-        CreateUser: create_user,
-        DeleteUser: delete_user,
+        CreatePasswordUser: create_password_user,
+        DeletePasswordUser: delete_password_user,
         ChangePassword: change_password,
     }
 
     query_handlers = {
-        Login: login,
-        GetUserByEmail: get_user_by_email,
-        GetUserByAPIToken: get_user_by_api_token,
+        LoginPasswordUser: login_password_user,
+        GetAccountByEmail: get_account_by_email,
+        GetAccountByAPIToken: get_account_by_api_token,
     }

--- a/server/infrastructure/auth/transformers.py
+++ b/server/infrastructure/auth/transformers.py
@@ -1,8 +1,46 @@
-from server.domain.auth.entities import User
+from server.domain.auth.entities import Account, PasswordUser
 
-from .models import UserModel
+from .models import AccountModel, PasswordUserModel
 
 
-def update_instance(instance: UserModel, entity: User) -> None:
-    for field in set(User.__fields__) - {"id"}:
+def make_account_instance(entity: Account) -> AccountModel:
+    return AccountModel(
+        id=entity.id,
+        organization_siret=entity.organization_siret,
+        email=entity.email,
+        role=entity.role,
+        api_token=entity.api_token,
+    )
+
+
+def make_account_entity(instance: AccountModel) -> Account:
+    return Account(
+        id=instance.id,
+        organization_siret=instance.organization_siret,
+        email=instance.email,
+        role=instance.role,
+        api_token=instance.api_token,
+    )
+
+
+def make_password_user_instance(entity: PasswordUser) -> PasswordUserModel:
+    return PasswordUserModel(
+        account_id=entity.account_id,
+        password_hash=entity.password_hash,
+    )
+
+
+def make_password_user_entity(instance: PasswordUserModel) -> PasswordUser:
+    return PasswordUser(
+        account_id=instance.account_id,
+        account=make_account_entity(instance.account),
+        password_hash=instance.password_hash,
+    )
+
+
+def update_instance(instance: PasswordUserModel, entity: PasswordUser) -> None:
+    for field in set(PasswordUser.__fields__) - {"account_id", "account"}:
         setattr(instance, field, getattr(entity, field))
+
+    for field in set(Account.__fields__) - {"id"}:
+        setattr(instance, field, getattr(entity.account, field))

--- a/server/infrastructure/organizations/models.py
+++ b/server/infrastructure/organizations/models.py
@@ -8,7 +8,7 @@ from server.domain.organizations.types import Siret
 from ..database import Base
 
 if TYPE_CHECKING:
-    from ..auth.repositories import UserModel
+    from ..auth.models import AccountModel
     from ..catalogs.models import CatalogModel
 
 
@@ -24,7 +24,7 @@ class OrganizationModel(Base):
         uselist=False,
     )
 
-    users: List["UserModel"] = relationship(
-        "UserModel",
+    accounts: List["AccountModel"] = relationship(
+        "AccountModel",
         back_populates="organization",
     )

--- a/server/migrations/versions/17a9b8d2f84e_split_account_password_user.py
+++ b/server/migrations/versions/17a9b8d2f84e_split_account_password_user.py
@@ -1,0 +1,82 @@
+"""split-account-password-user
+
+Revision ID: 17a9b8d2f84e
+Revises: f2ef4eef61e3
+Create Date: 2022-08-02 11:07:59.669511
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "17a9b8d2f84e"
+down_revision = "f2ef4eef61e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Users become accounts.
+    op.rename_table("user", "account")
+    op.execute("ALTER INDEX user_pkey RENAME TO account_pkey;")
+    op.execute("ALTER INDEX ix_user_email RENAME TO ix_account_email;")
+    op.execute(
+        """
+        ALTER TABLE account
+        RENAME CONSTRAINT user_organization_siret_fkey
+        TO account_organization_siret_fkey;
+        """
+    )
+
+    op.create_table(
+        "password_user",
+        sa.Column("account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["account.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("account_id"),
+    )
+
+    # Create password users from existing accounts.
+    op.execute(
+        """
+        INSERT INTO password_user (account_id, password_hash)
+        SELECT account.id, account.password_hash FROM account;
+        """
+    )
+
+    op.drop_column("account", "password_hash")
+
+
+def downgrade():
+    # Move password_hash back to accounts.
+    op.add_column(
+        "account",
+        sa.Column("password_hash", sa.String()),
+    )
+    op.execute(
+        """
+        UPDATE account
+        SET password_hash = pu.password_hash
+        FROM password_user AS pu
+        JOIN account AS acc ON pu.account_id = acc.id;
+        """
+    )
+    op.alter_column("account", "password_hash", nullable=False)
+
+    op.drop_table("password_user")
+
+    # Accounts become users.
+    op.execute("ALTER INDEX account_pkey RENAME TO user_pkey;")
+    op.execute("ALTER INDEX ix_account_email RENAME TO ix_user_email;")
+    op.execute(
+        """
+        ALTER TABLE account
+        RENAME CONSTRAINT account_organization_siret_fkey
+        TO user_organization_siret_fkey;
+        """
+    )
+    op.rename_table("account", "user")

--- a/tests/api/test_datasets_filters.py
+++ b/tests/api/test_datasets_filters.py
@@ -10,12 +10,12 @@ from server.domain.datasets.entities import DataFormat
 from server.seedwork.application.messages import MessageBus
 
 from ..factories import CreateDatasetFactory, CreateTagFactory
-from ..helpers import TestUser
+from ..helpers import TestPasswordUser
 
 
 @pytest.mark.asyncio
 async def test_dataset_filters_info(
-    client: httpx.AsyncClient, temp_user: TestUser
+    client: httpx.AsyncClient, temp_user: TestPasswordUser
 ) -> None:
     bus = resolve(MessageBus)
 
@@ -142,7 +142,7 @@ class _Env:
 )
 async def test_dataset_filters_apply(
     client: httpx.AsyncClient,
-    temp_user: TestUser,
+    temp_user: TestPasswordUser,
     filtername: str,
     create_kwargs: Callable[[_Env], dict],
     positive_value: Callable[[_Env], list],
@@ -171,7 +171,7 @@ async def test_dataset_filters_apply(
 
 @pytest.mark.asyncio
 async def test_dataset_filters_license_any(
-    client: httpx.AsyncClient, temp_user: TestUser
+    client: httpx.AsyncClient, temp_user: TestPasswordUser
 ) -> None:
     bus = resolve(MessageBus)
 

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -10,7 +10,7 @@ from server.config.di import resolve
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateDatasetFactory, UpdateDatasetFactory
 
-from ..helpers import TestUser
+from ..helpers import TestPasswordUser
 
 DEFAULT_CORPUS_ITEMS = [
     ("Inventaire national forestier", "Ensemble des forêts de France"),
@@ -84,7 +84,10 @@ async def add_corpus(items: List[Tuple[str, str]] = None) -> None:
     ],
 )
 async def test_search(
-    client: httpx.AsyncClient, temp_user: TestUser, q: str, expected_titles: List[str]
+    client: httpx.AsyncClient,
+    temp_user: TestPasswordUser,
+    q: str,
+    expected_titles: List[str],
 ) -> None:
     await add_corpus()
 
@@ -116,7 +119,7 @@ async def test_search(
     ],
 )
 async def test_search_robustness(
-    client: httpx.AsyncClient, temp_user: TestUser, q_ref: str, q_other: str
+    client: httpx.AsyncClient, temp_user: TestPasswordUser, q_ref: str, q_other: str
 ) -> None:
     await add_corpus()
 
@@ -145,7 +148,7 @@ async def test_search_robustness(
 @pytest.mark.asyncio
 async def test_search_results_change_when_data_changes(
     client: httpx.AsyncClient,
-    temp_user: TestUser,
+    temp_user: TestPasswordUser,
 ) -> None:
     await add_corpus()
 
@@ -219,7 +222,9 @@ async def test_search_results_change_when_data_changes(
 
 
 @pytest.mark.asyncio
-async def test_search_ranking(client: httpx.AsyncClient, temp_user: TestUser) -> None:
+async def test_search_ranking(
+    client: httpx.AsyncClient, temp_user: TestPasswordUser
+) -> None:
     items = [
         ("A", "..."),
         ("B", "Forêt nouvelle"),
@@ -271,7 +276,7 @@ async def test_search_ranking(client: httpx.AsyncClient, temp_user: TestUser) ->
 )
 async def test_search_highlight(
     client: httpx.AsyncClient,
-    temp_user: TestUser,
+    temp_user: TestPasswordUser,
     corpus: list,
     q: str,
     expected_headlines: Optional[dict],

--- a/tests/api/test_licenses.py
+++ b/tests/api/test_licenses.py
@@ -5,11 +5,13 @@ from server.config.di import resolve
 from server.seedwork.application.messages import MessageBus
 
 from ..factories import CreateDatasetFactory
-from ..helpers import TestUser
+from ..helpers import TestPasswordUser
 
 
 @pytest.mark.asyncio
-async def test_license_list(client: httpx.AsyncClient, temp_user: TestUser) -> None:
+async def test_license_list(
+    client: httpx.AsyncClient, temp_user: TestPasswordUser
+) -> None:
     bus = resolve(MessageBus)
 
     response = await client.get("/licenses/", auth=temp_user.auth)

--- a/tests/api/test_organizations.py
+++ b/tests/api/test_organizations.py
@@ -2,7 +2,7 @@ import httpx
 import pytest
 
 from ..factories import CreateOrganizationFactory
-from ..helpers import TestUser, to_payload
+from ..helpers import TestPasswordUser, to_payload
 
 
 def api_key_auth(request: httpx.Request) -> httpx.Request:
@@ -39,7 +39,7 @@ def api_key_auth(request: httpx.Request) -> httpx.Request:
 )
 async def test_create_organization_invalid(
     client: httpx.AsyncClient,
-    temp_user: TestUser,
+    temp_user: TestPasswordUser,
     payload: dict,
     expected_errors_attrs: list,
 ) -> None:
@@ -104,7 +104,7 @@ class TestOrganizationPermissions:
         assert response.status_code == 403
 
     async def test_create_authenticated(
-        self, client: httpx.AsyncClient, temp_user: TestUser
+        self, client: httpx.AsyncClient, temp_user: TestPasswordUser
     ) -> None:
         response = await client.post(
             "/organizations/",

--- a/tests/api/test_tags.py
+++ b/tests/api/test_tags.py
@@ -5,11 +5,13 @@ from server.application.tags.commands import CreateTag
 from server.config.di import resolve
 from server.seedwork.application.messages import MessageBus
 
-from ..helpers import TestUser
+from ..helpers import TestPasswordUser
 
 
 @pytest.mark.asyncio
-async def test_tags_list(client: httpx.AsyncClient, temp_user: TestUser) -> None:
+async def test_tags_list(
+    client: httpx.AsyncClient, temp_user: TestPasswordUser
+) -> None:
     bus = resolve(MessageBus)
 
     response = await client.get("/tags/", auth=temp_user.auth)

--- a/tests/application/test_auth.py
+++ b/tests/application/test_auth.py
@@ -1,8 +1,8 @@
 import pytest
 from pydantic import EmailStr, SecretStr
 
-from server.application.auth.commands import ChangePassword, CreateUser
-from server.application.auth.queries import Login
+from server.application.auth.commands import ChangePassword, CreatePasswordUser
+from server.application.auth.queries import LoginPasswordUser
 from server.config.di import resolve
 from server.domain.auth.exceptions import LoginFailed
 from server.seedwork.application.messages import MessageBus
@@ -13,11 +13,13 @@ async def test_changepassword() -> None:
     bus = resolve(MessageBus)
     email = EmailStr("changepassworduser@mydomain.org")
 
-    await bus.execute(CreateUser(email=email, password=SecretStr("initialpwd")))
+    await bus.execute(CreatePasswordUser(email=email, password=SecretStr("initialpwd")))
 
     await bus.execute(ChangePassword(email=email, password=SecretStr("newpwd")))
 
     with pytest.raises(LoginFailed):
-        await bus.execute(Login(email=email, password=SecretStr("initialpwd")))
+        await bus.execute(
+            LoginPasswordUser(email=email, password=SecretStr("initialpwd"))
+        )
 
-    await bus.execute(Login(email=email, password=SecretStr("newpwd")))
+    await bus.execute(LoginPasswordUser(email=email, password=SecretStr("newpwd")))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateTagFactory
 
-from .helpers import TestUser, create_client, create_test_user
+from .helpers import TestPasswordUser, create_client, create_test_password_user
 
 if TYPE_CHECKING:
     from server.api.app import App
@@ -106,10 +106,10 @@ async def client(app: "App") -> AsyncIterator[httpx.AsyncClient]:
 
 
 @pytest_asyncio.fixture(name="temp_user")
-async def fixture_temp_user() -> TestUser:
-    return await create_test_user(UserRole.USER)
+async def fixture_temp_user() -> TestPasswordUser:
+    return await create_test_password_user(UserRole.USER)
 
 
 @pytest_asyncio.fixture
-async def admin_user() -> TestUser:
-    return await create_test_user(UserRole.ADMIN)
+async def admin_user() -> TestPasswordUser:
+    return await create_test_password_user(UserRole.ADMIN)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -7,7 +7,7 @@ from faker.providers import BaseProvider
 from pydantic import BaseModel
 from pydantic_factories import ModelFactory, Use
 
-from server.application.auth.commands import CreateUser
+from server.application.auth.commands import CreatePasswordUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.organizations.commands import CreateOrganization
 from server.application.tags.commands import CreateTag
@@ -38,8 +38,8 @@ class Factory(ModelFactory[T]):
         return super().get_mock_value(field_type)
 
 
-class CreateUserFactory(Factory[CreateUser]):
-    __model__ = CreateUser
+class CreatePasswordUserFactory(Factory[CreatePasswordUser]):
+    __model__ = CreatePasswordUser
 
     organization_siret = Use(lambda: LEGACY_ORGANIZATION_SIRET)
 

--- a/tests/infrastructure/test_catalogs.py
+++ b/tests/infrastructure/test_catalogs.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import EmailStr
 
-from server.application.auth.queries import GetUserByEmail
+from server.application.auth.queries import GetAccountByEmail
 from server.application.datasets.queries import GetDatasetByID
 from server.config.di import resolve
 from server.domain.organizations.types import Siret
@@ -10,7 +10,7 @@ from server.infrastructure.database import Database
 from server.infrastructure.organizations.repositories import OrganizationModel
 from server.seedwork.application.messages import MessageBus
 
-from ..factories import CreateDatasetFactory, CreateUserFactory
+from ..factories import CreateDatasetFactory, CreatePasswordUserFactory
 
 
 @pytest.mark.asyncio
@@ -32,10 +32,12 @@ async def test_catalog_creation_and_relationships() -> None:
 
     # Add a user to the organization...
     email = "test@mydomain.org"
-    await bus.execute(CreateUserFactory.build(organization_siret=siret, email=email))
+    await bus.execute(
+        CreatePasswordUserFactory.build(organization_siret=siret, email=email)
+    )
 
-    user = await bus.execute(GetUserByEmail(email=EmailStr("test@mydomain.org")))
-    assert user.organization_siret == siret
+    account = await bus.execute(GetAccountByEmail(email=EmailStr("test@mydomain.org")))
+    assert account.organization_siret == siret
 
     # Add a dataset to the catalog...
     dataset_id = await bus.execute(CreateDatasetFactory.build(organization_siret=siret))

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pytest
 from pydantic import EmailStr, SecretStr
 
-from server.application.auth.commands import DeleteUser
-from server.application.auth.queries import Login
+from server.application.auth.commands import DeletePasswordUser
+from server.application.auth.queries import LoginPasswordUser
 from server.application.datasets.commands import UpdateDataset
 from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
 from server.config.di import resolve
@@ -85,12 +85,14 @@ async def test_initdata_env_password(
     monkeypatch.setenv("TOOLS_PASSWORDS", json.dumps({"test@admin.org": "testpwd"}))
     await initdata.main(path, no_input=True)
 
-    user = await bus.execute(
-        Login(email=EmailStr("test@admin.org"), password=SecretStr("testpwd"))
+    account = await bus.execute(
+        LoginPasswordUser(
+            email=EmailStr("test@admin.org"), password=SecretStr("testpwd")
+        )
     )
 
     # (Delete user to prevent email collision below.)
-    await bus.execute(DeleteUser(id=user.id))
+    await bus.execute(DeletePasswordUser(account_id=account.id))
 
     # If not set, it would be prompted in the terminal.
     monkeypatch.delenv("TOOLS_PASSWORDS")

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -17,11 +17,11 @@ from server.api.auth.permissions import (
 from server.api.types import APIRequest
 from server.domain.auth.entities import UserRole
 
-from ..helpers import TestUser
+from ..helpers import TestPasswordUser
 
 
 @pytest.mark.asyncio
-async def test_is_authenticated(temp_user: TestUser) -> None:
+async def test_is_authenticated(temp_user: TestPasswordUser) -> None:
     app = FastAPI()
 
     app.add_middleware(AuthMiddleware, backend=TokenAuthBackend())
@@ -34,13 +34,15 @@ async def test_is_authenticated(temp_user: TestUser) -> None:
         response = await client.get("/")
         assert response.status_code == 401
 
-        headers = {"Authorization": f"Bearer {temp_user.api_token}"}
+        headers = {"Authorization": f"Bearer {temp_user.account.api_token}"}
         response = await client.get("/", headers=headers)
         assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_has_role(temp_user: TestUser, admin_user: TestUser) -> None:
+async def test_has_role(
+    temp_user: TestPasswordUser, admin_user: TestPasswordUser
+) -> None:
     app = FastAPI()
 
     app.add_middleware(AuthMiddleware, backend=TokenAuthBackend())
@@ -53,11 +55,11 @@ async def test_has_role(temp_user: TestUser, admin_user: TestUser) -> None:
         response = await client.get("/")
         assert response.status_code == 401
 
-        headers = {"Authorization": f"Bearer {temp_user.api_token}"}
+        headers = {"Authorization": f"Bearer {temp_user.account.api_token}"}
         response = await client.get("/", headers=headers)
         assert response.status_code == 403
 
-        headers = {"Authorization": f"Bearer {admin_user.api_token}"}
+        headers = {"Authorization": f"Bearer {admin_user.account.api_token}"}
         response = await client.get("/", headers=headers)
         assert response.status_code == 200
 

--- a/tools/changepassword.py
+++ b/tools/changepassword.py
@@ -6,23 +6,23 @@ from pydantic import EmailStr, SecretStr
 
 from server.application.auth.commands import ChangePassword
 from server.config.di import bootstrap, resolve
-from server.domain.auth.entities import User
-from server.domain.auth.repositories import UserRepository
+from server.domain.auth.entities import PasswordUser
+from server.domain.auth.repositories import PasswordUserRepository
 from server.seedwork.application.messages import MessageBus
 
 
-async def _prompt_user() -> User:
-    repository = resolve(UserRepository)
+async def _prompt_password_user() -> PasswordUser:
+    repository = resolve(PasswordUserRepository)
 
     email = click.prompt("Email")
 
-    user = await repository.get_by_email(email)
+    password_user = await repository.get_by_email(email)
 
-    if user is None:
-        click.echo(click.style(f"User does not exist: {email}", fg="red"))
+    if password_user is None:
+        click.echo(click.style(f"PasswordUser does not exist: {email}", fg="red"))
         sys.exit(1)
 
-    return user
+    return password_user
 
 
 def _prompt_password() -> SecretStr:
@@ -37,10 +37,12 @@ def _prompt_password() -> SecretStr:
 async def main() -> None:
     bus = resolve(MessageBus)
 
-    user = await _prompt_user()
+    user = await _prompt_password_user()
     password = _prompt_password()
 
-    await bus.execute(ChangePassword(email=EmailStr(user.email), password=password))
+    await bus.execute(
+        ChangePassword(email=EmailStr(user.account.email), password=password)
+    )
 
 
 if __name__ == "__main__":

--- a/tools/initdata.py
+++ b/tools/initdata.py
@@ -11,12 +11,12 @@ import yaml
 from dotenv import load_dotenv
 from pydantic import BaseModel, ValidationError, parse_raw_as
 
-from server.application.auth.commands import CreateUser
+from server.application.auth.commands import CreatePasswordUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.tags.commands import CreateTag
 from server.config.di import bootstrap, resolve
 from server.domain.auth.entities import UserRole
-from server.domain.auth.repositories import UserRepository
+from server.domain.auth.repositories import PasswordUserRepository
 from server.domain.datasets.entities import Dataset
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.tags.repositories import TagRepository
@@ -51,13 +51,13 @@ async def handle_user(
     item: dict, *, no_input: bool, env_passwords: Dict[str, str]
 ) -> None:
     bus = resolve(MessageBus)
-    repository = resolve(UserRepository)
+    repository = resolve(PasswordUserRepository)
 
     email = item["params"]["email"]
     existing_user = await repository.get_by_email(email)
 
     if existing_user is not None:
-        print(f"{info('ok')}: User(email={email!r}, ...)")
+        print(f"{info('ok')}: PasswordUser(email={email!r}, ...)")
         return
 
     extras = UserExtras(**item.get("extras", {}))
@@ -74,7 +74,7 @@ async def handle_user(
             password = click.prompt(f"Password for {email}", hide_input=True)
         item["params"]["password"] = password
 
-    command = CreateUser(**item["params"])
+    command = CreatePasswordUser(**item["params"])
     await bus.execute(command, id_=item["id"], **extras.dict())
     print(f"{success('created')}: {command!r}")
 


### PR DESCRIPTION
Closes #362 

Cette PR décompose l'entité existante `User` en deux entités:

* `Account` : contient les données "génériques" liées aux comptes utilisateurs dans l'outil
* `PasswordUser` : contient les données "spécifiques" à une authentification par couple email/mdp, en l'occurrence seulement le `password_hash`

La convention est :

* On crée/modifie/supprime des `password_user` (données "spécifiques") (et bientôt des `datapass_user`, refs #361) via les commands
* On lit des `accounts` (données "génériques") via les queries

De cette façon la présentation reste unifiée via l'interface `AccountView`.

De fait, il n'y a aucune incidence du point de vue du frontend, qui manipulait déjà des `UserView`, renommées en `AccountView`.

TODO

* [x] Validation staging