### PR TITLE
Fix console error when manipulating contactEmails field

### DIFF
--- a/client/src/lib/components/ContactEmailsField/ContactEmailsField.svelte
+++ b/client/src/lib/components/ContactEmailsField/ContactEmailsField.svelte
@@ -54,7 +54,7 @@
             id="contactEmails-{i}"
             data-testid="contactEmails"
             placeholder="Adresse e-mail"
-            name={contactEmails[i]}
+            name="contactEmails-{i}"
             required={!hasAtLeastOneEmail}
             on:change
             on:blur

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -174,6 +174,11 @@
     dispatch("touched");
   };
 
+  const handleContactEmailsChange = () => {
+    // Skip regular handleChange() as the array has already been updated.
+    dispatch("touched");
+  };
+
   const handleLastUpdatedAtChange = async (
     event: Event & { currentTarget: EventTarget & HTMLInputElement }
   ) => {
@@ -336,8 +341,8 @@
     <ContactEmailsField
       bind:errors={emailErrors}
       bind:contactEmails={$form.contactEmails}
-      on:blur={handleFieldChange}
-      on:input={handleFieldChange}
+      on:blur={handleContactEmailsChange}
+      on:input={handleContactEmailsChange}
     />
   </div>
 


### PR DESCRIPTION
**Motivation**

Il y avait une erreur dans la console lorsqu'on manipulait (input ou focus/blur) le champ des contacts. Elle provenait de yup : le nom du champ était dynamique : `contactEmails[i]` (par exemple : `catalogue.demo@yopmail.com`) et cette valeur était utilisée par yup pour mettre à jour l'équivalent de `$form[contactEmails[i]]`, qui évidemment n'existait pas.

En réalité `ContactEmailsField` met déjà à jour l'array qui est bindée à `$form.contactEmails`, donc $il me semble* qu'on peut se contenter de propager l'event `touched` comme dans les autres cas, sans faire gérer la mise à jour.

De fait, manuellement ça fonctionne et les tests E2E (_à lancer manuellement en local_, cf #390) sont OK.