### PR TITLE
Add catalog extra fields backend

### DIFF
--- a/ops/ansible/environments/demo/assets/initdata.yml
+++ b/ops/ansible/environments/demo/assets/initdata.yml
@@ -61,6 +61,7 @@ datasets:
       license: Licence Ouverte
       tag_ids:
         - "9c1549a5-02ef-43a9-aa20-6babdce0b733"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
@@ -101,6 +102,7 @@ datasets:
       license: Licence Ouverte
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
@@ -120,6 +122,8 @@ datasets:
       url: "https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/"
       license: Licence Ouverte
       tag_ids: []
+      extra_field_values: []
+
 organizations:
   - params:
       name: "Ministère de la Culture"
@@ -128,3 +132,8 @@ organizations:
 catalogs:
   - params:
       organization_siret: "11004601800013"
+      extra_fields:
+        - name: referentiel
+          title: Référentiel ou norme
+          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
+          type: TEXT

--- a/ops/ansible/environments/staging/assets/initdata.yml
+++ b/ops/ansible/environments/staging/assets/initdata.yml
@@ -61,6 +61,7 @@ datasets:
       license: Licence Ouverte
       tag_ids:
         - "9c1549a5-02ef-43a9-aa20-6babdce0b733"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
@@ -101,6 +102,7 @@ datasets:
       license: Licence Ouverte
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
@@ -120,6 +122,8 @@ datasets:
       url: "https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/"
       license: Licence Ouverte
       tag_ids: []
+      extra_field_values: []
+
 organizations:
   - params:
       name: "Ministère de la Culture"
@@ -128,3 +132,8 @@ organizations:
 catalogs:
   - params:
       organization_siret: "11004601800013"
+      extra_fields:
+        - name: referentiel
+          title: Référentiel ou norme
+          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
+          type: TEXT

--- a/server/api/catalogs/routes.py
+++ b/server/api/catalogs/routes.py
@@ -27,7 +27,7 @@ router = APIRouter(prefix="/catalogs", tags=["catalogs"])
 async def create_catalog(data: CatalogCreate) -> JSONResponse:
     bus = resolve(MessageBus)
 
-    command = CreateCatalog(organization_siret=data.organization_siret)
+    command = CreateCatalog(**data.dict())
 
     try:
         siret = await bus.execute(command)

--- a/server/api/catalogs/schemas.py
+++ b/server/api/catalogs/schemas.py
@@ -1,7 +1,26 @@
-from pydantic import BaseModel
+from typing import List
 
+from pydantic import BaseModel, Field
+
+from server.application.catalogs.validation import CreateCatalogValidationMixin
+from server.domain.catalogs.entities import ExtraFieldType
+from server.domain.common.types import ID
 from server.domain.organizations.types import Siret
 
 
-class CatalogCreate(BaseModel):
+class ExtraFieldCreate(BaseModel):
+    name: str
+    title: str
+    hint_text: str
+    type: ExtraFieldType
+    data: dict = Field(default_factory=dict)
+
+
+class CatalogCreate(CreateCatalogValidationMixin, BaseModel):
     organization_siret: Siret
+    extra_fields: List[ExtraFieldCreate] = Field(default_factory=list)
+
+
+class ExtraFieldValueCreate(BaseModel):
+    extra_field_id: ID
+    value: str

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field
 
+from server.api.catalogs.schemas import ExtraFieldValueCreate
 from server.application.datasets.validation import (
     CreateDatasetValidationMixin,
     UpdateDatasetValidationMixin,
@@ -50,6 +51,7 @@ class DatasetCreate(CreateDatasetValidationMixin, BaseModel):
     url: Optional[str] = None
     license: Optional[str] = None
     tag_ids: List[ID] = Field(default_factory=list)
+    extra_field_values: List[ExtraFieldValueCreate] = Field(default_factory=list)
 
 
 class DatasetUpdate(UpdateDatasetValidationMixin, BaseModel):
@@ -66,3 +68,4 @@ class DatasetUpdate(UpdateDatasetValidationMixin, BaseModel):
     url: Optional[str] = Field(...)
     license: Optional[str] = Field(...)
     tag_ids: List[ID]
+    extra_field_values: List[ExtraFieldValueCreate]

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -68,4 +68,4 @@ class DatasetUpdate(UpdateDatasetValidationMixin, BaseModel):
     url: Optional[str] = Field(...)
     license: Optional[str] = Field(...)
     tag_ids: List[ID]
-    extra_field_values: List[ExtraFieldValueCreate]
+    extra_field_values: List[ExtraFieldValueCreate] = Field(default_factory=list)

--- a/server/application/catalogs/commands.py
+++ b/server/application/catalogs/commands.py
@@ -1,6 +1,14 @@
+from typing import List
+
+from pydantic import Field
+
+from server.domain.catalogs.entities import ExtraField
 from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
+from .validation import CreateCatalogValidationMixin
 
-class CreateCatalog(Command[Siret]):
+
+class CreateCatalog(CreateCatalogValidationMixin, Command[Siret]):
     organization_siret: Siret
+    extra_fields: List[ExtraField] = Field(default_factory=list)

--- a/server/application/catalogs/handlers.py
+++ b/server/application/catalogs/handlers.py
@@ -32,6 +32,7 @@ async def create_catalog(command: CreateCatalog) -> Siret:
 
     catalog = Catalog(
         organization_siret=siret,
+        extra_fields=command.extra_fields,
     )
 
     return await repository.insert(catalog)

--- a/server/application/catalogs/validation.py
+++ b/server/application/catalogs/validation.py
@@ -1,0 +1,48 @@
+from typing import Any, List
+
+from pydantic import BaseModel, ValidationError, root_validator, validator
+
+from server.domain.catalogs.entities import (
+    ExtraField,
+    ExtraFieldType,
+    parse_extra_fields,
+)
+
+
+class CreateCatalogValidationMixin(BaseModel):
+    @validator("extra_fields", check_fields=False, each_item=True, pre=True)
+    def convert_extra_fields_type(cls, v: Any) -> dict:
+        if isinstance(v, dict) and "type" in v:
+            # This may be a string. Ensure Pydantic receives an enum value, as the type
+            # annotations are `Literal[ExtraFieldType.<value>]` which Pydantic does not
+            # seem to know how to process, contrary to `ExtraFieldType`.
+            v["type"] = ExtraFieldType(v["type"])
+        return v
+
+    # Fill `organization_siret` both BEFORE (1) and AFTER (2) built-in validation occurs
+    # Indeed, depending on the model M used in `extra_fields: List[M]` type annotation,
+    # built-in validation may either require it (command entity) or drop it (API schema
+    # model).
+
+    # (1)
+    @root_validator(pre=True)
+    def fill_extra_fields_organization_siret(cls, values: dict) -> dict:
+        if "organization_siret" in values:
+            for item in values.get("extra_fields", []):
+                if isinstance(item, dict):
+                    item["organization_siret"] = values["organization_siret"]
+
+        return values
+
+    # (2)
+    @validator("extra_fields", check_fields=False)
+    def validate_extra_fields(cls, items: list, values: dict) -> List[ExtraField]:
+        items = [
+            {**item.dict(), "organization_siret": values["organization_siret"]}
+            for item in items
+        ]
+
+        try:
+            return parse_extra_fields(items)
+        except ValidationError:
+            raise

--- a/server/application/catalogs/views.py
+++ b/server/application/catalogs/views.py
@@ -1,7 +1,21 @@
+from typing import List
+
 from pydantic import BaseModel
 
+from server.domain.catalogs.entities import ExtraFieldType
+from server.domain.common.types import ID
 from server.domain.organizations.types import Siret
+
+
+class ExtraFieldView(BaseModel):
+    id: ID
+    name: str
+    title: str
+    hint_text: str
+    type: ExtraFieldType
+    data: dict
 
 
 class CatalogView(BaseModel):
     organization_siret: Siret
+    extra_fields: List[ExtraFieldView]

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from pydantic import EmailStr, Field
 
+from server.domain.catalogs.entities import ExtraFieldValue
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
@@ -27,6 +28,7 @@ class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
     url: Optional[str] = None
     license: Optional[str] = None
     tag_ids: List[ID] = Field(default_factory=list)
+    extra_field_values: List[ExtraFieldValue] = Field(default_factory=list)
 
 
 class UpdateDataset(UpdateDatasetValidationMixin, Command[None]):
@@ -44,6 +46,7 @@ class UpdateDataset(UpdateDatasetValidationMixin, Command[None]):
     url: Optional[str] = Field(...)
     license: Optional[str] = Field(...)
     tag_ids: List[ID]
+    extra_field_values: List[ExtraFieldValue]
 
 
 class DeleteDataset(Command[None]):

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -55,7 +55,11 @@ async def update_dataset(command: UpdateDataset) -> None:
         raise DatasetDoesNotExist(pk)
 
     tags = await tag_repository.get_all(ids=command.tag_ids)
-    dataset.update(**command.dict(exclude={"id", "tag_ids"}), tags=tags)
+    dataset.update(
+        **command.dict(exclude={"id", "tag_ids", "extra_field_values"}),
+        tags=tags,
+        extra_field_values=command.extra_field_values,
+    )
 
     await repository.update(dataset)
 

--- a/server/application/datasets/views.py
+++ b/server/application/datasets/views.py
@@ -11,6 +11,11 @@ from ..catalog_records.views import CatalogRecordView
 from ..tags.views import TagView
 
 
+class ExtraFieldValueView(BaseModel):
+    extra_field_id: ID
+    value: str
+
+
 class DatasetView(BaseModel):
     id: ID
     catalog_record: CatalogRecordView
@@ -27,6 +32,7 @@ class DatasetView(BaseModel):
     url: Optional[str]
     license: Optional[str]
     tags: List[TagView]
+    extra_field_values: List[ExtraFieldValueView]
 
     # Extras
     headlines: Optional[DatasetHeadlines] = None

--- a/server/domain/catalogs/entities.py
+++ b/server/domain/catalogs/entities.py
@@ -1,7 +1,70 @@
+from enum import Enum
+from typing import Any, List, Literal, Union
+
+from pydantic import BaseModel, Field, parse_obj_as
+from typing_extensions import Annotated, TypedDict
+
+from server.domain.common.types import ID, id_factory
 from server.seedwork.domain.entities import Entity
 
 from ..organizations.types import Siret
 
 
+class ExtraFieldType(Enum):
+    TEXT = "TEXT"
+    ENUM = "ENUM"
+    BOOL = "BOOL"
+
+
+class _ExtraFieldBase(BaseModel):
+    id: ID = Field(default_factory=id_factory)
+    organization_siret: Siret
+    name: str
+    title: str
+    hint_text: str
+
+
+class TextExtraField(_ExtraFieldBase, Entity):
+    type: Literal[ExtraFieldType.TEXT] = ExtraFieldType.TEXT
+    data: dict = {}
+
+
+class _EnumExtraFieldData(TypedDict):
+    values: List[str]
+
+
+class EnumExtraField(_ExtraFieldBase, Entity):
+    type: Literal[ExtraFieldType.ENUM] = ExtraFieldType.ENUM
+    data: _EnumExtraFieldData
+
+
+class _BoolExtraFieldData(TypedDict):
+    true_value: str
+    false_value: str
+
+
+class BoolExtraField(_ExtraFieldBase, Entity):
+    type: Literal[ExtraFieldType.BOOL] = ExtraFieldType.BOOL
+    data: _BoolExtraFieldData
+
+
+# See: https://pydantic-docs.helpmanual.io/usage/types/#discriminated-unions-aka-tagged-unions  # noqa: E501
+ExtraField = Union[TextExtraField, EnumExtraField, BoolExtraField]
+
+
+def parse_extra_field(item: Any) -> ExtraField:
+    return parse_obj_as(ExtraField, item)  # type: ignore
+
+
+def parse_extra_fields(items: list) -> List[ExtraField]:
+    return parse_obj_as(List[Annotated[ExtraField, Field(discriminator="type")]], items)
+
+
+class ExtraFieldValue(Entity):
+    extra_field_id: ID
+    value: str
+
+
 class Catalog(Entity):
     organization_siret: Siret
+    extra_fields: List[Annotated[ExtraField, Field(discriminator="type")]]

--- a/server/domain/catalogs/repositories.py
+++ b/server/domain/catalogs/repositories.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from server.domain.organizations.types import Siret
 from server.seedwork.domain.repositories import Repository
 
+from ..organizations.types import Siret
 from .entities import Catalog
 
 

--- a/server/domain/datasets/entities.py
+++ b/server/domain/datasets/entities.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field
 
+from server.domain.catalogs.entities import ExtraFieldValue
 from server.domain.tags.entities import Tag
 from server.seedwork.domain.entities import Entity
 
@@ -45,6 +46,7 @@ class Dataset(Entity):
     url: Optional[str] = None
     license: Optional[str] = None
     tags: List[Tag] = Field(default_factory=list)
+    extra_field_values: List[ExtraFieldValue] = Field(default_factory=list)
 
     class Config:
         orm_mode = True
@@ -64,6 +66,7 @@ class Dataset(Entity):
         url: Optional[str],
         license: Optional[str],
         tags: List[Tag],
+        extra_field_values: List[ExtraFieldValue],
     ) -> None:
         self.title = title
         self.description = description
@@ -78,3 +81,4 @@ class Dataset(Entity):
         self.url = url
         self.license = license
         self.tags = tags
+        self.extra_field_values = extra_field_values

--- a/server/infrastructure/catalogs/models.py
+++ b/server/infrastructure/catalogs/models.py
@@ -1,15 +1,19 @@
 import datetime as dt
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
-from sqlalchemy import CHAR, Column, DateTime, ForeignKey, func
+from sqlalchemy import CHAR, Column, DateTime, Enum, ForeignKey, Index, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
+from server.domain.catalogs.entities import ExtraFieldType
+from server.domain.common.types import ID
 from server.domain.organizations.types import Siret
 
 from ..database import Base
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ..catalog_records.repositories import CatalogRecordModel
+    from ..datasets.models import DatasetModel
     from ..organizations.models import OrganizationModel
 
 
@@ -35,3 +39,59 @@ class CatalogModel(Base):
         "CatalogRecordModel",
         back_populates="catalog",
     )
+    extra_fields: List["ExtraFieldModel"] = relationship(
+        "ExtraFieldModel",
+        back_populates="catalog",
+    )
+
+
+class ExtraFieldModel(Base):
+    __tablename__ = "extra_field"
+
+    id: ID = Column(UUID(as_uuid=True), primary_key=True)
+    organization_siret: Siret = Column(
+        CHAR(14),
+        ForeignKey("catalog.organization_siret"),
+        nullable=False,
+        index=True,
+    )
+    name = Column(String(), nullable=False)
+    title = Column(String(), nullable=False)
+    hint_text = Column(String(), nullable=False)
+    type: ExtraFieldType = Column(
+        Enum(ExtraFieldType, name="extra_field_type_enum"), nullable=False
+    )
+    data: dict = Column(JSONB(), nullable=False)
+    catalog: "CatalogModel" = relationship(
+        "CatalogModel", back_populates="extra_fields"
+    )
+    values: List["ExtraFieldValueModel"] = relationship(
+        "ExtraFieldValueModel", back_populates="extra_field"
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_extra_field_unique_organization_siret_name",
+            organization_siret,
+            name,
+            unique=True,
+        ),
+    )
+
+
+class ExtraFieldValueModel(Base):
+    __tablename__ = "extra_field_value"
+
+    dataset_id: ID = Column(
+        UUID(as_uuid=True), ForeignKey("dataset.id"), primary_key=True
+    )
+    dataset: "DatasetModel" = relationship(
+        "DatasetModel", back_populates="extra_field_values"
+    )
+    extra_field_id: ID = Column(
+        UUID(as_uuid=True), ForeignKey("extra_field.id"), primary_key=True
+    )
+    extra_field: "ExtraFieldModel" = relationship(
+        "ExtraFieldModel", back_populates="values"
+    )
+    value: Any = Column(JSONB(), nullable=False)

--- a/server/infrastructure/catalogs/transformers.py
+++ b/server/infrastructure/catalogs/transformers.py
@@ -1,13 +1,62 @@
-from server.domain.catalogs.entities import Catalog
+from server.domain.catalogs.entities import (
+    Catalog,
+    ExtraField,
+    ExtraFieldValue,
+    parse_extra_field,
+)
+from server.domain.common.types import ID
 
-from .models import CatalogModel
+from .models import CatalogModel, ExtraFieldModel, ExtraFieldValueModel
 
 
 def make_entity(instance: CatalogModel) -> Catalog:
     return Catalog(
         organization_siret=instance.organization_siret,
+        extra_fields=[
+            _make_extra_field_entity(extra_field_instance)
+            for extra_field_instance in instance.extra_fields
+        ],
     )
 
 
 def make_instance(entity: Catalog) -> CatalogModel:
-    return CatalogModel(**entity.dict())
+    return CatalogModel(
+        **entity.dict(exclude={"extra_fields"}),
+        extra_fields=[
+            ExtraFieldModel(**extra_field.dict()) for extra_field in entity.extra_fields
+        ]
+    )
+
+
+def _make_extra_field_entity(instance: ExtraFieldModel) -> ExtraField:
+    kwargs = {
+        field: getattr(instance, field)
+        for field in (
+            "id",
+            "organization_siret",
+            "name",
+            "title",
+            "hint_text",
+            "type",
+            "data",
+        )
+    }
+
+    return parse_extra_field(kwargs)  # type: ignore
+
+
+def make_extra_field_value_entity(instance: ExtraFieldValueModel) -> ExtraFieldValue:
+    return ExtraFieldValue(
+        extra_field_id=instance.extra_field_id,
+        value=instance.value,
+    )
+
+
+def make_extra_field_value_instance(
+    entity: ExtraFieldValue, dataset_id: ID
+) -> ExtraFieldValueModel:
+    return ExtraFieldValueModel(
+        dataset_id=dataset_id,
+        extra_field_id=entity.extra_field_id,
+        value=entity.value,
+    )

--- a/server/infrastructure/datasets/models.py
+++ b/server/infrastructure/datasets/models.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from sqlalchemy import (
     Column,
@@ -20,6 +20,9 @@ from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from ..catalog_records.repositories import CatalogRecordModel
 from ..database import Base, mapper_registry
 from ..tags.repositories import TagModel, dataset_tag
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..catalogs.models import ExtraFieldValueModel
 
 # Association table
 # See: https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#many-to-many
@@ -79,6 +82,9 @@ class DatasetModel(Base):
     license = Column(String)
     tags: List["TagModel"] = relationship(
         "TagModel", back_populates="datasets", secondary=dataset_tag
+    )
+    extra_field_values: List["ExtraFieldValueModel"] = relationship(
+        "ExtraFieldValueModel", cascade="all, delete-orphan", back_populates="dataset"
     )
 
     search_tsv: Mapped[str] = Column(

--- a/server/infrastructure/datasets/queries/get_all.py
+++ b/server/infrastructure/datasets/queries/get_all.py
@@ -94,6 +94,7 @@ class GetAllQuery:
                 contains_eager(DatasetModel.catalog_record),
                 selectinload(DatasetModel.formats),
                 selectinload(DatasetModel.tags),
+                selectinload(DatasetModel.extra_field_values),
             )
             .where(*whereclauses)
             .order_by(*orderbyclauses, CatalogRecordModel.created_at.desc())

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -54,6 +54,7 @@ class SqlDatasetRepository(DatasetRepository):
                 contains_eager(DatasetModel.catalog_record),
                 selectinload(DatasetModel.formats),
                 selectinload(DatasetModel.tags),
+                selectinload(DatasetModel.extra_field_values),
             )
         )
         result = await session.execute(stmt)

--- a/server/infrastructure/datasets/transformers.py
+++ b/server/infrastructure/datasets/transformers.py
@@ -1,6 +1,10 @@
 from typing import List
 
 from server.domain.datasets.entities import Dataset
+from server.infrastructure.catalogs.transformers import (
+    make_extra_field_value_entity,
+    make_extra_field_value_instance,
+)
 
 from ..catalog_records.repositories import make_entity as make_catalog_record_entity
 from ..tags.repositories import TagModel
@@ -13,6 +17,10 @@ def make_entity(instance: DatasetModel) -> Dataset:
         "catalog_record": make_catalog_record_entity(instance.catalog_record),
         "formats": [fmt.name for fmt in instance.formats],
         "tags": [make_tag_entity(tag) for tag in instance.tags],
+        "extra_field_values": [
+            make_extra_field_value_entity(value)
+            for value in instance.extra_field_values
+        ],
     }
 
     kwargs.update(
@@ -31,12 +39,18 @@ def make_instance(
     tags: List[TagModel],
 ) -> DatasetModel:
     instance = DatasetModel(
-        **entity.dict(exclude={"catalog_record", "formats", "tags"}),
+        **entity.dict(
+            exclude={"catalog_record", "formats", "tags", "extra_field_values"}
+        ),
     )
 
     instance.catalog_record = catalog_record
     instance.formats = formats
     instance.tags = tags
+    instance.extra_field_values = [
+        make_extra_field_value_instance(value, dataset_id=entity.id)
+        for value in entity.extra_field_values
+    ]
 
     return instance
 
@@ -47,8 +61,18 @@ def update_instance(
     formats: List[DataFormatModel],
     tags: List[TagModel],
 ) -> None:
-    for field in set(Dataset.__fields__) - {"id", "catalog_record", "formats", "tags"}:
+    for field in set(Dataset.__fields__) - {
+        "id",
+        "catalog_record",
+        "formats",
+        "tags",
+        "extra_field_values",
+    }:
         setattr(instance, field, getattr(entity, field))
 
     instance.formats = formats
     instance.tags = tags
+    instance.extra_field_values = [
+        make_extra_field_value_instance(value, dataset_id=entity.id)
+        for value in entity.extra_field_values
+    ]

--- a/server/migrations/versions/2022-08-09_21a0f4491f8d_add_extra_fields.py
+++ b/server/migrations/versions/2022-08-09_21a0f4491f8d_add_extra_fields.py
@@ -1,0 +1,70 @@
+"""add-extra-fields
+
+Revision ID: 21a0f4491f8d
+Revises: 3928481ec7d2
+Create Date: 2022-08-09 15:55:39.537207
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "21a0f4491f8d"
+down_revision = "3928481ec7d2"
+branch_labels = None
+depends_on = None
+
+extra_field_type_enum = sa.Enum("TEXT", "ENUM", "BOOL", name="extra_field_type_enum")
+
+
+def upgrade():
+    op.create_table(
+        "extra_field",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_siret", sa.CHAR(length=14), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("hint_text", sa.String(), nullable=False),
+        sa.Column("type", extra_field_type_enum, nullable=False),
+        sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["organization_siret"],
+            ["catalog.organization_siret"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_extra_field_organization_siret",
+        "extra_field",
+        ["organization_siret"],
+    )
+    op.create_index(
+        "ix_extra_field_unique_organization_siret_name",
+        "extra_field",
+        ["organization_siret", "name"],
+        unique=True,
+    )
+
+    op.create_table(
+        "extra_field_value",
+        sa.Column("dataset_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("extra_field_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("value", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["dataset_id"],
+            ["dataset.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["extra_field_id"],
+            ["extra_field.id"],
+        ),
+        sa.PrimaryKeyConstraint("dataset_id", "extra_field_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("extra_field_value")
+    op.drop_table("extra_field")
+    extra_field_type_enum.drop(op.get_bind())

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -391,7 +391,7 @@ class TestDatasetUpdate:
             "url",
             "license",
             "tag_ids",
-            "extra_field_values",
+            # extra_field_values -- empty OK until frontend is implemented
         ]
         errors = response.json()["detail"]
         assert len(errors) == len(fields)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -66,12 +66,14 @@ class CreateDatasetFactory(Factory[CreateDataset]):
     url = Use(lambda: fake.url() if random.random() < 0.5 else None)
     license = Use(random.choice, [None, *BUILTIN_LICENSE_SUGGESTIONS])
     tag_ids = Use(lambda: [])
+    extra_field_values = Use(lambda: [])
 
 
 class UpdateDatasetFactory(Factory[UpdateDataset]):
     __model__ = UpdateDataset
 
     tag_ids = Use(lambda: [])
+    extra_field_values = Use(lambda: [])
 
 
 class CreateOrganizationFactory(Factory[CreateOrganization]):

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -61,6 +61,7 @@ datasets:
       license: Licence Ouverte
       tag_ids:
         - "9c1549a5-02ef-43a9-aa20-6babdce0b733"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
@@ -81,6 +82,7 @@ datasets:
       license: Autre (Open)
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/
     id: "3707e03b-d020-4a14-bb85-1ad0545b1578"
@@ -101,6 +103,7 @@ datasets:
       license: Licence Ouverte
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
@@ -120,6 +123,8 @@ datasets:
       url: "https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/"
       license: Licence Ouverte
       tag_ids: []
+      extra_field_values: []
+
 organizations:
   - params:
       name: "Ministère de la Culture"
@@ -128,3 +133,8 @@ organizations:
 catalogs:
   - params:
       organization_siret: "11004601800013"
+      extra_fields:
+        - name: referentiel
+          title: Référentiel ou norme
+          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
+          type: TEXT


### PR DESCRIPTION
Closes #367

TODO

* [x] Créer modèle `ExtraField` et `ExtraFieldValue`
* [x] Ajouter relations `Catalog.extra_fields` et `Dataset.extra_field_values`
* [x] Créer migration
* [x] Mettre à jour `POST /catalogs/` pour accepter un champ `extra_fields`
* [x] Tests création catalogue avec/sans champs complémentaires
* [x] Màj `POST/PUT /datasets/` pour accepte un champ `extra_field_values`
* [x] Tests ajout dataset à un catalogue avec valeurs de champs complémentaires
* [x] Màj initdata : conformité schéma
* [x] Màj initdata : ajouter des `extra_fields` au catalogue d'exemple

L'intégration frontend est repoussée à une PR ultérieure (sur base des maquettes de Romain).

Aucun impact sur le comportement actuel (cf tests E2E OK) : les endpoints datasets acceptent des `extra_field_values` vides par défaut.

## Revue

Au-delà du code, consulter la documentation d'API mise à jour http://localhost:3579/api/docs pour valider les changements à l'API (endpoints datasets et catalogs)