### PR TITLE
Define organization_siret for demo2 user

### DIFF
--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -25,7 +25,7 @@ users:
   - id: "2753fcf9-ab6a-426e-b1d1-e4e16470a5d0"
     params:
       organization_siret: "13001653800014"
-      # In MonComptePro, a user linked to two organizations was created with this email.
+      # In auth-staging.api.gouv.fr, a user linked to two organizations was created with this email.
       email: catalogue.demo2@yopmail.com
       password: password1234
 

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -24,7 +24,9 @@ users:
 
   - id: "2753fcf9-ab6a-426e-b1d1-e4e16470a5d0"
     params:
-      email: catalogue.demo2@yopmail.com # This user is linked to two organizations
+      organization_siret: "13001653800014"
+      # In MonComptePro, a user linked to two organizations was created with this email.
+      email: catalogue.demo2@yopmail.com
       password: password1234
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/pull/400/files#r968187069

Sinon on aurait encore un cas de #414 

Je pense aussi qu'il faudrait renommer la section `users` en `password_users` et que `organization_siret` y devienne obligatoire... à voir.