### PR TITLE
fix: tags must go the next line if there are too many of them to hold in a single line

### DIFF
--- a/client/src/routes/(app)/fiches/[id]/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/+page.svelte
@@ -152,5 +152,6 @@
   .header__tags {
     display: flex;
     gap: 10px;
+    flex-wrap: wrap;
   }
 </style>


### PR DESCRIPTION
### Cette PR ajoute

- un correctif css pour fair en sorte que les tags prennent x lignes si ils sont trop nombreux pour rester sur une ligne

Avant 
![Screenshot from 2022-09-20 16-53-02](https://user-images.githubusercontent.com/15958334/191291508-6ec89652-7335-47e6-8c76-5873b7e7fd52.png)

Après 
![Screenshot from 2022-09-20 16-46-20](https://user-images.githubusercontent.com/15958334/191291613-2605ae91-1568-446e-9d6a-4f140906450a.png)


rel : https://github.com/etalab/catalogage-donnees/issues/372