### PR TITLE
Use pip cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
       TOOLS_PASSWORDS: '{"admin@catalogue.data.gouv.fr": "ci-admin"}'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          # cache: "pip"
+          cache: "pip"
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Le cache avait été désactivé dans #272 en raison d'une indisponibilité de PyPI :

> [temp: disable pip cache due to 503](https://github.com/etalab/catalogage-donnees/pull/272/commits/09a4abc7c0497fe5e11847348d1b6912e205b3e4)