### PR TITLE
Add catalog creation endpoint

### DIFF
--- a/server/api/catalogs/__init__.py
+++ b/server/api/catalogs/__init__.py
@@ -1,0 +1,5 @@
+from .routes import router
+
+__all__ = [
+    "router",
+]

--- a/server/api/catalogs/routes.py
+++ b/server/api/catalogs/routes.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+
+from server.application.catalogs.commands import CreateCatalog
+from server.application.catalogs.queries import GetCatalogBySiret
+from server.application.catalogs.views import CatalogView
+from server.config.di import resolve
+from server.domain.catalogs.exceptions import CatalogAlreadyExists
+from server.seedwork.application.messages import MessageBus
+
+from ..auth.permissions import HasAPIKey
+from .schemas import CatalogCreate
+
+router = APIRouter(prefix="/catalogs", tags=["catalogs"])
+
+
+@router.post(
+    "/",
+    dependencies=[Depends(HasAPIKey())],
+    response_model=CatalogView,
+    status_code=201,
+    responses={
+        200: {},
+    },
+)
+async def create_catalog(data: CatalogCreate) -> JSONResponse:
+    bus = resolve(MessageBus)
+
+    command = CreateCatalog(organization_siret=data.organization_siret)
+
+    try:
+        siret = await bus.execute(command)
+    except CatalogAlreadyExists as exc:
+        content = jsonable_encoder(CatalogView(**exc.catalog.dict()))
+        return JSONResponse(content, status_code=200)
+
+    query = GetCatalogBySiret(siret=siret)
+    catalog = await bus.execute(query)
+    content = jsonable_encoder(catalog)
+
+    return JSONResponse(content, status_code=201)

--- a/server/api/catalogs/schemas.py
+++ b/server/api/catalogs/schemas.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+from server.domain.organizations.types import Siret
+
+
+class CatalogCreate(BaseModel):
+    organization_siret: Siret

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -5,7 +5,7 @@ from starlette.responses import RedirectResponse
 from server.config import Settings
 from server.config.di import resolve
 
-from . import auth, datasets, licenses, organizations, tags
+from . import auth, catalogs, datasets, licenses, organizations, tags
 
 router = APIRouter()
 
@@ -22,3 +22,4 @@ router.include_router(datasets.router)
 router.include_router(tags.router)
 router.include_router(licenses.router)
 router.include_router(organizations.router)
+router.include_router(catalogs.router)

--- a/server/application/catalogs/commands.py
+++ b/server/application/catalogs/commands.py
@@ -1,0 +1,6 @@
+from server.domain.organizations.types import Siret
+from server.seedwork.application.commands import Command
+
+
+class CreateCatalog(Command[Siret]):
+    organization_siret: Siret

--- a/server/application/catalogs/handlers.py
+++ b/server/application/catalogs/handlers.py
@@ -1,0 +1,37 @@
+from server.config.di import resolve
+from server.domain.catalogs.entities import Catalog
+from server.domain.catalogs.exceptions import CatalogAlreadyExists, CatalogDoesNotExist
+from server.domain.catalogs.repositories import CatalogRepository
+from server.domain.organizations.types import Siret
+
+from .commands import CreateCatalog
+from .queries import GetCatalogBySiret
+from .views import CatalogView
+
+
+async def get_catalog_by_siret(query: GetCatalogBySiret) -> CatalogView:
+    repository = resolve(CatalogRepository)
+
+    siret = query.siret
+    catalog = await repository.get_by_siret(siret)
+
+    if catalog is None:
+        raise CatalogDoesNotExist(siret)
+
+    return CatalogView(**catalog.dict())
+
+
+async def create_catalog(command: CreateCatalog) -> Siret:
+    repository = resolve(CatalogRepository)
+
+    siret = command.organization_siret
+    catalog = await repository.get_by_siret(siret)
+
+    if catalog is not None:
+        raise CatalogAlreadyExists(catalog)
+
+    catalog = Catalog(
+        organization_siret=siret,
+    )
+
+    return await repository.insert(catalog)

--- a/server/application/catalogs/queries.py
+++ b/server/application/catalogs/queries.py
@@ -1,0 +1,8 @@
+from server.domain.organizations.types import Siret
+from server.seedwork.application.queries import Query
+
+from .views import CatalogView
+
+
+class GetCatalogBySiret(Query[CatalogView]):
+    siret: Siret

--- a/server/application/catalogs/views.py
+++ b/server/application/catalogs/views.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+from server.domain.organizations.types import Siret
+
+
+class CatalogView(BaseModel):
+    organization_siret: Siret

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -62,6 +62,7 @@ Or in any custom scripts as seems fit.
 from server.application.auth.passwords import PasswordEncoder
 from server.domain.auth.repositories import AccountRepository, PasswordUserRepository
 from server.domain.catalog_records.repositories import CatalogRecordRepository
+from server.domain.catalogs.repositories import CatalogRepository
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.organizations.repositories import OrganizationRepository
 from server.domain.tags.repositories import TagRepository
@@ -74,6 +75,7 @@ from server.infrastructure.auth.repositories import (
 from server.infrastructure.catalog_records.repositories import (
     SqlCatalogRecordRepository,
 )
+from server.infrastructure.catalogs.repositories import SqlCatalogRepository
 from server.infrastructure.database import Database
 from server.infrastructure.datasets.repositories import SqlDatasetRepository
 from server.infrastructure.organizations.repositories import SqlOrganizationRepository
@@ -142,6 +144,7 @@ def configure(container: "Container") -> None:
     container.register_instance(DatasetRepository, SqlDatasetRepository(db))
     container.register_instance(TagRepository, SqlTagRepository(db))
     container.register_instance(OrganizationRepository, SqlOrganizationRepository(db))
+    container.register_instance(CatalogRepository, SqlCatalogRepository(db))
 
 
 _CONTAINER = Container(configure)

--- a/server/domain/catalogs/exceptions.py
+++ b/server/domain/catalogs/exceptions.py
@@ -1,0 +1,12 @@
+from ..common.exceptions import DoesNotExist
+from .entities import Catalog
+
+
+class CatalogDoesNotExist(DoesNotExist):
+    entity_name = "Catalog"
+
+
+class CatalogAlreadyExists(Exception):
+    def __init__(self, catalog: Catalog) -> None:
+        super().__init__()
+        self.catalog = catalog

--- a/server/domain/catalogs/repositories.py
+++ b/server/domain/catalogs/repositories.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from server.domain.organizations.types import Siret
+from server.seedwork.domain.repositories import Repository
+
+from .entities import Catalog
+
+
+class CatalogRepository(Repository):
+    async def get_by_siret(self, siret: Siret) -> Optional[Catalog]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def insert(self, catalog: Catalog) -> Siret:
+        raise NotImplementedError  # pragma: no cover

--- a/server/infrastructure/catalogs/module.py
+++ b/server/infrastructure/catalogs/module.py
@@ -1,7 +1,14 @@
+from server.application.catalogs.commands import CreateCatalog
+from server.application.catalogs.handlers import create_catalog, get_catalog_by_siret
+from server.application.catalogs.queries import GetCatalogBySiret
 from server.seedwork.application.modules import Module
-
-from . import models  # noqa  # Trigger SQLAlchemy table discovery.
 
 
 class CatalogsModule(Module):
-    pass
+    command_handlers = {
+        CreateCatalog: create_catalog,
+    }
+
+    query_handlers = {
+        GetCatalogBySiret: get_catalog_by_siret,
+    }

--- a/server/infrastructure/catalogs/repositories.py
+++ b/server/infrastructure/catalogs/repositories.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+from sqlalchemy import select
+
+from server.domain.catalogs.entities import Catalog
+from server.domain.catalogs.repositories import CatalogRepository
+from server.domain.organizations.types import Siret
+
+from ..database import Database
+from .models import CatalogModel
+from .transformers import make_entity, make_instance
+
+
+class SqlCatalogRepository(CatalogRepository):
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def get_by_siret(self, siret: Siret) -> Optional[Catalog]:
+        async with self._db.session() as session:
+            stmt = select(CatalogModel).where(CatalogModel.organization_siret == siret)
+            result = await session.execute(stmt)
+            instance = result.scalar_one_or_none()
+            if instance is None:
+                return None
+            return make_entity(instance)
+
+    async def insert(self, entity: Catalog) -> Siret:
+        async with self._db.session() as session:
+            instance = make_instance(entity)
+
+            session.add(instance)
+
+            await session.commit()
+            await session.refresh(instance)
+
+            return instance.organization_siret

--- a/server/infrastructure/catalogs/transformers.py
+++ b/server/infrastructure/catalogs/transformers.py
@@ -1,0 +1,13 @@
+from server.domain.catalogs.entities import Catalog
+
+from .models import CatalogModel
+
+
+def make_entity(instance: CatalogModel) -> Catalog:
+    return Catalog(
+        organization_siret=instance.organization_siret,
+    )
+
+
+def make_instance(entity: Catalog) -> CatalogModel:
+    return CatalogModel(**entity.dict())

--- a/tests/api/test_catalogs.py
+++ b/tests/api/test_catalogs.py
@@ -1,0 +1,67 @@
+import httpx
+import pytest
+
+from server.application.catalogs.commands import CreateCatalog
+from server.application.catalogs.queries import GetCatalogBySiret
+from server.application.datasets.queries import GetDatasetByID
+from server.config.di import resolve
+from server.seedwork.application.messages import MessageBus
+
+from ..factories import CreateDatasetFactory, CreateOrganizationFactory
+from ..helpers import TestPasswordUser, api_key_auth
+
+
+@pytest.mark.asyncio
+async def test_catalog_create(client: httpx.AsyncClient) -> None:
+    bus = resolve(MessageBus)
+    siret = await bus.execute(CreateOrganizationFactory.build())
+
+    response = await client.post(
+        "/catalogs/", json={"organization_siret": str(siret)}, auth=api_key_auth
+    )
+    assert response.status_code == 201
+    assert response.json() == {
+        "organization_siret": str(siret),
+    }
+    catalog = await bus.execute(GetCatalogBySiret(siret=siret))
+    assert catalog.organization_siret == siret
+
+    dataset_id = await bus.execute(CreateDatasetFactory.build(organization_siret=siret))
+    dataset = await bus.execute(GetDatasetByID(id=dataset_id))
+    assert dataset.catalog_record.organization_siret == siret
+
+
+@pytest.mark.asyncio
+async def test_catalog_create_already_exists(client: httpx.AsyncClient) -> None:
+    bus = resolve(MessageBus)
+    siret = await bus.execute(CreateOrganizationFactory.build())
+    await bus.execute(CreateCatalog(organization_siret=siret))
+
+    response = await client.post(
+        "/catalogs/", json={"organization_siret": str(siret)}, auth=api_key_auth
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "organization_siret": str(siret),
+    }
+
+
+@pytest.mark.asyncio
+class TestCatalogPermissions:
+    async def test_create_anonymous(self, client: httpx.AsyncClient) -> None:
+        bus = resolve(MessageBus)
+        siret = await bus.execute(CreateOrganizationFactory.build())
+        response = await client.post(
+            "/catalogs/", json={"organization_siret": str(siret)}
+        )
+        assert response.status_code == 403
+
+    async def test_create_authenticated(
+        self, client: httpx.AsyncClient, temp_user: TestPasswordUser
+    ) -> None:
+        bus = resolve(MessageBus)
+        siret = await bus.execute(CreateOrganizationFactory.build())
+        response = await client.post(
+            "/catalogs/", json={"organization_siret": str(siret)}, auth=temp_user.auth
+        )
+        assert response.status_code == 403

--- a/tests/api/test_organizations.py
+++ b/tests/api/test_organizations.py
@@ -2,12 +2,7 @@ import httpx
 import pytest
 
 from ..factories import CreateOrganizationFactory
-from ..helpers import TestPasswordUser, to_payload
-
-
-def api_key_auth(request: httpx.Request) -> httpx.Request:
-    request.headers["X-Api-Key"] = "<testing>"
-    return request
+from ..helpers import TestPasswordUser, api_key_auth, to_payload
 
 
 @pytest.mark.asyncio

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -53,3 +53,8 @@ async def create_test_password_user(role: UserRole) -> TestPasswordUser:
     assert user is not None
 
     return TestPasswordUser(**user.dict(), password=command.password.get_secret_value())
+
+
+def api_key_auth(request: httpx.Request) -> httpx.Request:
+    request.headers["X-Api-Key"] = "<testing>"
+    return request


### PR DESCRIPTION
* Refs #367 
* Extrait de #368 pour en réduire la portée et car cette partie est déjà prête

Cette PR ajoute un endpoint `POST /catalogs/` qui permettra à https://github.com/etalab/cataloage-donnees-config d'envoyer à l'outil le catalogue d'une organisation à partir de son fichier de configuration.

Il est protégé par clé d'API tout comme `POST /organizations/`.

#368 viendra l'enrichir avec les champs complémentaires.