### PR TITLE
Refactor client auth

### DIFF
--- a/client/src/definitions/auth.ts
+++ b/client/src/definitions/auth.ts
@@ -5,26 +5,24 @@ export interface LoginFormData {
   password: string;
 }
 
-export interface LoginApiRequestData {
+export interface PasswordLoginData {
   email: string;
   password: string;
 }
 
 export type UserRole = "USER" | "ADMIN";
 
-export interface LoginApiResponseData {
+export interface Account {
   email: string;
   role: UserRole;
-  apiToken: string;
 }
 
-export interface User {
-  email: string;
-  role: UserRole;
+export interface AuthenticatedUser {
+  account: Account;
   apiToken: string;
 }
 
 export interface UserInfo {
   loggedIn: boolean;
-  user: Maybe<User>;
+  authenticatedUser: Maybe<AuthenticatedUser>;
 }

--- a/client/src/lib/auth/guard.ts
+++ b/client/src/lib/auth/guard.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store";
 import type { LoadOutput } from "@sveltejs/kit";
-import { user } from "../stores/auth";
+import { account } from "../stores/auth";
 import { NON_AUTH_GUARDED_PAGES } from "src/constants";
 import { Maybe } from "$lib/util/maybe";
 
@@ -13,7 +13,7 @@ export const authGuard = (url: URL): LoadOutput => {
     return {};
   }
 
-  if (Maybe.Some(get(user))) {
+  if (Maybe.Some(get(account))) {
     return {};
   }
 

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -254,7 +254,7 @@ describe("Test the dataset form", () => {
 
   describe("Authenticated tests", () => {
     beforeAll(() =>
-      login({ email: "john@domain.org", role: "USER", apiToken: "abcd1234" })
+      login({ email: "john@domain.org", role: "USER" }, "abcd1234")
     );
 
     afterAll(() => logout());

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -11,7 +11,7 @@
   import { DATA_FORMAT_LABELS, UPDATE_FREQUENCY_LABELS } from "src/constants";
   import { formatHTMLDate } from "$lib/util/format";
   import RequiredMarker from "../RequiredMarker/RequiredMarker.svelte";
-  import { user } from "src/lib/stores/auth";
+  import { account } from "src/lib/stores/auth";
   import ContactEmailsField from "../ContactEmailsField/ContactEmailsField.svelte";
   import GeographicalCoverageField from "./_GeographicalCoverageField.svelte";
   import Select from "../Select/Select.svelte";
@@ -63,7 +63,7 @@
       ({ value }) => !!(initial?.formats || []).find((v) => v === value)
     ),
     producerEmail: initial?.producerEmail || "",
-    contactEmails: initial?.contactEmails || [$user?.email || ""],
+    contactEmails: initial?.contactEmails || [$account?.email || ""],
     lastUpdatedAt: initial?.lastUpdatedAt
       ? formatHTMLDate(initial.lastUpdatedAt)
       : null,

--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
-  import { logout, user } from "$lib/stores/auth";
+  import { logout, account } from "$lib/stores/auth";
   import paths from "$lib/paths";
   import { Maybe } from "$lib/util/maybe";
 
@@ -72,9 +72,9 @@
         </div>
         <div class="fr-header__tools tools-container">
           <div class="fr-header__tools-links">
-            {#if Maybe.Some($user)}
+            {#if Maybe.Some($account)}
               <p>
-                {$user.email}
+                {$account.email}
               </p>
               <ul class="fr-btns-group">
                 <li>
@@ -116,7 +116,7 @@
 
       <div class="fr-header__menu-links" />
 
-      {#if Maybe.Some($user)}
+      {#if Maybe.Some($account)}
         <nav
           class="fr-nav"
           role="navigation"

--- a/client/src/lib/transformers/auth.ts
+++ b/client/src/lib/transformers/auth.ts
@@ -1,0 +1,8 @@
+import type { Account } from "src/definitions/auth";
+
+export const toAccount = (data: any): Account => {
+  return {
+    email: data.email,
+    role: data.role,
+  };
+};

--- a/client/src/routes/__layout@base.svelte
+++ b/client/src/routes/__layout@base.svelte
@@ -3,14 +3,14 @@
   import Footer from "$lib/components/Footer/Footer.svelte";
   import { onMount } from "svelte";
   import LayoutProviders from "$lib/providers/LayoutProviders.svelte";
-  import { user } from "$lib/stores/auth";
+  import { account, apiToken } from "$lib/stores/auth";
   import { checkLogin } from "$lib/repositories/auth";
   import { Maybe } from "$lib/util/maybe";
 
   onMount(async () => {
-    if (Maybe.Some($user)) {
+    if (Maybe.Some($account)) {
       // Ensure user session is still valid.
-      await checkLogin({ fetch, apiToken: $user.apiToken });
+      await checkLogin({ fetch, apiToken: $apiToken });
     }
   });
 </script>

--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { apiToken, user } from "src/lib/stores/auth";
+  import { apiToken, account } from "src/lib/stores/auth";
   import DatasetListTemplate from "src/lib/templates/DatasetListTemplate/DatasetListTemplate.svelte";
 
   import { getPageFromParams } from "src/lib/util/pagination";
@@ -11,7 +11,7 @@
   let pageNumber = getPageFromParams($page.url.searchParams) || 1;
 </script>
 
-{#if $user}
+{#if $account}
   {#await getDatasets({ fetch, apiToken: $apiToken, page: pageNumber })}
     <div class="spinner-container">
       <Spinner />

--- a/client/src/routes/login.svelte
+++ b/client/src/routes/login.svelte
@@ -4,9 +4,9 @@
 
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import type { LoginFormData, User } from "src/definitions/auth";
+  import type { LoginFormData } from "src/definitions/auth";
   import { login } from "$lib/stores/auth";
-  import { login as sendLoginRequest } from "$lib/repositories/auth";
+  import { loginWithPassword } from "$lib/repositories/auth";
   import LoginForm from "$lib/components/LoginForm/LoginForm.svelte";
 
   let loading = false;
@@ -17,20 +17,16 @@
       loading = true;
       loginFailed = false;
 
-      const response = await sendLoginRequest({ fetch, data: event.detail });
+      const response = await loginWithPassword({ fetch, data: event.detail });
       loginFailed = response.status === 401;
 
       if (loginFailed) {
         return;
       }
 
-      const user: User = {
-        email: response.data.email,
-        role: response.data.role,
-        apiToken: response.data.apiToken,
-      };
+      const { account, apiToken } = response.data;
 
-      login(user);
+      login(account, apiToken);
       await goto("/");
     } finally {
       loading = false;


### PR DESCRIPTION
En préparation de #409 (ou d'une autre PR encore plus petite qui ajoutera `user.organizationSiret`),

Cette PR :

* Revoit les définitions des types utilisateur pour mieux coller à la logique qui prévaut désormais dans le back.
  * À savoir : séparer les informations de "compte" (email, role... sous `Account`) et les informations de sécurité (apiToken).
    * NB : le nom "Account" vient du back, mais je suis ouvert à garder `User` côté front, car vérifier `if ($account)` pour savoir si on est connecté avec un utilisateur à disposition semble moins "intuitif" que faire `if ($user)`.
  * En effet, ces informations ne doivent être manipulées ensemble qu'après un login, où l'on obtient un `AuthenticatedUser`. Le reste du temps, l'application devrait les manipuler séparément, en accédant à `$account` (pour inspecter l'utilisateur courant) ou à `$apiToken` (pour faire des requêtes d'API).
* Déplace le code de parsing du login datapass vers `repositories/auth.ts`, à côté du code qui fait la requête email/mdp.