### PR TITLE
doc: update fixtures and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pour plus d'informations, consultez [le guide de démarrage rapide](./docs/fr/de
 
 ## Démo
 
-Une instance de démonstration de l'application est accessible sur [demo.catalogue.multi.coop](http://demo.catalogue.multi.coop/). Login : `demo@catalogue.data.gouv.fr`, mot de passe : `demo`.
+Une instance de démonstration de l'application est accessible sur [demo.catalogue.multi.coop](http://demo.catalogue.multi.coop/). Login : `catalogue.demo@yopmail.com `, mot de passe : `password1234`.
 
 ## Contribuer
 

--- a/client/src/tests/e2e/constants.ts
+++ b/client/src/tests/e2e/constants.ts
@@ -1,4 +1,4 @@
-export const TEST_EMAIL = "demo@catalogue.data.gouv.fr";
+export const TEST_EMAIL = "catalogue.demo@yopmail.com";
 export const TEST_PASSWORD = "demo";
 export const ADMIN_EMAIL = "admin@catalogue.data.gouv.fr";
 export const STATE_AUTHENTICATED = "./src/tests/e2e/storage/authenticated.json";

--- a/client/src/tests/e2e/login.spec.ts
+++ b/client/src/tests/e2e/login.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "@playwright/test";
+import { TEST_EMAIL } from "./constants";
 import { test } from "./fixtures";
 
 test.describe("Login", () => {
@@ -16,8 +17,8 @@ test.describe("Login", () => {
     await expect(page).toHaveTitle("Connexion");
 
     const email = page.locator("form [name=email]");
-    await email.fill("demo@catalogue.data.gouv.fr");
-    expect(await email.inputValue()).toBe("demo@catalogue.data.gouv.fr");
+    await email.fill(TEST_EMAIL);
+    expect(await email.inputValue()).toBe(TEST_EMAIL);
 
     const password = page.locator("form [name=password]");
     await password.fill("demo");
@@ -33,7 +34,7 @@ test.describe("Login", () => {
     expect(request.method()).toBe("POST");
     expect(response.status()).toBe(200);
     const json = await response.json();
-    expect(json.email).toBe("demo@catalogue.data.gouv.fr");
+    expect(json.email).toBe(TEST_EMAIL);
     expect(json).toHaveProperty("api_token");
 
     await page.locator("text='Recherchez un jeu de données'").waitFor();
@@ -44,8 +45,8 @@ test.describe("Login", () => {
     await page.goto("/login");
 
     const email = page.locator("form [name=email]");
-    await email.fill("demo@catalogue.data.gouv.fr");
-    expect(await email.inputValue()).toBe("demo@catalogue.data.gouv.fr");
+    await email.fill(TEST_EMAIL);
+    expect(await email.inputValue()).toBe(TEST_EMAIL);
 
     const password = page.locator("form [name=password][type=password]");
     await password.fill("wrongpassword");

--- a/ops/ansible/environments/demo/assets/initdata.yml
+++ b/ops/ansible/environments/demo/assets/initdata.yml
@@ -1,8 +1,8 @@
 users:
-  - id: "b80b614c-30d1-48cf-8acf-9f1056f8eb0f"
+  - id: "c33cc0bb-975c-45a1-ac2a-7fed9971ce6a"
     params:
-      email: demo@catalogue.data.gouv.fr
-      password: demo
+      email: catalogue.demo@yopmail.com
+      password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:

--- a/ops/ansible/environments/staging/assets/initdata.yml
+++ b/ops/ansible/environments/staging/assets/initdata.yml
@@ -1,8 +1,8 @@
 users:
-  - id: "b80b614c-30d1-48cf-8acf-9f1056f8eb0f"
+  - id: "c33cc0bb-975c-45a1-ac2a-7fed9971ce6a"
     params:
-      email: demo@catalogue.data.gouv.fr
-      password: demo
+      email: catalogue.demo@yopmail.com
+      password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -1,8 +1,8 @@
 users:
-  - id: "b80b614c-30d1-48cf-8acf-9f1056f8eb0f"
+  - id: "c33cc0bb-975c-45a1-ac2a-7fed9971ce6a"
     params:
-      email: demo@catalogue.data.gouv.fr
-      password: demo
+      email: catalogue.demo@yopmail.com
+      password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:


### PR DESCRIPTION
### Cette PR ajoute:

- les modifications nécessaires afin que l'on puisse se connecter à l'application via datapass ou via le login avec les même credentials

Problématique:

avoir un compte qui permet de se connecter via le login et via datapass sur tout les environements (demo, local, staging)

Discussion sur mattermost :

```
Il faut que j'y réflechisse un peu. Il faut composer avec le fait que
1/ les adresses mail doivent être accessibles car il faut recevoir le code de validation
2/ les utilisateurs doivent utiliser le mm domaine si on veut les relier à la même orga sur staging et en local (cf mes explications sur le fait qu'il n'y a pas de validation humaine sur auth-staging)

Yopmail semblait être le plus simple pour ne pas dépendre de "vraies" adresses mail extérieures.

On aurait donc par ex :

[catalogue.demo@yopmail.com](mailto:catalogue.demo@yopmail.com) / password1234 (à inscrire dans le initdata local + staging + demo)
En local, chacun d'entre nous utilise une adresse @yopmail.com de son choix : ça liera les données à l'orga "Fake" ou "MC" (ou qq soit l'orga qu'on décide d'utiliser sur staging, par ex actuellement c'est le siret de Fake) sur auth-staging
```