### PR TITLE
Display organization name in form

### DIFF
--- a/client/src/definitions/catalogs.ts
+++ b/client/src/definitions/catalogs.ts
@@ -1,3 +1,5 @@
+import type { Organization } from "./organizations";
+
 interface ExtraFieldBase {
   id: string;
   name: string;
@@ -28,7 +30,7 @@ interface EnumExtraField extends ExtraFieldBase {
 export type ExtraField = TextExtraField | BoolExtraField | EnumExtraField;
 
 export interface Catalog {
-  organizationSiret: string;
+  organization: Organization;
   extraFields: ExtraField[];
 }
 export interface ExtraFieldValue {

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -13,6 +13,7 @@ import type {
 import { login, logout } from "$lib/stores/auth";
 import { buildFakeTag } from "src/tests/factories/tags";
 import type { Catalog, ExtraField } from "src/definitions/catalogs";
+import type { Organization } from "src/definitions/organizations";
 
 describe("Test the dataset form", () => {
   beforeAll(() =>
@@ -28,7 +29,12 @@ describe("Test the dataset form", () => {
 
   afterAll(() => logout());
 
-  const catalog: Catalog = { organizationSiret: "<siret1>", extraFields: [] };
+  const organization: Organization = {
+    siret: "<siret>",
+    name: "Org 1",
+  };
+
+  const catalog: Catalog = { organization, extraFields: [] };
 
   const extraField: ExtraField = {
     id: "<extraField1Id>",
@@ -40,7 +46,7 @@ describe("Test the dataset form", () => {
   };
 
   const catalogWithExtraFields: Catalog = {
-    organizationSiret: "<siret2>",
+    organization,
     extraFields: [extraField],
   };
 

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -62,8 +62,7 @@
   );
 
   const initialValues: DatasetFormValues = {
-    organizationSiret:
-      initial?.catalogRecord.organization.siret || catalog.organizationSiret,
+    organizationSiret: catalog.organization.siret,
     title: initial?.title || "",
     description: initial?.description || "",
     service: initial?.service || "",

--- a/client/src/lib/components/DatasetFormLayout/DatasetFormLayout.svelte
+++ b/client/src/lib/components/DatasetFormLayout/DatasetFormLayout.svelte
@@ -97,6 +97,6 @@
 <style>
   nav {
     /* A bit hacky but ... it makes sure that this menu stays below the header */
-    top: 10vh;
+    top: 12vh;
   }
 </style>

--- a/client/src/lib/transformers/catalogs.ts
+++ b/client/src/lib/transformers/catalogs.ts
@@ -20,9 +20,9 @@ const toExtraField = (data: any): ExtraField => {
 };
 
 export const toCatalog = (data: any): Catalog => {
-  const { organization_siret, extra_fields } = data;
+  const { organization, extra_fields } = data;
   return {
-    organizationSiret: organization_siret,
+    organization,
     extraFields: extra_fields.map((v: any) => toExtraField(v)),
   };
 };

--- a/client/src/routes/(app)/contribuer/+page.svelte
+++ b/client/src/routes/(app)/contribuer/+page.svelte
@@ -44,7 +44,16 @@
 </script>
 
 <header class="fr-p-4w">
-  <h5>Créer une fiche de jeu de données</h5>
+  <div class="fr-col">
+    <h5 class="fr-grid-row fr-text--regular">
+      Contribuer une fiche de jeu de données
+    </h5>
+    {#if Maybe.Some(catalog)}
+      <p class="fr-grid-row fr-text--sm fr-text-mention--grey">
+        Catalogue : {catalog.organization.name}
+      </p>
+    {/if}
+  </div>
 
   {#if formHasBeenTouched}
     <button
@@ -87,7 +96,7 @@
 
 <style>
   header {
-    height: 10vh;
+    height: 12vh;
     display: flex;
     position: sticky;
     justify-content: space-between;

--- a/client/src/routes/(app)/fiches/[id]/edit/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/edit/+page.svelte
@@ -71,7 +71,14 @@
 
 {#if Maybe.Some(catalog) && Maybe.Some(dataset) && Maybe.Some(tags) && Maybe.Some(licenses) && Maybe.Some(filtersInfo)}
   <header class="fr-p-4w">
-    <h5>Modifier la fiche de jeu de données</h5>
+    <div class="fr-col">
+      <h5 class="fr-grid-row fr-text--regular">
+        Modifier la fiche de jeu de données
+      </h5>
+      <p class="fr-grid-row fr-text--sm fr-text-mention--grey">
+        Catalogue : {dataset.catalogRecord.organization.name}
+      </p>
+    </div>
 
     {#if formHasBeenTouched}
       <button
@@ -132,7 +139,7 @@
 
 <style>
   header {
-    height: 10vh;
+    height: 12vh;
     display: flex;
     position: sticky;
     justify-content: space-between;

--- a/client/src/routes/(app)/fiches/[id]/page.spec.ts
+++ b/client/src/routes/(app)/fiches/[id]/page.spec.ts
@@ -13,7 +13,10 @@ import type {
 } from "src/definitions/catalogs";
 
 const catalog: Catalog = {
-  organizationSiret: "<siret>",
+  organization: {
+    siret: "<siret>",
+    name: "Org 1",
+  },
   extraFields: [],
 };
 

--- a/client/src/tests/e2e/contribuer.spec.ts
+++ b/client/src/tests/e2e/contribuer.spec.ts
@@ -24,6 +24,8 @@ test.describe("Basic form submission", () => {
 
     await page.goto("/contribuer");
 
+    await page.locator("text=Ministère de la Culture").waitFor();
+
     // "Information Générales" section
 
     expect(

--- a/client/src/tests/e2e/edit.spec.ts
+++ b/client/src/tests/e2e/edit.spec.ts
@@ -10,6 +10,8 @@ test.describe("Edit dataset", () => {
   test("Visits the edit page", async ({ page, dataset }) => {
     await page.goto(`/fiches/${dataset.id}/edit`);
 
+    await page.locator("text=Ministère de la Culture").waitFor();
+
     // Check initial data
 
     const title = page.locator("form [name=title]");

--- a/server/api/catalogs/routes.py
+++ b/server/api/catalogs/routes.py
@@ -7,6 +7,7 @@ from server.application.catalogs.queries import GetCatalogBySiret
 from server.application.catalogs.views import CatalogView
 from server.config.di import resolve
 from server.domain.catalogs.exceptions import CatalogAlreadyExists, CatalogDoesNotExist
+from server.domain.organizations.exceptions import OrganizationDoesNotExist
 from server.domain.organizations.types import Siret
 from server.seedwork.application.messages import MessageBus
 
@@ -32,6 +33,8 @@ async def create_catalog(data: CatalogCreate) -> JSONResponse:
 
     try:
         siret = await bus.execute(command)
+    except OrganizationDoesNotExist as exc:
+        raise HTTPException(400, detail=str(exc))
     except CatalogAlreadyExists as exc:
         content = jsonable_encoder(CatalogView(**exc.catalog.dict()))
         return JSONResponse(content, status_code=200)

--- a/server/application/catalogs/views.py
+++ b/server/application/catalogs/views.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel
 
 from server.domain.catalogs.entities import ExtraFieldType
 from server.domain.common.types import ID
-from server.domain.organizations.types import Siret
+
+from ..organizations.views import OrganizationView
 
 
 class ExtraFieldView(BaseModel):
@@ -17,5 +18,5 @@ class ExtraFieldView(BaseModel):
 
 
 class CatalogView(BaseModel):
-    organization_siret: Siret
+    organization: OrganizationView
     extra_fields: List[ExtraFieldView]

--- a/server/domain/catalogs/entities.py
+++ b/server/domain/catalogs/entities.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated, TypedDict
 from server.domain.common.types import ID, id_factory
 from server.seedwork.domain.entities import Entity
 
+from ..organizations.entities import Organization
 from ..organizations.types import Siret
 
 
@@ -66,5 +67,5 @@ class ExtraFieldValue(Entity):
 
 
 class Catalog(Entity):
-    organization_siret: Siret
+    organization: Organization
     extra_fields: List[Annotated[ExtraField, Field(discriminator="type")]]

--- a/server/infrastructure/catalogs/repositories.py
+++ b/server/infrastructure/catalogs/repositories.py
@@ -20,8 +20,12 @@ class SqlCatalogRepository(CatalogRepository):
         async with self._db.session() as session:
             stmt = (
                 select(CatalogModel)
+                .join(CatalogModel.organization)
                 .join(CatalogModel.extra_fields, isouter=True)
-                .options(contains_eager(CatalogModel.extra_fields))
+                .options(
+                    contains_eager(CatalogModel.organization),
+                    contains_eager(CatalogModel.extra_fields),
+                )
                 .where(CatalogModel.organization_siret == siret)
             )
             result = await session.execute(stmt)

--- a/server/infrastructure/catalogs/transformers.py
+++ b/server/infrastructure/catalogs/transformers.py
@@ -6,12 +6,13 @@ from server.domain.catalogs.entities import (
 )
 from server.domain.common.types import ID
 
+from ..organizations.transformers import make_entity as make_organization_entity
 from .models import CatalogModel, ExtraFieldModel, ExtraFieldValueModel
 
 
 def make_entity(instance: CatalogModel) -> Catalog:
     return Catalog(
-        organization_siret=instance.organization_siret,
+        organization=make_organization_entity(instance.organization),
         extra_fields=[
             _make_extra_field_entity(extra_field_instance)
             for extra_field_instance in instance.extra_fields
@@ -21,7 +22,13 @@ def make_entity(instance: CatalogModel) -> Catalog:
 
 def make_instance(entity: Catalog) -> CatalogModel:
     return CatalogModel(
-        **entity.dict(exclude={"extra_fields"}),
+        **entity.dict(
+            exclude={
+                "organization",
+                "extra_fields",
+            }
+        ),
+        organization_siret=entity.organization.siret,
         extra_fields=[
             ExtraFieldModel(**extra_field.dict()) for extra_field in entity.extra_fields
         ]


### PR DESCRIPTION
Cette PR affiche le nom de l'organisation à laquelle on contribue dans le header du formulaire, conformément à la maquette

**TODO**

* [x] Back - `GET /catalogs/:siret/` - Renvoyer organisation complète (name+siret) dans `catalog.organization`
* [x] Front - Afficher nom de l'organisation
  * [x] Contribution
  * [x] Edition
* [x] Tests unitaires / E2E

**Aperçu**

![Screenshot 2022-09-12 at 16-49-25 Screenshot](https://user-images.githubusercontent.com/15911462/189685375-48e5710b-c296-4275-9c68-cfe5a381d8ea.png) (48 kB)
