### PR TITLE
Display extra fields on dataset detail page

### DIFF
--- a/client/src/routes/(app)/fiches/[id]/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/+page.svelte
@@ -5,10 +5,11 @@
   import { formatFullDate, splitParagraphs } from "src/lib/util/format";
   import { Maybe } from "$lib/util/maybe";
   import AsideItem from "./_AsideItem.svelte";
+  import ExtraFieldsList from "./_ExtraFieldsList.svelte";
 
   export let data: PageData;
 
-  $: ({ dataset } = data);
+  $: ({ catalog, dataset } = data);
 
   $: editUrl = Maybe.map(dataset, (dataset) =>
     paths.datasetEdit({ id: dataset.id })
@@ -16,7 +17,7 @@
 </script>
 
 <section class="fr-container">
-  {#if Maybe.Some(dataset) && Maybe.Some(editUrl)}
+  {#if Maybe.Some(catalog) && Maybe.Some(dataset) && Maybe.Some(editUrl)}
     <header class="fr-mt-5w">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
         <div class="fr-col-sm-4 fr-col-md-3 fr-col-lg-2">
@@ -119,17 +120,24 @@
         />
       </aside>
 
-      <section
-        class="fr-col-md-8 fr-text--sm"
-        aria-label="Description du jeu de données"
-        data-testid="dataset-description"
-      >
-        {#each splitParagraphs(dataset.description) as text}
-          <p class="fr-text--lg">
-            {text}
-          </p>
-        {/each}
-      </section>
+      <div class="fr-col-md-8">
+        <div class="fr-text--sm fr-mb-4w" data-testid="dataset-description">
+          {#each splitParagraphs(dataset.description) as text}
+            <p class="fr-text--lg">
+              {text}
+            </p>
+          {/each}
+        </div>
+
+        {#if catalog.extraFields.length > 0}
+          <h6 class="fr-mb-2w">Informations complémentaires</h6>
+
+          <ExtraFieldsList
+            extraFields={catalog.extraFields}
+            extraFieldValues={dataset.extraFieldValues}
+          />
+        {/if}
+      </div>
     </div>
   {/if}
 </section>

--- a/client/src/routes/(app)/fiches/[id]/+page.ts
+++ b/client/src/routes/(app)/fiches/[id]/+page.ts
@@ -1,16 +1,29 @@
 import type { PageLoad } from "./$types";
 import { get } from "svelte/store";
 import { getDatasetByID } from "$lib/repositories/datasets";
-import { apiToken } from "$lib/stores/auth";
+import { getCatalogBySiret } from "$lib/repositories/catalogs";
+import { Maybe } from "$lib/util/maybe";
+import { apiToken as apiTokenStore } from "$lib/stores/auth";
 
 export const load: PageLoad = async ({ fetch, params }) => {
+  const apiToken = get(apiTokenStore);
+
   const dataset = await getDatasetByID({
     fetch,
-    apiToken: get(apiToken),
+    apiToken,
     id: params.id,
   });
 
+  const catalog = await Maybe.map(dataset, (dataset) =>
+    getCatalogBySiret({
+      fetch,
+      apiToken,
+      siret: dataset.catalogRecord.organization.siret,
+    })
+  );
+
   return {
+    catalog,
     dataset,
   };
 };

--- a/client/src/routes/(app)/fiches/[id]/_ExtraFieldsList.svelte
+++ b/client/src/routes/(app)/fiches/[id]/_ExtraFieldsList.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { ExtraField, ExtraFieldValue } from "src/definitions/catalogs";
+  import { Maybe } from "src/lib/util/maybe";
+
+  export let extraFields: ExtraField[];
+  export let extraFieldValues: ExtraFieldValue[];
+
+  const makeItems = (fields: ExtraField[], values: ExtraFieldValue[]) => {
+    return fields.map(({ id, title }) => {
+      const value = values.find(({ extraFieldId }) => id === extraFieldId);
+      return {
+        id,
+        label: title,
+        value: Maybe.map(value, ({ value }) => value),
+      };
+    });
+  };
+
+  $: items = makeItems(extraFields, extraFieldValues);
+</script>
+
+<div class="fr-grid-row fr-grid-row--gutters">
+  {#each items as { id, label, value } (id)}
+    <div class="fr-col-12 fr-col-sm-6">
+      <div class="fr-text--sm fr-my-0 fr-text-mention--grey">
+        {label}
+      </div>
+      <div>
+        {#if Maybe.Some(value)}
+          {value}
+        {:else}
+          -
+        {/if}
+      </div>
+    </div>
+  {/each}
+</div>

--- a/client/src/routes/(app)/fiches/[id]/page.spec.ts
+++ b/client/src/routes/(app)/fiches/[id]/page.spec.ts
@@ -6,6 +6,16 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/svelte";
 import index from "./+page.svelte";
 import { getFakeDataset } from "src/tests/factories/dataset";
+import type {
+  Catalog,
+  ExtraField,
+  ExtraFieldValue,
+} from "src/definitions/catalogs";
+
+const catalog: Catalog = {
+  organizationSiret: "<siret>",
+  extraFields: [],
+};
 
 const dataset = getFakeDataset({
   id: "d4765f06-ccdf-4bae-b237-2bced67e6dc2",
@@ -16,7 +26,7 @@ const dataset = getFakeDataset({
   contactEmails: ["service@mydomain.org"],
 });
 
-const data = { dataset };
+const data = { catalog, dataset };
 
 describe("Dataset detail page header", () => {
   test("The dataset title is present", () => {
@@ -49,12 +59,12 @@ describe("Dataset detail description", () => {
 
   test("The url link button is present if a url is set", async () => {
     const { getByText, queryByText, rerender } = render(index, {
-      data: { dataset: { ...dataset, url: null } },
+      data: { ...data, dataset: { ...dataset, url: null } },
     });
     let urlLink = queryByText("Voir les données", { exact: false });
     expect(urlLink).not.toBeInTheDocument();
     rerender({
-      data: { dataset: { ...dataset, url: "https://example.org" } },
+      data: { ...data, dataset: { ...dataset, url: "https://example.org" } },
     });
     urlLink = getByText("Voir les données", { exact: false });
     expect(urlLink).toBeInTheDocument();
@@ -63,14 +73,74 @@ describe("Dataset detail description", () => {
 
   test("The license is shown if it is set", async () => {
     const { getByText, queryByText, rerender } = render(index, {
-      data: { dataset: { ...dataset, license: null } },
+      data: { ...data, dataset: { ...dataset, license: null } },
     });
     let license = queryByText("Licence Ouverte", { exact: false });
     expect(license).not.toBeInTheDocument();
+
     rerender({
-      data: { dataset: { ...dataset, license: "Licence Ouverte" } },
+      data: { ...data, dataset: { ...dataset, license: "Licence Ouverte" } },
     });
     license = getByText("Licence Ouverte", { exact: false });
     expect(license).toBeInTheDocument();
+  });
+});
+
+describe("Dataset detail extra fields", () => {
+  test("Extra fields section not shown if no extra fields in catalog", () => {
+    const { queryByRole } = render(index, { data });
+    const title = queryByRole("heading", {
+      level: 6,
+      name: "Informations complémentaires",
+    });
+    expect(title).not.toBeInTheDocument();
+  });
+
+  test("Extra fields are shown along with dataset values", () => {
+    const extraFields: ExtraField[] = [
+      {
+        id: "<id_1>",
+        name: "referentiel",
+        title: "Référentiel",
+        hintText: "Choisissez un référentiel",
+        type: "TEXT",
+        data: {},
+      },
+      {
+        id: "<id_2>",
+        name: "sous_domaine",
+        title: "Sous-domaine",
+        hintText: "Choisissez un sous-domaine",
+        type: "TEXT",
+        data: {},
+      },
+    ];
+
+    const extraFieldValues: ExtraFieldValue[] = [
+      { extraFieldId: "<id_1>", value: "Référentiel A" },
+    ];
+
+    const { getByRole, getByText } = render(index, {
+      data: {
+        catalog: { ...catalog, extraFields },
+        dataset: { ...dataset, extraFieldValues },
+      },
+    });
+
+    const title = getByRole("heading", {
+      level: 6,
+      name: "Informations complémentaires",
+    });
+    expect(title).toBeInTheDocument();
+
+    const referentielLabel = getByText("Référentiel");
+    expect(referentielLabel).toBeInTheDocument();
+    const referentielValue = referentielLabel.nextElementSibling;
+    expect(referentielValue).toHaveTextContent("Référentiel A");
+
+    const sousDomaineLabel = getByText("Sous-domaine");
+    expect(sousDomaineLabel).toBeInTheDocument();
+    const sousDomaineValue = sousDomaineLabel.nextElementSibling;
+    expect(sousDomaineValue).toHaveTextContent("-");
   });
 });

--- a/client/src/tests/e2e/details.spec.ts
+++ b/client/src/tests/e2e/details.spec.ts
@@ -9,10 +9,10 @@ test.describe("Dataset details", () => {
     await page.goto(`/fiches/${dataset.id}`);
 
     const title = page.locator("h1");
-    expect(title).toHaveText(dataset.title);
+    await expect(title).toHaveText(dataset.title);
 
     const description = page.locator("[data-testid=dataset-description]");
-    expect(description).toHaveText(dataset.description);
+    await expect(description).toHaveText(dataset.description);
 
     const editUrl = page.locator("text=Modifier");
 


### PR DESCRIPTION
* Closes #406 
* Par-dessus #399 

Cette PR affiche les champs complémentaires dans la fiche de jeu de donneés (page de détail)

**Notes techniques**

* On récupère le catalogue par un appel à l'endpoint `GET /catalogs/`. Cet appel doit être séquencé _après_ celui pour récupérer le jeu de données, car on en obtient le SIRET du catalogue à récupérer. Cela rallonge le temps de chargement. On pourrait faire ce chargement du catalogue en asynchrone et afficher un placeholder pendant ce temps... Mais ça fait travailler le client au lieu d'une jointure rapide côté DB. C'est une situation de plus en faveur d'inclure le catalogue dans le détail d'un dataset...

**TODO**

* [x] Afficher champs complémentaires
* [x] Tests unitaires
* [x] Màj tests E2E

**Aperçu**

![Screenshot 2022-09-12 at 16-51-24 Catalogue](https://user-images.githubusercontent.com/15911462/189685886-320404ba-1a3a-43cf-b133-60a1c631cd24.png) (62 kB)
