### PR TITLE
Restrict dataset creation endpoint to users in requested organization

### DIFF
--- a/client/src/lib/repositories/datasets.ts
+++ b/client/src/lib/repositories/datasets.ts
@@ -84,16 +84,18 @@ export const getDatasets: GetDatasets = async ({
 type CreateDataset = (opts: {
   fetch: Fetch;
   apiToken: string;
+  siret: string;
   data: DatasetCreateData;
 }) => Promise<Maybe<Dataset>>;
 
 export const createDataset: CreateDataset = async ({
   fetch,
   apiToken,
+  siret,
   data,
 }) => {
   const body = JSON.stringify(toPayload(data));
-  const url = `${getApiUrl()}/datasets/`;
+  const url = `${getApiUrl()}/catalogs/${siret}/datasets/`;
   const request = new Request(url, {
     method: "POST",
     headers: new Headers([

--- a/client/src/routes/(app)/contribuer/+page.svelte
+++ b/client/src/routes/(app)/contribuer/+page.svelte
@@ -27,6 +27,7 @@
       const dataset = await createDataset({
         fetch,
         apiToken: $apiTokenStore,
+        siret: Maybe.expect(catalog, "catalog").organization.siret,
         data: { tagIds, ...event.detail },
       });
 

--- a/client/src/tests/e2e/fixtures.ts
+++ b/client/src/tests/e2e/fixtures.ts
@@ -57,8 +57,9 @@ export const test = base.extend<AppTestArgs>({
   dataset: async ({ apiContext, adminApiToken }, use) => {
     const headers = { Authorization: `Bearer ${adminApiToken}` };
 
+    const siret = "11004601800013";
+
     const data = {
-      organization_siret: "11004601800013",
       title: "Sample title",
       description: "Sample description",
       formats: ["api"],
@@ -77,7 +78,8 @@ export const test = base.extend<AppTestArgs>({
         },
       ],
     };
-    let response = await apiContext.post("/datasets/", {
+
+    let response = await apiContext.post(`/catalogs/${siret}/datasets/`, {
       data,
       headers,
     });

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -11,8 +11,6 @@ from server.application.datasets.validation import (
 )
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
-from server.domain.organizations.entities import LEGACY_ORGANIZATION
-from server.domain.organizations.types import Siret
 
 
 class DatasetListParams:
@@ -40,7 +38,6 @@ class DatasetListParams:
 
 
 class DatasetCreate(CreateDatasetValidationMixin, BaseModel):
-    organization_siret: Siret = LEGACY_ORGANIZATION.siret
     title: str
     description: str
     service: str

--- a/server/api/organizations/permissions.py
+++ b/server/api/organizations/permissions.py
@@ -1,0 +1,22 @@
+from typing import Callable
+
+from ..auth.permissions import BasePermission
+from ..types import APIRequest
+
+
+class MatchesUserSiret(BasePermission):
+    def __init__(self, key: Callable[[APIRequest], str]) -> None:
+        super().__init__()
+        self._key = key
+
+    def has_permission(self, request: APIRequest) -> bool:
+        if not request.user.is_authenticated:
+            raise RuntimeError(
+                "Running BelongsToOrganization but user is not authenticated. "
+                "Hint: use IsAuthenticated() & BelongsToOrganization(...)"
+            )
+
+        user_siret = request.user.account.organization_siret
+        claimed_siret = self._key(request)
+
+        return user_siret == claimed_siret

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateTagFactory
 
+from .factories import CreatePasswordUserFactory
 from .helpers import TestPasswordUser, create_client, create_test_password_user
 
 if TYPE_CHECKING:
@@ -111,9 +112,11 @@ async def client(app: "App") -> AsyncIterator[httpx.AsyncClient]:
 
 @pytest_asyncio.fixture(name="temp_user")
 async def fixture_temp_user() -> TestPasswordUser:
-    return await create_test_password_user(UserRole.USER)
+    command = CreatePasswordUserFactory.build()
+    return await create_test_password_user(command, role=UserRole.USER)
 
 
 @pytest_asyncio.fixture
 async def admin_user() -> TestPasswordUser:
-    return await create_test_password_user(UserRole.ADMIN)
+    command = CreatePasswordUserFactory.build()
+    return await create_test_password_user(command, role=UserRole.ADMIN)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,12 +4,11 @@ from typing import Callable
 import httpx
 from pydantic import BaseModel
 
+from server.application.auth.commands import CreatePasswordUser
 from server.config.di import resolve
 from server.domain.auth.entities import PasswordUser, UserRole
 from server.domain.auth.repositories import PasswordUserRepository
 from server.seedwork.application.messages import MessageBus
-
-from .factories import CreatePasswordUserFactory
 
 
 def create_client(app: Callable) -> httpx.AsyncClient:
@@ -46,11 +45,12 @@ class TestPasswordUser(PasswordUser):
         return request
 
 
-async def create_test_password_user(role: UserRole) -> TestPasswordUser:
+async def create_test_password_user(
+    command: CreatePasswordUser, *, role: UserRole = UserRole.USER
+) -> TestPasswordUser:
     bus = resolve(MessageBus)
     password_user_repository = resolve(PasswordUserRepository)
 
-    command = CreatePasswordUserFactory.build()
     await bus.execute(command, role=role)
 
     user = await password_user_repository.get_by_email(command.email)


### PR DESCRIPTION
Refs #388 

Cette PR transforme l'endpoint `POST /datasets/` en `POST /catalogs/:siret/datasets/`, en vérifiant la concordance entre le `:siret` cible et celui de l'utilisateur qui fait la requête.

Elle démontre l'approche qui sera ensuite utilisée pour les autres endpoints.