### PR TITLE
Fix redirect loop on home page

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -6,6 +6,8 @@ export const STATIC_PAGES = [
   "/auth/datapass/login",
 ];
 
+export const NON_AUTH_GUARDED_PAGES = [...STATIC_PAGES, "/"];
+
 export const DATA_FORMAT_LABELS: { [K in DataFormat]: string } = {
   file_tabular: "Fichier tabulaire (XLS, XLSX, CSV, ...)",
   file_gis: "Fichier SIG (Shapefile, ...)",

--- a/client/src/lib/auth/guard.ts
+++ b/client/src/lib/auth/guard.ts
@@ -1,7 +1,7 @@
 import { get } from "svelte/store";
 import type { LoadOutput } from "@sveltejs/kit";
 import { user } from "../stores/auth";
-import { STATIC_PAGES } from "src/constants";
+import { NON_AUTH_GUARDED_PAGES } from "src/constants";
 import { Maybe } from "$lib/util/maybe";
 
 /**
@@ -9,7 +9,7 @@ import { Maybe } from "$lib/util/maybe";
  * is attempting to access a protected page.
  */
 export const authGuard = (url: URL): LoadOutput => {
-  if (STATIC_PAGES.includes(url.pathname)) {
+  if (NON_AUTH_GUARDED_PAGES.includes(url.pathname)) {
     return {};
   }
 


### PR DESCRIPTION
Corrige un bug introduit par #398 

`PUBLIC_PAGES` était aussi utilisé par le `authGuard` pour ne pas vérifier la présence de `$user` sur certaines pages.

En le transformant en `STATIC_PAGES` (qui exclut du SSR) et en en retiarnt `/`, la page d'accueil non-connectée souffre maintenant d'une **500 Redirect Loop**.

Pour l'instant j'utilise donc une nouvelle variable au nom peu élégant mais évocateur.

Je vais déployer sur staging pour vérifier, puis merger et déployer pour corriger le bug (hotfix).

Ce bug a pu apparaître car notre CI n'échoue toujours pas si les tests E2E sont HS. Or ils l'étaient sur #398 et je ne l'ai pas vu. Par ailleurs le comportement qui était sensé être corrigé par #392 en passant à Node v16 sur la CI semble être revenu...