### PR TITLE
refacto: upgrade makeApiRequest to reject the promise

### DIFF
--- a/client/src/lib/fetch.ts
+++ b/client/src/lib/fetch.ts
@@ -105,3 +105,16 @@ export async function makeApiRequest(
 
   return response;
 }
+
+export async function makeApiRequestOrFail(
+  fetch: Fetch,
+  request: Request
+): Promise<Maybe<Response>> {
+  const response = await fetch(request);
+
+  if (!response.ok) {
+    pushApiError(response);
+    return Promise.reject(response);
+  }
+  return response;
+}


### PR DESCRIPTION
## Cette Pr introduit :

- le fait que `makeApiRequest` rejette la promesse si la requète HTTP initiée par fetch n'est pas ok (en cas de satus code >=400)

Exemple d'utilisation:

- en utilisant directement makeApirRequest (dans un repository par exemple)

```
try {
await makeApiRequest(fetch, "url")
}
catch (e) {
// gestion de l'erreur
}
```
- va l'utilisation d'un repository dans un composant par exemple


```
try {
await getAllUsers(fetch, data)
}
catch (e) {
// gestion de l'erreur
}
```

Inspiré de

- https://dev.to/myogeshchavan97/do-you-know-why-we-check-for-response-ok-while-using-fetch-1mkd
- https://sangster.dev/posts/fetch-response-ok/