### PR TITLE
fix: minor UI fixes

### DIFF
--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -41,9 +41,8 @@
           <div class="fr-header__brand-top">
             <div class="fr-header__logo">
               <p class="fr-logo">
-                Catalogage
-                <br />des
-                <br />données
+                République
+                <br />Française
               </p>
             </div>
             <div class="fr-header__navbar">
@@ -67,7 +66,12 @@
               <p class="fr-header__service-title">
                 Catalogue Interministériel des Données
               </p>
-            </a>
+              <p
+                class="fr-badge fr-badge--success fr-badge--sm fr-badge--no-icon"
+              >
+                Bêta
+              </p></a
+            >
           </div>
         </div>
         <div class="fr-header__tools tools-container">
@@ -148,17 +152,9 @@
     overflow-x: hidden; /* Prevent beta banner from overflowing */
   }
 
-  header::after {
-    /* Beta corner banner */
-    position: absolute;
-    float: right;
-    top: 1.5em;
-    right: -3em;
-    padding: 0.5em 3em;
-    transform: rotate(45deg);
-    background-color: var(--background-action-low-pink-tuile);
-    content: "Version bêta";
-    z-index: 1;
+  a {
+    display: flex;
+    gap: 15px;
   }
 
   @media (max-width: 1440px) and (min-width: 768px) {

--- a/client/src/routes/(app)/fiches/[id]/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/+page.svelte
@@ -26,13 +26,15 @@
           </p>
         </div>
         <div class="fr-col-sm-8 fr-col-md-9 fr-col-lg-10">
-          <p class="fr-m-0 fr-text-mention--grey">Ministère de la culture</p>
+          <p class="fr-m-0 fr-text-mention--grey">{dataset.service}</p>
           <h1 class="fr-mb-0">
             {dataset.title}
           </h1>
           <div class="header__tags fr-mt-2w">
             {#each dataset.tags as tag}
-              <span class="fr-badge fr-badge--info fr-badge--no-icon">
+              <span
+                class="fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon"
+              >
                 {tag.name}</span
               >
             {/each}
@@ -66,6 +68,27 @@
 
     <div class="fr-grid-row fr-grid-row--gutters">
       <aside class="fr-col-md-4">
+        <h6 class="fr-mb-2w">Accès aux données</h6>
+
+        <AsideItem
+          icon="fr-icon-global-line"
+          label="Lien vers les données"
+          value={dataset.url}
+        >
+          <a
+            class="fr-btn fr-btn--icon-right fr-icon-external-link-line"
+            href={dataset.url}
+            target="_blank"
+          >
+            Voir les données
+          </a>
+        </AsideItem>
+
+        <AsideItem
+          icon="fr-icon-x-open-data"
+          label="Licence de réutilisation"
+          value={dataset.license}
+        />
         <h6 class="fr-mt-4w fr-mb-2w">Informations générales</h6>
 
         <AsideItem
@@ -96,28 +119,6 @@
             (v) => UPDATE_FREQUENCY_LABELS[v]
           )}
         />
-
-        <h6 class="fr-mb-2w">Accès aux données</h6>
-
-        <AsideItem
-          icon="fr-icon-global-line"
-          label="Lien vers les données"
-          value={dataset.url}
-        >
-          <a
-            class="fr-btn fr-btn--icon-right fr-icon-external-link-line"
-            href={dataset.url}
-            target="_blank"
-          >
-            Voir les données
-          </a>
-        </AsideItem>
-
-        <AsideItem
-          icon="fr-icon-x-open-data"
-          label="Licence de réutilisation"
-          value={dataset.license}
-        />
       </aside>
 
       <div class="fr-col-md-8">
@@ -144,7 +145,8 @@
 
 <style>
   .fr-logo {
-    white-space: nowrap;
+    width: 100%;
+    word-break: break-all;
   }
 
   .header__tags {


### PR DESCRIPTION
rel #372 

### Cette PR corrige/améliore

-  Remplacer le titre "catalogage des données" sous la marianne par "République Française"
-  Mettre le groupe "Accès aux données" en haut de page
-   Les badges mot-clés sont de taille SM (css `fr-badge--sm`)
-  Le champ qui se trouve au-dessus du titre correspond en fait au champ "service" et non "nom_orga"
-  Mettre à jour le bandeau "bêta" avec la dernière version du design system [ici](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/en-tete)
