### PR TITLE
Fix DataPass login when account already exists via a PasswordUser

### DIFF
--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -53,6 +53,8 @@ async def create_password_user(
         api_token=api_token,
     )
 
+    await account_repository.insert(account)
+
     password_user = PasswordUser(
         account_id=account.id,
         account=account,
@@ -102,6 +104,7 @@ async def create_datapass_user(command: CreateDataPassUser) -> ID:
             role=UserRole.USER,
             api_token=generate_api_token(),
         )
+        await account_repository.insert(account)
 
     datapass_user = await datapass_user_repository.get_by_email(email)
 

--- a/server/domain/auth/repositories.py
+++ b/server/domain/auth/repositories.py
@@ -16,6 +16,9 @@ class AccountRepository(Repository):
     async def get_by_api_token(self, api_token: str) -> Optional[Account]:
         raise NotImplementedError  # pragma: no cover
 
+    async def insert(self, account: Account) -> ID:
+        raise NotImplementedError  # pragma: no cover
+
 
 class PasswordUserRepository(Repository):
     async def get_by_email(self, email: str) -> Optional[PasswordUser]:

--- a/server/infrastructure/auth/repositories.py
+++ b/server/infrastructure/auth/repositories.py
@@ -54,6 +54,16 @@ class SqlAccountRepository(AccountRepository):
                 return None
             return make_account_entity(instance)
 
+    async def insert(self, account: Account) -> ID:
+        async with self._db.session() as session:
+            instance = make_account_instance(account)
+            session.add(instance)
+
+            await session.commit()
+            await session.refresh(instance)
+
+            return ID(instance.id)
+
 
 class SqlPasswordUserRepository(PasswordUserRepository):
     def __init__(self, db: Database) -> None:
@@ -85,9 +95,6 @@ class SqlPasswordUserRepository(PasswordUserRepository):
 
     async def insert(self, entity: PasswordUser) -> ID:
         async with self._db.session() as session:
-            account_instance = make_account_instance(entity.account)
-            session.add(account_instance)
-
             instance = make_password_user_instance(entity)
             session.add(instance)
 
@@ -145,9 +152,6 @@ class SqlDataPassUserRepository(DataPassUserRepository):
 
     async def insert(self, entity: DataPassUser) -> ID:
         async with self._db.session() as session:
-            account_instance = make_account_instance(entity.account)
-            session.add(account_instance)
-
             instance = make_datapass_user_instance(entity)
             session.add(instance)
 


### PR DESCRIPTION
Correctif suite à #365 

Si un `PasswordUser` existe déjà, se connecter avec le même email via DataPass entraînait une `IntegrityError` en DB car on essayait de créer un nouvel `Account` pour cet email alors qu'il existe déjà (il est lié au `PasswordUser` existant).

Cette PR corrige ce pb en séparant l'insertion d'un `Account` de celle d'un `PasswordUser` / `DataPassUser`. Ainsi on insert l'account au moment opportun (s'il n'existe pas encore, ce qu'on vérifiait déjà), sans que les repositories des *User ne doivent s'en soucier.