### PR TITLE
Add endpoint to register a DataPassUser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ authlib==1.0.1
 alembic==1.8.0
 fastapi==0.78.0
 gunicorn==20.1.0
-itsdangerous==2.1.2  # Starlette SessionMiddleware
+itsdangerous==2.1.2
 punq==0.6.2
 pydantic[email]==1.9.0
 python-json-logger==2.0.2

--- a/server/api/auth/datapass/schemas.py
+++ b/server/api/auth/datapass/schemas.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, EmailStr
+
+from server.domain.organizations.types import Siret
+
+
+class DataPassUserCreate(BaseModel):
+    email: EmailStr
+    organization_siret: Siret

--- a/server/application/auth/passwords.py
+++ b/server/application/auth/passwords.py
@@ -17,3 +17,11 @@ API_TOKEN_LENGTH = 64
 def generate_api_token() -> str:
     nbytes = API_TOKEN_LENGTH // 2
     return secrets.token_hex(nbytes)
+
+
+class Signer:
+    def sign(self, value: str) -> bytes:
+        raise NotImplementedError  # pragma: no cover
+
+    def verify(self, data: bytes) -> bool:
+        raise NotImplementedError  # pragma: no cover

--- a/server/config/di.py
+++ b/server/config/di.py
@@ -60,7 +60,7 @@ Or in any custom scripts as seems fit.
 """
 from typing import Type, TypeVar
 
-from server.application.auth.passwords import PasswordEncoder
+from server.application.auth.passwords import PasswordEncoder, Signer
 from server.domain.auth.repositories import (
     AccountRepository,
     DataPassUserRepository,
@@ -76,7 +76,10 @@ from server.infrastructure.auth.datapass import (
     DataPassOpenIDClient,
     get_datapass_openid_client,
 )
-from server.infrastructure.auth.passwords import Argon2PasswordEncoder
+from server.infrastructure.auth.passwords import (
+    Argon2PasswordEncoder,
+    ItsDangerousSigner,
+)
 from server.infrastructure.auth.repositories import (
     SqlAccountRepository,
     SqlDataPassUserRepository,
@@ -122,6 +125,7 @@ def configure(container: "Container") -> None:
 
     # Auth services
     container.register_instance(PasswordEncoder, Argon2PasswordEncoder())
+    container.register_instance(Signer, ItsDangerousSigner(settings))
     container.register_instance(
         DataPassOpenIDClient, get_datapass_openid_client(settings)
     )

--- a/server/infrastructure/auth/passwords.py
+++ b/server/infrastructure/auth/passwords.py
@@ -1,7 +1,9 @@
 import argon2
+import itsdangerous
 from pydantic import SecretStr
 
-from server.application.auth.passwords import PasswordEncoder
+from server.application.auth.passwords import PasswordEncoder, Signer
+from server.config.settings import Settings
 
 
 class Argon2PasswordEncoder(PasswordEncoder):
@@ -18,3 +20,14 @@ class Argon2PasswordEncoder(PasswordEncoder):
             return False
         except argon2.exceptions.InvalidHash:
             return False
+
+
+class ItsDangerousSigner(Signer):
+    def __init__(self, settings: Settings) -> None:
+        self._signer = itsdangerous.TimestampSigner(settings.secret_key)
+
+    def sign(self, value: str) -> bytes:
+        return self._signer.sign(value)
+
+    def verify(self, data: bytes) -> bool:
+        return self._signer.validate(data)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -7,7 +7,7 @@ from faker.providers import BaseProvider
 from pydantic import BaseModel
 from pydantic_factories import ModelFactory, Use
 
-from server.application.auth.commands import CreatePasswordUser
+from server.application.auth.commands import CreateDataPassUser, CreatePasswordUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.organizations.commands import CreateOrganization
 from server.application.tags.commands import CreateTag
@@ -42,6 +42,10 @@ class CreatePasswordUserFactory(Factory[CreatePasswordUser]):
     __model__ = CreatePasswordUser
 
     organization_siret = Use(lambda: LEGACY_ORGANIZATION_SIRET)
+
+
+class CreateDataPassUserFactory(Factory[CreateDataPassUser]):
+    __model__ = CreateDataPassUser
 
 
 class CreateTagFactory(Factory[CreateTag]):


### PR DESCRIPTION
* Closes #383
* Pré-requis backend pour la partie "N orgas" de #373 

Cette PR :

* Modifie le résultat du callback dans le cas "N orgas" : on renvoie désormais un token + un JSON `info { email, organizations }`
* Ajoute un endpoint `POST /auth/datapass/users/` qui attend le token + email + organization_siret

Documentation OpenAPI mise à jour :

![Screenshot 2022-08-30 at 17-02-15 FastAPI - Swagger UI](https://user-images.githubusercontent.com/15911462/187471981-0473fc81-be03-492b-8c99-b2ca5e2a458e.png) (75 kB)

![Screenshot 2022-08-30 at 17-02-35 FastAPI - Swagger UI](https://user-images.githubusercontent.com/15911462/187472027-6e5df04e-df8f-4b3c-987f-93c6a6f26935.png) (40 kB)