### PR TITLE
Fix inconsistencies in initdata organization links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ initdata: #- Initialize data
 initdatareset: #- Initialize data, resetting any changed target entities
 	${bin}python -m tools.initdata --reset tools/initdata.yml
 
+n ?= 500
 randomdatasets: #- Add 500 random datasets
-	${bin}python -m tools.addrandomdatasets 500
+	${bin}python -m tools.addrandomdatasets $(n) $(siret)
 
 id: #- Generate an ID suitable for use in database entities
 	${bin}python -m tools.makeid

--- a/docs/fr/outils.md
+++ b/docs/fr/outils.md
@@ -120,6 +120,20 @@ N.B. : Avant de créer chaque entité, le script s'assure qu'elle n'existe pas d
 
 Pour plus de détails, lire le code source.
 
+### Jeux de données aléatoires
+
+Il est possible d'ajouter un paquet de jeux de données aléatoires au catalogue d'une organisation de cette façon:
+
+```bash
+siret=... make randomdatasets
+```
+
+Par défaut 500 jeux de données sont ajoutés. Pour en ajouter une autre quantité, utiliser :
+
+```bash
+siret=... n=... make randomdatasets
+```
+
 ## Générer un UUID
 
 Pour générer un UUID d'entité, lancer :

--- a/ops/ansible/environments/demo/assets/initdata.yml
+++ b/ops/ansible/environments/demo/assets/initdata.yml
@@ -1,11 +1,27 @@
+organizations:
+  - params:
+      name: "Ministère de la Culture"
+      siret: "11004601800013"
+
+catalogs:
+  - params:
+      organization_siret: "11004601800013"
+      extra_fields:
+        - name: referentiel
+          title: Référentiel ou norme
+          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
+          type: TEXT
+
 users:
   - id: "c33cc0bb-975c-45a1-ac2a-7fed9971ce6a"
     params:
+      organization_siret: "11004601800013"
       email: catalogue.demo@yopmail.com
       password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:
+      organization_siret: "11004601800013"
       email: admin@catalogue.data.gouv.fr
       password: __env__
     extras:
@@ -44,6 +60,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/donnees-brutes-de-l-inventaire-forestier/
     id: "16b398af-f8c7-48b9-898a-18ad3404f528"
     params:
+      organization_siret: "11004601800013"
       title: Données brutes de l'inventaire forestier
       description: |
         Les données brutes de l'inventaire forestier correspondent à l'ensemble des données collectées en forêt (y compris en peupleraie) sur le territoire métropolitain par les agents forestiers de terrain de l'IGN. Ces données portent sur les caractéristiques des placettes d'inventaire (6000 par an), les mesures et observations sur les arbres (60 000 par an), les données éco-floristiques.
@@ -66,6 +83,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
     params:
+      organization_siret: "11004601800013"
       title: Ensemble des lieux de restauration des CROUS
       description: |
         Les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
@@ -86,6 +104,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/
     id: "3707e03b-d020-4a14-bb85-1ad0545b1578"
     params:
+      organization_siret: "11004601800013"
       title: Restaurants, brasseries et cafétérias des CROUS
       description: |
         Par région, les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
@@ -107,6 +126,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
     params:
+      organization_siret: "11004601800013"
       title: Catalogue des enquêtes réalisées par la DARES
       description: |
         Présentation sous forme de fiches répertoriées par thèmes des enquêtes menées par la DARES avec reprise des objectifs, de la périodicité, de la taille de l'échantillon, des publications.
@@ -123,17 +143,3 @@ datasets:
       license: Licence Ouverte
       tag_ids: []
       extra_field_values: []
-
-organizations:
-  - params:
-      name: "Ministère de la Culture"
-      siret: "11004601800013"
-
-catalogs:
-  - params:
-      organization_siret: "11004601800013"
-      extra_fields:
-        - name: referentiel
-          title: Référentiel ou norme
-          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
-          type: TEXT

--- a/ops/ansible/environments/demo/assets/initdata.yml
+++ b/ops/ansible/environments/demo/assets/initdata.yml
@@ -100,6 +100,7 @@ datasets:
       license: Autre (Open)
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/
     id: "3707e03b-d020-4a14-bb85-1ad0545b1578"

--- a/ops/ansible/environments/staging/assets/initdata.yml
+++ b/ops/ansible/environments/staging/assets/initdata.yml
@@ -1,11 +1,27 @@
+organizations:
+  - params:
+      name: "Ministère de la Culture"
+      siret: "11004601800013"
+
+catalogs:
+  - params:
+      organization_siret: "11004601800013"
+      extra_fields:
+        - name: referentiel
+          title: Référentiel ou norme
+          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
+          type: TEXT
+
 users:
   - id: "c33cc0bb-975c-45a1-ac2a-7fed9971ce6a"
     params:
+      organization_siret: "11004601800013"
       email: catalogue.demo@yopmail.com
       password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:
+      organization_siret: "11004601800013"
       email: admin@catalogue.data.gouv.fr
       password: __env__
     extras:
@@ -44,6 +60,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/donnees-brutes-de-l-inventaire-forestier/
     id: "16b398af-f8c7-48b9-898a-18ad3404f528"
     params:
+      organization_siret: "11004601800013"
       title: Données brutes de l'inventaire forestier
       description: |
         Les données brutes de l'inventaire forestier correspondent à l'ensemble des données collectées en forêt (y compris en peupleraie) sur le territoire métropolitain par les agents forestiers de terrain de l'IGN. Ces données portent sur les caractéristiques des placettes d'inventaire (6000 par an), les mesures et observations sur les arbres (60 000 par an), les données éco-floristiques.
@@ -66,6 +83,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
     params:
+      organization_siret: "11004601800013"
       title: Ensemble des lieux de restauration des CROUS
       description: |
         Les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
@@ -86,6 +104,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/
     id: "3707e03b-d020-4a14-bb85-1ad0545b1578"
     params:
+      organization_siret: "11004601800013"
       title: Restaurants, brasseries et cafétérias des CROUS
       description: |
         Par région, les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
@@ -107,6 +126,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
     params:
+      organization_siret: "11004601800013"
       title: Catalogue des enquêtes réalisées par la DARES
       description: |
         Présentation sous forme de fiches répertoriées par thèmes des enquêtes menées par la DARES avec reprise des objectifs, de la périodicité, de la taille de l'échantillon, des publications.
@@ -123,17 +143,3 @@ datasets:
       license: Licence Ouverte
       tag_ids: []
       extra_field_values: []
-
-organizations:
-  - params:
-      name: "Ministère de la Culture"
-      siret: "11004601800013"
-
-catalogs:
-  - params:
-      organization_siret: "11004601800013"
-      extra_fields:
-        - name: referentiel
-          title: Référentiel ou norme
-          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
-          type: TEXT

--- a/ops/ansible/environments/staging/assets/initdata.yml
+++ b/ops/ansible/environments/staging/assets/initdata.yml
@@ -100,6 +100,7 @@ datasets:
       license: Autre (Open)
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
+      extra_field_values: []
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/
     id: "3707e03b-d020-4a14-bb85-1ad0545b1578"

--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -93,16 +93,17 @@ async def create_datapass_user(command: CreateDataPassUser) -> ID:
 
     email = command.email
 
-    # Reuse an existing account (e.g. tied to an existing PasswordUser), or create one.
+    # Reuse an existing account tied to an existing PasswordUser, or create one.
     account = await account_repository.get_by_email(email)
 
-    # Caution: if we messed up data setup, it may not be linked to the same
-    # organization...
+    # Ensure the existing account is linked to the same organization.
+    # A misconfigured initdata.yml used to allow different organizations.
+    # See: https://github.com/etalab/catalogage-donnees/issues/414
     if account is not None and account.organization_siret != command.organization_siret:
         raise RuntimeError(
             f"Found account for {email=!r} "
             f"in organization {account.organization_siret!r}, "
-            "and requested to create a DataPassUser for it "
+            "but requested to create a DataPassUser "
             f"in different organization {command.organization_siret!r}. "
             "HINT: This is most likely a data setup issue on the developer side. "
             "Did you set up a PasswordUser for this email "

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -52,6 +52,16 @@ class CreateTagFactory(Factory[CreateTag]):
     __model__ = CreateTag
 
 
+_FAKE_GEOGRAPHICAL_COVERAGES = [
+    "Ville d'Angers",
+    "Métropole Européenne de Lille",
+    "Région Île-de-France",
+    "Région Nouvelle-Aquitaine",
+    "France métropolitaine",
+    "Monde",
+]
+
+
 class CreateDatasetFactory(Factory[CreateDataset]):
     __model__ = CreateDataset
 
@@ -59,6 +69,7 @@ class CreateDatasetFactory(Factory[CreateDataset]):
     title = Use(fake.sentence)
     description = Use(fake.text)
     service = Use(fake.company)
+    geographical_coverage = Use(lambda: random.choice(_FAKE_GEOGRAPHICAL_COVERAGES))
     formats = Use(lambda: random.choices(list(DataFormat), k=random.randint(1, 3)))
     technical_source = Use(
         lambda: fake.sentence(nb_words=3) if random.random() < 0.5 else None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,7 +13,11 @@ from .factories import CreatePasswordUserFactory
 
 
 def create_client(app: Callable) -> httpx.AsyncClient:
-    return httpx.AsyncClient(app=app, base_url="http://testserver")
+    transport = httpx.ASGITransport(
+        app,
+        raise_app_exceptions=True,  # We explicitly want this.
+    )
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
 
 
 def to_payload(obj: BaseModel) -> dict:

--- a/tests/tools/test_addrandomdatasets.py
+++ b/tests/tools/test_addrandomdatasets.py
@@ -1,8 +1,10 @@
 import pytest
 
+from server.application.catalogs.commands import CreateCatalog
 from server.application.datasets.queries import GetAllDatasets
 from server.config.di import resolve
 from server.seedwork.application.messages import MessageBus
+from tests.factories import CreateOrganizationFactory
 from tools import addrandomdatasets
 
 
@@ -11,10 +13,13 @@ from tools import addrandomdatasets
 async def test_addrandomdatasets() -> None:
     bus = resolve(MessageBus)
 
+    siret = await bus.execute(CreateOrganizationFactory.build())
+    await bus.execute(CreateCatalog(organization_siret=siret))
+
     pagination = await bus.execute(GetAllDatasets())
     assert pagination.total_items == 0
 
-    await addrandomdatasets.main(n=20)
+    await addrandomdatasets.main(n=20, siret=siret)
 
     pagination = await bus.execute(GetAllDatasets())
     assert pagination.total_items == 20

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -50,15 +50,14 @@ async def test_initdata_env_password_invalid(
     path = tmp_path / "initdata.yml"
     path.write_text(
         """
+        organizations: []
+        catalogs: []
         users:
           - id: 9c2cefce-ea47-4e6e-8c79-8befd4495f45
             params:
               email: test@admin.org
               password: __env__
         datasets: []
-        organizations: []
-        catalogs: []
-
         """
     )
 
@@ -124,9 +123,11 @@ async def test_repo_initdata(
     num_users = 2
     num_tags = 7
     num_datasets = 4
-    num_organization = 1
-    num_catalog = 1
-    num_entities = num_users + num_tags + num_datasets + num_catalog + num_organization
+    num_organizations = 1
+    num_catalogs = 1
+    num_entities = (
+        num_users + num_tags + num_datasets + num_catalogs + num_organizations
+    )
 
     await initdata.main(path, no_input=True)
     captured = capsys.readouterr()

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -1,11 +1,27 @@
+organizations:
+  - params:
+      name: "Ministère de la Culture"
+      siret: "11004601800013"
+
+catalogs:
+  - params:
+      organization_siret: "11004601800013"
+      extra_fields:
+        - name: referentiel
+          title: Référentiel ou norme
+          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
+          type: TEXT
+
 users:
   - id: "c33cc0bb-975c-45a1-ac2a-7fed9971ce6a"
     params:
+      organization_siret: "11004601800013"
       email: catalogue.demo@yopmail.com
       password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:
+      organization_siret: "11004601800013"
       email: admin@catalogue.data.gouv.fr
       password: __env__
     extras:
@@ -44,6 +60,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/donnees-brutes-de-l-inventaire-forestier/
     id: "16b398af-f8c7-48b9-898a-18ad3404f528"
     params:
+      organization_siret: "11004601800013"
       title: Données brutes de l'inventaire forestier
       description: |
         Les données brutes de l'inventaire forestier correspondent à l'ensemble des données collectées en forêt (y compris en peupleraie) sur le territoire métropolitain par les agents forestiers de terrain de l'IGN. Ces données portent sur les caractéristiques des placettes d'inventaire (6000 par an), les mesures et observations sur les arbres (60 000 par an), les données éco-floristiques.
@@ -66,6 +83,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/
     id: "4370d027-1447-4e1b-9452-781233be7f5a"
     params:
+      organization_siret: "11004601800013"
       title: Ensemble des lieux de restauration des CROUS
       description: |
         Les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
@@ -87,6 +105,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/
     id: "3707e03b-d020-4a14-bb85-1ad0545b1578"
     params:
+      organization_siret: "11004601800013"
       title: Restaurants, brasseries et cafétérias des CROUS
       description: |
         Par région, les ressources ci-dessous recensent les restaurants, brasseries et cafétérias dans le réseau des CROUS.
@@ -108,6 +127,7 @@ datasets:
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/catalogue-des-enquetes-realisees-par-la-dares-2012-572205/
     id: "40abb40f-af83-4a3b-b926-78428402688f"
     params:
+      organization_siret: "11004601800013"
       title: Catalogue des enquêtes réalisées par la DARES
       description: |
         Présentation sous forme de fiches répertoriées par thèmes des enquêtes menées par la DARES avec reprise des objectifs, de la périodicité, de la taille de l'échantillon, des publications.
@@ -124,17 +144,3 @@ datasets:
       license: Licence Ouverte
       tag_ids: []
       extra_field_values: []
-
-organizations:
-  - params:
-      name: "Ministère de la Culture"
-      siret: "11004601800013"
-
-catalogs:
-  - params:
-      organization_siret: "11004601800013"
-      extra_fields:
-        - name: referentiel
-          title: Référentiel ou norme
-          hint_text: Ce jeu de données contient-il un référentiel ou une norme ? Si oui, lequel ?
-          type: TEXT


### PR DESCRIPTION
Closes #414 

Notre initdata était incohérent dans le sens où l'on pensait créer des utilisateurs liés à une certaine organisation (MC = organisation à laquelle a été relié l'utilisateur catalogue.demo@yopmail.com sur DataPass staging), mais en réalité ils étaient liés à l'orga "000..." car les PasswordUsers (champ `users` dans le initdata) étaient créés sans préciser l'orga, et utilisaient donc cette orga par défaut.

Cette PR corrige ces problèmes en liant toutes les ressources créées dans l'initdata à une organisation de ce même initdata (à savoir l'orga MC).

Pour éviter que cela ne se reproduise, une erreur 500 est désormais renvoyée si on essaie d'inscrire un DataPassUser avec un email déjà utilisé par un PasswordUser dans une autre organisation. Il n'y a en effet aucune résolution possible : c'est un bug lié à la configuration des PasswordUsers qui est de notre responsabilité (personne ne peut en créer à part nous via un initdata).

... J'intègre aussi quelques correctifs à la génération de jeux de données aléatoires, qui est HS actuellement et affichait des geographical_coverages dégueu (chaînes de caractère du type `fjQKJnYvAE...`). J'espère qu'on me pardonnera cet opportunisme : j'en ai besoin pour préparer l'env de demo pour la démo Etalab de demain.

## Impact

En local, il faudra relancer l'initdata. Le plus simple est de supprimer la DB et la recréer.

```
dropdb catalogage
createdb catalogage
make migrate
make initdata
```

Sur staging et demo, on peut aussi relancer l'initdata (`make ops-initdata env=...`) après avoir nettoyé la DB manuellement.

```sql
DELETE FROM dataset_tag;
DELETE FROM dataset_dataformat;
DELETE FROM catalog_record;
DELETE FROM extra_field;
DELETE FROM catalog;
DELETE FROM account;
DELETE FROM organization;
```

Le DataPassUser pour catalogue.demo@yopmail.com sera recréé la prochaine fois que l'on se connectera.

Sur prod, pas d'impact puisque la donnée n'y provient pas d'un initdata. Par ailleurs, les utilisateurs y sont tous liés à "000..." et il n'y a pas de DataPassUser.

## Validation

Je vais déployer sur staging et y relancer l'initdata, puis je vérifierai que les utilisateurs et jeux de données sont désormais bien liés à l'orga MC, en inspectant les payloads d'API.

Edit : j'ai trouvé un `extra_field_values` manquant dans l'initdata.yml des environnements.

Edit : `make randomdatasets` a échoué car on n'y accepte pas de SIRET et on utilise "000..." par défaut, qui a été effacé par nos `DELETE` (bien qu'il devrait continuer d'exister car il provient d'une migration). Il faudrait tester cet outil.

Une fois corrigé, résultat = :heavy_check_mark: 