### PR TITLE
Exclude home page from SSR to fix connected flash

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,9 +1,7 @@
 import type { DataFormat, UpdateFrequency } from "./definitions/datasets";
 
-// Note : the / page (the home page) is "semi public". This page layout and information displayed depends whether the user is connected or not
-export const PUBLIC_PAGES = [
+export const STATIC_PAGES = [
   "/login",
-  "/",
   "/auth/datapass/create-organization",
   "/auth/datapass/login",
 ];

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,15 +1,16 @@
 import type { Handle } from "@sveltejs/kit";
 import { maybePatchDataUrl } from "$lib/fetch";
-import { PUBLIC_PAGES } from "./constants";
+import { STATIC_PAGES } from "./constants";
 
 // See: https://kit.svelte.dev/docs/hooks#handle
 export const handle: Handle = async ({ event, resolve }) => {
   let response = await resolve(event, {
-    // NOTE: SSR usage is aimed at improving SEO, so we focus on public pages.
+    // NOTE: SSR usage is aimed at improving SEO, so we focus on static pages
+    // that do not depend on user authentication.
     // This also happens to simplify the e2e test setup, as auth state
     // for private pages can then be exclusively managed in the browser.
     // See: https://github.com/etalab/catalogage-donnees/pull/143
-    ssr: PUBLIC_PAGES.includes(event.url.pathname),
+    ssr: STATIC_PAGES.includes(event.url.pathname),
   });
 
   response = await maybePatchDataUrl(response, event.url);

--- a/client/src/lib/auth/guard.ts
+++ b/client/src/lib/auth/guard.ts
@@ -1,7 +1,7 @@
 import { get } from "svelte/store";
 import type { LoadOutput } from "@sveltejs/kit";
 import { user } from "../stores/auth";
-import { PUBLIC_PAGES } from "src/constants";
+import { STATIC_PAGES } from "src/constants";
 import { Maybe } from "$lib/util/maybe";
 
 /**
@@ -9,7 +9,7 @@ import { Maybe } from "$lib/util/maybe";
  * is attempting to access a protected page.
  */
 export const authGuard = (url: URL): LoadOutput => {
-  if (PUBLIC_PAGES.includes(url.pathname)) {
+  if (STATIC_PAGES.includes(url.pathname)) {
     return {};
   }
 


### PR DESCRIPTION
La page `/` est "semi-publique": elle a un contenu différent selon qu'on est connecté ou pas.

Actuellement elle souffre d'un **flash**. En effet, le SSR est activé sur cette page, et comme le serveur n'a aucune connaissance de l'état d'authentification, quand on est connecté on voit apparaître la page non-connecté pendant un court instant (elle provient du HTML généré par le serveur), puis quand le SPA prend le relais et calcule `$user`, on bascule sur la vue connectée.

Cette PR corrige ce flash en excluant la page `/` du SSR, puisque celle-ci dépend en réalité d'un état d'authentification que le serveur ne peut pas connaître.

Elle renomme donc `PUBLIC_PAGES` en `STATIC_PAGES` pour qu'il soit plus clair ce qui peut être servi en SSR ou non à ce stade.

**Alternatives envisagées**

Il est théoriquement possible de stocker les infos d'authentification sur le serveur SvelteKit et de passer par un cookie, de cette façon on pourrait servir à peu près n'importe quelle page en SSR, mais c'est bien plus complexe.