### PR TITLE
Expose full organization in dataset.catalog_record

### DIFF
--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -15,6 +15,7 @@ from server.domain.common.pagination import Page, Pagination
 from server.domain.common.types import ID
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.specifications import DatasetSpec
+from server.domain.organizations.exceptions import OrganizationDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
 from ..auth.permissions import HasRole, IsAuthenticated
@@ -81,7 +82,10 @@ async def create_dataset(data: DatasetCreate) -> DatasetView:
 
     command = CreateDataset(**data.dict())
 
-    id = await bus.execute(command)
+    try:
+        id = await bus.execute(command)
+    except OrganizationDoesNotExist as exc:
+        raise HTTPException(400, detail=str(exc))
 
     query = GetDatasetByID(id=id)
     return await bus.execute(query)

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -11,6 +11,8 @@ from server.application.datasets.validation import (
 )
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
+from server.domain.organizations.entities import LEGACY_ORGANIZATION
+from server.domain.organizations.types import Siret
 
 
 class DatasetListParams:
@@ -38,6 +40,7 @@ class DatasetListParams:
 
 
 class DatasetCreate(CreateDatasetValidationMixin, BaseModel):
+    organization_siret: Siret = LEGACY_ORGANIZATION.siret
     title: str
     description: str
     service: str

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -1,13 +1,13 @@
 from pydantic import EmailStr, SecretStr
 
 from server.domain.common.types import ID
-from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
 
 class CreatePasswordUser(Command[ID]):
-    organization_siret: Siret = LEGACY_ORGANIZATION_SIRET
+    organization_siret: Siret = LEGACY_ORGANIZATION.siret
     email: EmailStr
     password: SecretStr
 

--- a/server/application/catalog_records/views.py
+++ b/server/application/catalog_records/views.py
@@ -3,10 +3,11 @@ import datetime as dt
 from pydantic import BaseModel
 
 from server.domain.common.types import ID
-from server.domain.organizations.types import Siret
+
+from ..organizations.views import OrganizationView
 
 
 class CatalogRecordView(BaseModel):
     id: ID
-    organization_siret: Siret
+    organization: OrganizationView
     created_at: dt.datetime

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -6,7 +6,7 @@ from pydantic import EmailStr, Field
 from server.domain.catalogs.entities import ExtraFieldValue
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
-from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
@@ -14,7 +14,7 @@ from .validation import CreateDatasetValidationMixin, UpdateDatasetValidationMix
 
 
 class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
-    organization_siret: Siret = LEGACY_ORGANIZATION_SIRET
+    organization_siret: Siret = LEGACY_ORGANIZATION.siret
     title: str
     description: str
     service: str

--- a/server/domain/catalog_records/entities.py
+++ b/server/domain/catalog_records/entities.py
@@ -6,10 +6,10 @@ from server.seedwork.domain.entities import Entity
 
 from ..common import datetime as dtutil
 from ..common.types import ID
-from ..organizations.types import Siret
+from ..organizations.entities import Organization
 
 
 class CatalogRecord(Entity):
     id: ID
-    organization_siret: Siret
+    organization: Organization
     created_at: dt.datetime = Field(default_factory=dtutil.now)

--- a/server/domain/organizations/entities.py
+++ b/server/domain/organizations/entities.py
@@ -8,7 +8,9 @@ class Organization(Entity):
     siret: Siret
 
 
-# A fake SIRET used for the organization that holds legacy users and whose catalog holds
-# legacy datasets. "Legacy" means "before the multi-org system powered by DataPass.
+# This organization holds legacy users. Its catalog holds legacy datasets.
+# "Legacy" means "prior to multi-org system powered by DataPass".
 # Going forward SIRET numbers will come from DataPass via the user's organization(s).
-LEGACY_ORGANIZATION_SIRET = Siret("000 000 000 00000")
+LEGACY_ORGANIZATION = Organization(
+    name="Organisation par défaut", siret=Siret("000 000 000 00000")
+)

--- a/server/infrastructure/catalog_records/transformers.py
+++ b/server/infrastructure/catalog_records/transformers.py
@@ -1,12 +1,13 @@
 from server.domain.catalog_records.entities import CatalogRecord
 
+from ..organizations.transformers import make_entity as make_organization_entity
 from .models import CatalogRecordModel
 
 
 def make_entity(instance: CatalogRecordModel) -> CatalogRecord:
     return CatalogRecord(
         id=instance.id,
-        organization_siret=instance.organization_siret,
+        organization=make_organization_entity(instance.catalog.organization),
         created_at=instance.created_at,
     )
 
@@ -15,7 +16,9 @@ def make_instance(entity: CatalogRecord) -> CatalogRecordModel:
     return CatalogRecordModel(
         **entity.dict(
             exclude={
+                "organization",
                 "created_at",  # Managed by DB for better time consistency
             }
         ),
+        organization_siret=entity.organization.siret,
     )

--- a/server/infrastructure/datasets/models.py
+++ b/server/infrastructure/datasets/models.py
@@ -17,11 +17,11 @@ from sqlalchemy.orm import Mapped, relationship
 
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 
-from ..catalog_records.models import CatalogRecordModel
 from ..database import Base, mapper_registry
 from ..tags.models import TagModel, dataset_tag
 
 if TYPE_CHECKING:  # pragma: no cover
+    from ..catalog_records.models import CatalogRecordModel
     from ..catalogs.models import ExtraFieldValueModel
 
 # Association table

--- a/server/infrastructure/datasets/repositories.py
+++ b/server/infrastructure/datasets/repositories.py
@@ -10,7 +10,9 @@ from server.domain.datasets.entities import Dataset
 from server.domain.datasets.repositories import DatasetGetAllExtras, DatasetRepository
 from server.domain.datasets.specifications import DatasetSpec
 
+from ..catalog_records.models import CatalogRecordModel
 from ..catalog_records.raw_queries import get_catalog_record_instance_by_id
+from ..catalogs.models import CatalogModel
 from ..database import Database
 from ..helpers.sqlalchemy import get_count_from, to_limit_offset
 from ..tags.raw_queries import get_all_tag_instances_by_ids
@@ -49,9 +51,13 @@ class SqlDatasetRepository(DatasetRepository):
         stmt = (
             select(DatasetModel)
             .join(DatasetModel.catalog_record)
+            .join(CatalogRecordModel.catalog)
+            .join(CatalogModel.organization)
             .where(DatasetModel.id == id)
             .options(
-                contains_eager(DatasetModel.catalog_record),
+                contains_eager(DatasetModel.catalog_record)
+                .contains_eager(CatalogRecordModel.catalog)
+                .contains_eager(CatalogModel.organization),
                 selectinload(DatasetModel.formats),
                 selectinload(DatasetModel.tags),
                 selectinload(DatasetModel.extra_field_values),

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -8,7 +8,7 @@ from server.application.auth.queries import GetAccountByEmail
 from server.config.di import resolve
 from server.domain.auth.exceptions import AccountDoesNotExist
 from server.domain.common.types import id_factory
-from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.seedwork.application.messages import MessageBus
 
 from ..helpers import TestPasswordUser
@@ -89,7 +89,7 @@ async def test_create_user(
     assert isinstance(id_, str)
     assert user == {
         "id": id_,
-        "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+        "organization_siret": str(LEGACY_ORGANIZATION.siret),
         "email": "john@doe.com",
         "role": "USER",
     }
@@ -112,7 +112,7 @@ async def test_login(client: httpx.AsyncClient, temp_user: TestPasswordUser) -> 
     user = response.json()
     assert user == {
         "id": str(temp_user.account_id),
-        "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+        "organization_siret": str(LEGACY_ORGANIZATION.siret),
         "email": temp_user.account.email,
         "role": temp_user.account.role.value,
         "api_token": temp_user.account.api_token,

--- a/tests/api/test_catalogs.py
+++ b/tests/api/test_catalogs.py
@@ -32,7 +32,7 @@ async def test_catalog_create(client: httpx.AsyncClient) -> None:
 
     dataset_id = await bus.execute(CreateDatasetFactory.build(organization_siret=siret))
     dataset = await bus.execute(GetDatasetByID(id=dataset_id))
-    assert dataset.catalog_record.organization_siret == siret
+    assert dataset.catalog_record.organization.siret == siret
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -15,7 +15,7 @@ from server.domain.catalogs.entities import ExtraFieldValue, TextExtraField
 from server.domain.common.types import ID, id_factory
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.datasets.exceptions import DatasetDoesNotExist
-from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.infrastructure.catalogs.models import ExtraFieldValueModel
 from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
@@ -132,7 +132,7 @@ async def test_dataset_crud(
         "id": pk,
         "catalog_record": {
             **data["catalog_record"],
-            "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+            "organization_siret": str(LEGACY_ORGANIZATION.siret),
         },
         "title": "Example title",
         "description": "Example description",
@@ -482,7 +482,7 @@ class TestDatasetUpdate:
             "id": str(dataset_id),
             "catalog_record": {
                 **data["catalog_record"],
-                "organization_siret": str(LEGACY_ORGANIZATION_SIRET),
+                "organization_siret": str(LEGACY_ORGANIZATION.siret),
             },
             "title": "Other title",
             "description": "Other description",

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -16,6 +16,7 @@ from server.domain.common.types import ID, id_factory
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.organizations.entities import LEGACY_ORGANIZATION
+from server.domain.organizations.types import Siret
 from server.infrastructure.catalogs.models import ExtraFieldValueModel
 from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
@@ -98,6 +99,18 @@ async def test_create_dataset_invalid(
 
 
 @pytest.mark.asyncio
+async def test_create_dataset_invalid_organization_does_not_exist(
+    client: httpx.AsyncClient, temp_user: TestPasswordUser
+) -> None:
+    siret = Siret(fake.siret())
+    payload = to_payload(CreateDatasetFactory.build(organization_siret=siret))
+    response = await client.post("/datasets/", json=payload, auth=temp_user.auth)
+    assert response.status_code == 400
+    data = response.json()
+    assert data["detail"] == f"Organization not found: '{siret}'"
+
+
+@pytest.mark.asyncio
 async def test_dataset_crud(
     client: httpx.AsyncClient, temp_user: TestPasswordUser, admin_user: TestPasswordUser
 ) -> None:
@@ -132,7 +145,7 @@ async def test_dataset_crud(
         "id": pk,
         "catalog_record": {
             **data["catalog_record"],
-            "organization_siret": str(LEGACY_ORGANIZATION.siret),
+            "organization": LEGACY_ORGANIZATION.dict(),
         },
         "title": "Example title",
         "description": "Example description",
@@ -482,7 +495,7 @@ class TestDatasetUpdate:
             "id": str(dataset_id),
             "catalog_record": {
                 **data["catalog_record"],
-                "organization_siret": str(LEGACY_ORGANIZATION.siret),
+                "organization": LEGACY_ORGANIZATION.dict(),
             },
             "title": "Other title",
             "description": "Other description",

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,7 @@ from server.application.tags.commands import CreateTag
 from server.domain.common import datetime as dtutil
 from server.domain.datasets.entities import DataFormat
 from server.domain.licenses.entities import BUILTIN_LICENSE_SUGGESTIONS
-from server.domain.organizations.entities import LEGACY_ORGANIZATION_SIRET
+from server.domain.organizations.entities import LEGACY_ORGANIZATION
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -41,7 +41,7 @@ class Factory(ModelFactory[T]):
 class CreatePasswordUserFactory(Factory[CreatePasswordUser]):
     __model__ = CreatePasswordUser
 
-    organization_siret = Use(lambda: LEGACY_ORGANIZATION_SIRET)
+    organization_siret = Use(lambda: LEGACY_ORGANIZATION.siret)
 
 
 class CreateDataPassUserFactory(Factory[CreateDataPassUser]):
@@ -55,7 +55,7 @@ class CreateTagFactory(Factory[CreateTag]):
 class CreateDatasetFactory(Factory[CreateDataset]):
     __model__ = CreateDataset
 
-    organization_siret = Use(lambda: LEGACY_ORGANIZATION_SIRET)
+    organization_siret = Use(lambda: LEGACY_ORGANIZATION.siret)
     title = Use(fake.sentence)
     description = Use(fake.text)
     service = Use(fake.company)

--- a/tests/infrastructure/test_catalogs.py
+++ b/tests/infrastructure/test_catalogs.py
@@ -43,4 +43,4 @@ async def test_catalog_creation_and_relationships() -> None:
     dataset_id = await bus.execute(CreateDatasetFactory.build(organization_siret=siret))
 
     dataset = await bus.execute(GetDatasetByID(id=dataset_id))
-    assert dataset.catalog_record.organization_siret == siret
+    assert dataset.catalog_record.organization.siret == siret


### PR DESCRIPTION
Prérequis à #409 

Actuellement on uniquement accès au SIRET de l'organisation associée à un jeu de donnée via `dataset.catalog_record.organization_siret`

Cette PR expose l'organisation complète `{ siret, name }` ici : `dataset.catalog_record.organization`

Cela permettra au front de manipuler à la fois le SIRET et le nom de l'organisation.