### PR TITLE
Check user belongs to dataset organization before creation

### DIFF
--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 from starlette.responses import Response
@@ -23,6 +25,8 @@ from ..auth.permissions import HasRole, IsAuthenticated
 from ..types import APIRequest
 from . import filters
 from .schemas import DatasetCreate, DatasetListParams, DatasetUpdate
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 
@@ -89,7 +93,8 @@ async def create_dataset(data: DatasetCreate, request: "APIRequest") -> DatasetV
         id = await bus.execute(command)
     except CatalogDoesNotExist as exc:
         raise HTTPException(400, detail=str(exc))
-    except CannotCreateDataset:
+    except CannotCreateDataset as exc:
+        logger.exception(exc)
         raise HTTPException(403, detail="Permission denied")
 
     query = GetDatasetByID(id=id)

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -35,6 +35,8 @@ class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
 
 
 class UpdateDataset(UpdateDatasetValidationMixin, Command[None]):
+    account: Union[Account, Skip]
+
     id: ID
     title: str
     description: str

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -1,10 +1,11 @@
 import datetime as dt
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import EmailStr, Field
 
+from server.domain.auth.entities import Account
 from server.domain.catalogs.entities import ExtraFieldValue
-from server.domain.common.types import ID
+from server.domain.common.types import ID, Skip
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.domain.organizations.types import Siret
@@ -14,6 +15,8 @@ from .validation import CreateDatasetValidationMixin, UpdateDatasetValidationMix
 
 
 class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
+    account: Union[Account, Skip]
+
     organization_siret: Siret = LEGACY_ORGANIZATION.siret
     title: str
     description: str

--- a/server/application/datasets/exceptions.py
+++ b/server/application/datasets/exceptions.py
@@ -1,2 +1,6 @@
 class CannotCreateDataset(Exception):
     pass
+
+
+class CannotUpdateDataset(Exception):
+    pass

--- a/server/application/datasets/exceptions.py
+++ b/server/application/datasets/exceptions.py
@@ -1,0 +1,2 @@
+class CannotCreateDataset(Exception):
+    pass

--- a/server/application/datasets/handlers.py
+++ b/server/application/datasets/handlers.py
@@ -4,41 +4,48 @@ from server.application.tags.queries import GetAllTags
 from server.config.di import resolve
 from server.domain.catalog_records.entities import CatalogRecord
 from server.domain.catalog_records.repositories import CatalogRecordRepository
+from server.domain.catalogs.exceptions import CatalogDoesNotExist
+from server.domain.catalogs.repositories import CatalogRepository
 from server.domain.common.pagination import Pagination
-from server.domain.common.types import ID
+from server.domain.common.types import ID, Skip
 from server.domain.datasets.entities import DataFormat, Dataset
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.datasets.repositories import DatasetRepository
-from server.domain.organizations.exceptions import OrganizationDoesNotExist
-from server.domain.organizations.repositories import OrganizationRepository
 from server.domain.tags.repositories import TagRepository
 from server.seedwork.application.messages import MessageBus
 
 from .commands import CreateDataset, DeleteDataset, UpdateDataset
+from .exceptions import CannotCreateDataset
 from .queries import GetAllDatasets, GetDatasetByID, GetDatasetFilters
+from .specifications import can_create_dataset
 from .views import DatasetFiltersView, DatasetView
 
 
 async def create_dataset(command: CreateDataset, *, id_: ID = None) -> ID:
     repository = resolve(DatasetRepository)
-    organization_repository = resolve(OrganizationRepository)
+    catalog_repository = resolve(CatalogRepository)
     catalog_record_repository = resolve(CatalogRecordRepository)
     tag_repository = resolve(TagRepository)
 
     if id_ is None:
         id_ = repository.make_id()
 
-    organization = await organization_repository.get_by_siret(
-        siret=command.organization_siret
-    )
+    catalog = await catalog_repository.get_by_siret(siret=command.organization_siret)
 
-    if organization is None:
-        raise OrganizationDoesNotExist(command.organization_siret)
+    if catalog is None:
+        raise CatalogDoesNotExist(command.organization_siret)
+
+    if not isinstance(command.account, Skip) and not can_create_dataset(
+        catalog, command.account
+    ):
+        raise CannotCreateDataset(
+            f"{command.account.organization_siret=}, {catalog.organization.siret=}"
+        )
 
     catalog_record_id = await catalog_record_repository.insert(
         CatalogRecord(
             id=catalog_record_repository.make_id(),
-            organization=organization,
+            organization=catalog.organization,
         )
     )
     catalog_record = await catalog_record_repository.get_by_id(catalog_record_id)

--- a/server/application/datasets/specifications.py
+++ b/server/application/datasets/specifications.py
@@ -1,0 +1,9 @@
+from server.domain.auth.entities import Account, UserRole
+from server.domain.catalogs.entities import Catalog
+
+
+def can_create_dataset(catalog: Catalog, account: Account) -> bool:
+    if account.role == UserRole.ADMIN:
+        return True
+
+    return catalog.organization.siret == account.organization_siret

--- a/server/application/datasets/specifications.py
+++ b/server/application/datasets/specifications.py
@@ -1,9 +1,6 @@
-from server.domain.auth.entities import Account, UserRole
+from server.domain.auth.entities import Account
 from server.domain.catalogs.entities import Catalog
 
 
 def can_create_dataset(catalog: Catalog, account: Account) -> bool:
-    if account.role == UserRole.ADMIN:
-        return True
-
     return catalog.organization.siret == account.organization_siret

--- a/server/application/datasets/specifications.py
+++ b/server/application/datasets/specifications.py
@@ -1,6 +1,11 @@
 from server.domain.auth.entities import Account
 from server.domain.catalogs.entities import Catalog
+from server.domain.datasets.entities import Dataset
 
 
 def can_create_dataset(catalog: Catalog, account: Account) -> bool:
     return catalog.organization.siret == account.organization_siret
+
+
+def can_update_dataset(dataset: Dataset, account: Account) -> bool:
+    return dataset.catalog_record.organization.siret == account.organization_siret

--- a/server/domain/common/types.py
+++ b/server/domain/common/types.py
@@ -1,8 +1,16 @@
 import uuid
 from typing import NewType
 
+from pydantic import BaseModel
+
 ID = NewType("ID", uuid.UUID)
 
 
 def id_factory() -> ID:
     return ID(uuid.uuid4())
+
+
+class Skip(BaseModel):
+    """
+    A marker class for when an operation should be skipped.
+    """

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -12,7 +12,7 @@ from server.application.tags.commands import CreateTag
 from server.application.tags.queries import GetTagByID
 from server.config.di import resolve
 from server.domain.catalogs.entities import ExtraFieldValue, TextExtraField
-from server.domain.common.types import ID, id_factory
+from server.domain.common.types import ID, Skip, id_factory
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
 from server.domain.datasets.exceptions import DatasetDoesNotExist
 from server.domain.organizations.entities import LEGACY_ORGANIZATION
@@ -26,7 +26,7 @@ from ..factories import (
     CreateDatasetPayloadFactory,
     CreateOrganizationFactory,
     CreatePasswordUserFactory,
-    UpdateDatasetFactory,
+    UpdateDatasetPayloadFactory,
     fake,
 )
 from ..helpers import TestPasswordUser, create_test_password_user, to_payload
@@ -257,6 +257,51 @@ class TestDatasetPermissions:
         response = await client.put(f"/datasets/{pk}/", json={})
         assert response.status_code == 401
 
+    async def test_update_in_other_org_denied(
+        self, client: httpx.AsyncClient, temp_user: TestPasswordUser
+    ) -> None:
+        bus = resolve(MessageBus)
+
+        other_org_siret = await bus.execute(CreateOrganizationFactory.build())
+        await bus.execute(CreateCatalog(organization_siret=other_org_siret))
+
+        command = CreateDatasetFactory.build(
+            organization_siret=other_org_siret, account=Skip()
+        )
+        dataset_id = await bus.execute(command)
+
+        payload = to_payload(
+            UpdateDatasetPayloadFactory.build_from_create_command(command)
+        )
+        response = await client.put(
+            f"/datasets/{dataset_id}/", json=payload, auth=temp_user.auth
+        )
+
+        assert response.status_code == 403
+
+    async def test_update_in_other_org_admin_denied(
+        self, client: httpx.AsyncClient, admin_user: TestPasswordUser
+    ) -> None:
+        bus = resolve(MessageBus)
+
+        other_org_siret = await bus.execute(CreateOrganizationFactory.build())
+        assert admin_user.account.organization_siret != other_org_siret
+        await bus.execute(CreateCatalog(organization_siret=other_org_siret))
+
+        command = CreateDatasetFactory.build(
+            organization_siret=other_org_siret, account=Skip()
+        )
+        dataset_id = await bus.execute(command)
+
+        payload = to_payload(
+            UpdateDatasetPayloadFactory.build_from_create_command(command)
+        )
+        response = await client.put(
+            f"/datasets/{dataset_id}/", json=payload, auth=admin_user.auth
+        )
+
+        assert response.status_code == 403
+
     async def test_delete_not_authenticated(self, client: httpx.AsyncClient) -> None:
         pk = id_factory()
         response = await client.delete(f"/datasets/{pk}/")
@@ -425,7 +470,7 @@ class TestDatasetUpdate:
         pk = id_factory()
         response = await client.put(
             f"/datasets/{pk}/",
-            json=to_payload(UpdateDatasetFactory.build(id=pk)),
+            json=to_payload(UpdateDatasetPayloadFactory.build(id=pk)),
             auth=temp_user.auth,
         )
         assert response.status_code == 404
@@ -480,13 +525,13 @@ class TestDatasetUpdate:
         response = await client.put(
             f"/datasets/{dataset_id}/",
             json=to_payload(
-                UpdateDatasetFactory.build(
+                UpdateDatasetPayloadFactory.build_from_create_command(
+                    command.copy(exclude={"title", "description", "service", "url"}),
                     factory_use_construct=True,  # Skip validation
                     title="",
                     description="",
                     service="",
                     url="",
-                    **command.dict(exclude={"title", "description", "service", "url"}),
                 )
             ),
             auth=temp_user.auth,
@@ -523,7 +568,7 @@ class TestDatasetUpdate:
         other_last_updated_at = fake.date_time_tz()
 
         payload = to_payload(
-            UpdateDatasetFactory.build(
+            UpdateDatasetPayloadFactory.build(
                 title="Other title",
                 description="Other description",
                 service="Other service",
@@ -603,9 +648,9 @@ class TestFormats:
         response = await client.put(
             f"/datasets/{dataset_id}/",
             json=to_payload(
-                UpdateDatasetFactory.build(
+                UpdateDatasetPayloadFactory.build_from_create_command(
+                    command.copy(exclude={"formats"}),
                     formats=[DataFormat.WEBSITE, DataFormat.API, DataFormat.FILE_GIS],
-                    **command.dict(exclude={"formats"}),
                 )
             ),
             auth=temp_user.auth,
@@ -627,9 +672,9 @@ class TestFormats:
         response = await client.put(
             f"/datasets/{dataset_id}/",
             json=to_payload(
-                UpdateDatasetFactory.build(
+                UpdateDatasetPayloadFactory.build_from_create_command(
+                    command.copy(exclude={"formats"}),
                     formats=[DataFormat.WEBSITE],
-                    **command.dict(exclude={"formats"}),
                 )
             ),
             auth=temp_user.auth,
@@ -654,9 +699,9 @@ class TestTags:
         response = await client.put(
             f"/datasets/{dataset_id}/",
             json=to_payload(
-                UpdateDatasetFactory.build(
+                UpdateDatasetPayloadFactory.build_from_create_command(
+                    command.copy(exclude={"tag_ids"}),
                     tag_ids=[str(tag_architecture_id)],
-                    **command.dict(exclude={"tag_ids"}),
                 )
             ),
             auth=temp_user.auth,
@@ -684,9 +729,9 @@ class TestTags:
         response = await client.put(
             f"/datasets/{dataset_id}/",
             json=to_payload(
-                UpdateDatasetFactory.build(
+                UpdateDatasetPayloadFactory.build_from_create_command(
+                    command.copy(exclude={"tag_ids"}),
                     tag_ids=[],
-                    **command.dict(exclude={"tag_ids"}),
                 )
             ),
             auth=temp_user.auth,
@@ -752,9 +797,7 @@ class TestExtraFieldValues:
             }
         ]
 
-    async def test_add_extra_field_value(
-        self, client: httpx.AsyncClient, temp_user: TestPasswordUser
-    ) -> None:
+    async def test_add_extra_field_value(self, client: httpx.AsyncClient) -> None:
         bus = resolve(MessageBus)
         siret, user, extra_field_id = await self._setup()
 
@@ -766,19 +809,18 @@ class TestExtraFieldValues:
         assert not dataset.extra_field_values
 
         payload = to_payload(
-            UpdateDatasetFactory.build(
-                id=dataset_id,
+            UpdateDatasetPayloadFactory.build_from_create_command(
+                command.copy(exclude={"extra_field_values"}),
                 extra_field_values=[
                     ExtraFieldValue(
                         extra_field_id=extra_field_id,
                         value="Environ 10 To",
                     )
                 ],
-                **command.dict(exclude={"extra_field_values"}),
             )
         )
         response = await client.put(
-            f"/datasets/{dataset_id}/", json=payload, auth=temp_user.auth
+            f"/datasets/{dataset_id}/", json=payload, auth=user.auth
         )
         assert response.status_code == 200
         data = response.json()
@@ -789,9 +831,7 @@ class TestExtraFieldValues:
             }
         ]
 
-    async def test_remove_extra_field_value(
-        self, client: httpx.AsyncClient, temp_user: TestPasswordUser
-    ) -> None:
+    async def test_remove_extra_field_value(self, client: httpx.AsyncClient) -> None:
         bus = resolve(MessageBus)
         siret, user, extra_field_id = await self._setup()
 
@@ -810,14 +850,13 @@ class TestExtraFieldValues:
         assert len(dataset.extra_field_values) == 1
 
         payload = to_payload(
-            UpdateDatasetFactory.build(
-                id=dataset_id,
+            UpdateDatasetPayloadFactory.build_from_create_command(
+                command.copy(exclude={"extra_field_values"}),
                 extra_field_values=[],
-                **command.dict(exclude={"extra_field_values"}),
             )
         )
         response = await client.put(
-            f"/datasets/{dataset_id}/", json=payload, auth=temp_user.auth
+            f"/datasets/{dataset_id}/", json=payload, auth=user.auth
         )
         assert response.status_code == 200
         data = response.json()

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -183,7 +183,10 @@ async def test_search_results_change_when_data_changes(
 
     # Update dataset title
     update_command = UpdateDatasetFactory.build(
-        id=pk, title="Modifié", **command.dict(exclude={"title"})
+        account=temp_user.account,
+        id=pk,
+        title="Modifié",
+        **command.dict(exclude={"title", "account", "organization_siret"}),
     )
 
     await bus.execute(update_command)
@@ -200,7 +203,7 @@ async def test_search_results_change_when_data_changes(
     # Same on description
     update_command = UpdateDatasetFactory.build(
         description="Jeu de données spécial",
-        **update_command.dict(exclude={"description"})
+        **update_command.dict(exclude={"description"}),
     )
     await bus.execute(update_command)
     response = await client.get(

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -19,14 +19,18 @@ DEFAULT_CORPUS_ITEMS = [
 ]
 
 
-async def add_corpus(items: List[Tuple[str, str]] = None) -> None:
+async def add_corpus(
+    user: TestPasswordUser, *, items: List[Tuple[str, str]] = None
+) -> None:
     if items is None:
         items = DEFAULT_CORPUS_ITEMS
 
     bus = resolve(MessageBus)
 
     for title, description in items:
-        command = CreateDatasetFactory.build(title=title, description=description)
+        command = CreateDatasetFactory.build(
+            account=user.account, title=title, description=description
+        )
         pk = await bus.execute(command)
         query = GetDatasetByID(id=pk)
         await bus.execute(query)
@@ -89,7 +93,7 @@ async def test_search(
     q: str,
     expected_titles: List[str],
 ) -> None:
-    await add_corpus()
+    await add_corpus(temp_user)
 
     response = await client.get(
         "/datasets/",
@@ -121,7 +125,7 @@ async def test_search(
 async def test_search_robustness(
     client: httpx.AsyncClient, temp_user: TestPasswordUser, q_ref: str, q_other: str
 ) -> None:
-    await add_corpus()
+    await add_corpus(temp_user)
 
     response = await client.get(
         "/datasets/",
@@ -150,7 +154,7 @@ async def test_search_results_change_when_data_changes(
     client: httpx.AsyncClient,
     temp_user: TestPasswordUser,
 ) -> None:
-    await add_corpus()
+    await add_corpus(temp_user)
 
     bus = resolve(MessageBus)
 
@@ -165,7 +169,7 @@ async def test_search_results_change_when_data_changes(
     assert not data["items"]
 
     # Add new dataset
-    command = CreateDatasetFactory.build(title="Titre")
+    command = CreateDatasetFactory.build(account=temp_user.account, title="Titre")
     pk = await bus.execute(command)
     # New dataset is returned in search results
     response = await client.get(
@@ -234,7 +238,7 @@ async def test_search_ranking(
 
     random.shuffle(items)  # Ensure DB insert order is irrelevant.
 
-    await add_corpus(items)
+    await add_corpus(temp_user, items=items)
 
     q = "Forêt ancienne"  # Lexemes: forêt, ancien
 
@@ -281,7 +285,7 @@ async def test_search_highlight(
     q: str,
     expected_headlines: Optional[dict],
 ) -> None:
-    await add_corpus(corpus)
+    await add_corpus(temp_user, items=corpus)
 
     q = "restaurant"
 

--- a/tests/api/test_licenses.py
+++ b/tests/api/test_licenses.py
@@ -18,7 +18,9 @@ async def test_license_list(
     assert response.status_code == 200
     assert response.json() == ["Licence Ouverte", "ODC Open Database License"]
 
-    await bus.execute(CreateDatasetFactory.build(license="Autre licence"))
+    await bus.execute(
+        CreateDatasetFactory.build(account=temp_user.account, license="Autre licence")
+    )
 
     response = await client.get("/licenses/", auth=temp_user.auth)
     assert response.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from server.infrastructure.database import Database
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateTagFactory
 
+from .factories import CreatePasswordUserFactory
 from .helpers import TestPasswordUser, create_client, create_test_password_user
 
 if TYPE_CHECKING:
@@ -111,9 +112,11 @@ async def client(app: "App") -> AsyncIterator[httpx.AsyncClient]:
 
 @pytest_asyncio.fixture(name="temp_user")
 async def fixture_temp_user() -> TestPasswordUser:
-    return await create_test_password_user(UserRole.USER)
+    command = CreatePasswordUserFactory.build()
+    return await create_test_password_user(command, role=UserRole.USER)
 
 
 @pytest_asyncio.fixture
 async def admin_user() -> TestPasswordUser:
-    return await create_test_password_user(UserRole.ADMIN)
+    command = CreatePasswordUserFactory.build()
+    return await create_test_password_user(command, role=UserRole.ADMIN)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -7,7 +7,7 @@ from faker.providers import BaseProvider
 from pydantic import BaseModel
 from pydantic_factories import ModelFactory, Require, Use
 
-from server.api.datasets.schemas import DatasetCreate
+from server.api.datasets.schemas import DatasetCreate, DatasetUpdate
 from server.application.auth.commands import CreateDataPassUser, CreatePasswordUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.organizations.commands import CreateOrganization
@@ -93,11 +93,27 @@ class CreateDatasetPayloadFactory(_BaseCreateDatasetFactory, Factory[DatasetCrea
     __model__ = DatasetCreate
 
 
-class UpdateDatasetFactory(Factory[UpdateDataset]):
-    __model__ = UpdateDataset
-
+class _BaseUpdateDatasetFactory:
     tag_ids = Use(lambda: [])
     extra_field_values = Use(lambda: [])
+
+
+class UpdateDatasetFactory(_BaseCreateDatasetFactory, Factory[UpdateDataset]):
+    __model__ = UpdateDataset
+
+    account = Require()
+
+
+class UpdateDatasetPayloadFactory(_BaseUpdateDatasetFactory, Factory[DatasetUpdate]):
+    __model__ = DatasetUpdate
+
+    @classmethod
+    def build_from_create_command(
+        cls, command: CreateDataset, **kwargs: Any
+    ) -> DatasetUpdate:
+        return cls.build(
+            **command.dict(exclude={"account", "organization_siret"}), **kwargs
+        )
 
 
 class CreateOrganizationFactory(Factory[CreateOrganization]):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,8 +5,9 @@ from typing import Any, TypeVar
 import faker
 from faker.providers import BaseProvider
 from pydantic import BaseModel
-from pydantic_factories import ModelFactory, Use
+from pydantic_factories import ModelFactory, Require, Use
 
+from server.api.datasets.schemas import DatasetCreate
 from server.application.auth.commands import CreateDataPassUser, CreatePasswordUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.organizations.commands import CreateOrganization
@@ -62,9 +63,7 @@ _FAKE_GEOGRAPHICAL_COVERAGES = [
 ]
 
 
-class CreateDatasetFactory(Factory[CreateDataset]):
-    __model__ = CreateDataset
-
+class _BaseCreateDatasetFactory:
     organization_siret = Use(lambda: LEGACY_ORGANIZATION.siret)
     title = Use(fake.sentence)
     description = Use(fake.text)
@@ -82,6 +81,16 @@ class CreateDatasetFactory(Factory[CreateDataset]):
     license = Use(random.choice, [None, *BUILTIN_LICENSE_SUGGESTIONS])
     tag_ids = Use(lambda: [])
     extra_field_values = Use(lambda: [])
+
+
+class CreateDatasetFactory(_BaseCreateDatasetFactory, Factory[CreateDataset]):
+    __model__ = CreateDataset
+
+    account = Require()
+
+
+class CreateDatasetPayloadFactory(_BaseCreateDatasetFactory, Factory[DatasetCreate]):
+    __model__ = DatasetCreate
 
 
 class UpdateDatasetFactory(Factory[UpdateDataset]):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,12 +4,11 @@ from typing import Callable
 import httpx
 from pydantic import BaseModel
 
+from server.application.auth.commands import CreatePasswordUser
 from server.config.di import resolve
 from server.domain.auth.entities import PasswordUser, UserRole
 from server.domain.auth.repositories import PasswordUserRepository
 from server.seedwork.application.messages import MessageBus
-
-from .factories import CreatePasswordUserFactory
 
 
 def create_client(app: Callable) -> httpx.AsyncClient:
@@ -46,11 +45,12 @@ class TestPasswordUser(PasswordUser):
         return request
 
 
-async def create_test_password_user(role: UserRole) -> TestPasswordUser:
+async def create_test_password_user(
+    command: CreatePasswordUser, *, role: UserRole = UserRole.USER
+) -> TestPasswordUser:
     bus = resolve(MessageBus)
     password_user_repository = resolve(PasswordUserRepository)
 
-    command = CreatePasswordUserFactory.build()
     await bus.execute(command, role=role)
 
     user = await password_user_repository.get_by_email(command.email)

--- a/tests/infrastructure/test_datasets.py
+++ b/tests/infrastructure/test_datasets.py
@@ -10,16 +10,19 @@ from server.infrastructure.database import Database
 from server.infrastructure.datasets.models import DatasetModel
 from server.infrastructure.tags.models import TagModel, dataset_tag
 from server.seedwork.application.messages import MessageBus
+from tests.helpers import TestPasswordUser
 
 from ..factories import CreateDatasetFactory, CreateTagFactory
 
 
 @pytest.mark.asyncio
-async def test_dataset_cascades() -> None:
+async def test_dataset_cascades(temp_user: TestPasswordUser) -> None:
     bus = resolve(MessageBus)
 
     tag_id = await bus.execute(CreateTagFactory.build(name="Architecture"))
-    dataset_id = await bus.execute(CreateDatasetFactory.build(tag_ids=[tag_id]))
+    dataset_id = await bus.execute(
+        CreateDatasetFactory.build(account=temp_user.account, tag_ids=[tag_id])
+    )
 
     dataset = await bus.execute(GetDatasetByID(id=dataset_id))
 

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -11,7 +11,7 @@ from server.application.auth.queries import LoginPasswordUser
 from server.application.datasets.commands import UpdateDataset
 from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
 from server.config.di import resolve
-from server.domain.common.types import ID
+from server.domain.common.types import ID, Skip
 from server.seedwork.application.messages import MessageBus
 from tools import initdata
 
@@ -146,6 +146,7 @@ async def test_repo_initdata(
 
     # Make a change.
     command = UpdateDataset(
+        account=Skip(),
         **dataset.dict(exclude={"title"}),
         tag_ids=[tag.id for tag in dataset.tags],
         title="Changed",

--- a/tools/addrandomdatasets.py
+++ b/tools/addrandomdatasets.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 
 from server.application.tags.queries import GetAllTags
 from server.config.di import bootstrap, resolve
+from server.domain.common.types import Skip
 from server.domain.organizations.types import Siret
 from server.seedwork.application.messages import MessageBus
 from tests.factories import CreateDatasetFactory
@@ -26,7 +27,9 @@ async def main(n: int, siret: Siret) -> None:
             tag_id_set, k=random.randint(1, min(3, len(tag_id_set)))
         )
         await bus.execute(
-            CreateDatasetFactory.build(organization_siret=siret, tag_ids=tag_ids)
+            CreateDatasetFactory.build(
+                account=Skip(), organization_siret=siret, tag_ids=tag_ids
+            )
         )
 
     print(f"{success('created')}: {n} datasets")

--- a/tools/initdata.py
+++ b/tools/initdata.py
@@ -20,6 +20,7 @@ from server.config.di import bootstrap, resolve
 from server.domain.auth.entities import UserRole
 from server.domain.auth.repositories import PasswordUserRepository
 from server.domain.catalogs.repositories import CatalogRepository
+from server.domain.common.types import Skip
 from server.domain.datasets.entities import Dataset
 from server.domain.datasets.repositories import DatasetRepository
 from server.domain.organizations.repositories import OrganizationRepository
@@ -175,7 +176,7 @@ async def handle_dataset(item: dict, reset: bool = False) -> None:
         print(f"{info('ok')}: {dataset_repr}")
         return
 
-    create_command = CreateDataset(**item["params"])
+    create_command = CreateDataset(account=Skip(), **item["params"])
 
     await bus.execute(create_command, id_=id_)
     print(f"{success('created')}: {create_command!r}")

--- a/tools/initdata.py
+++ b/tools/initdata.py
@@ -159,7 +159,7 @@ async def handle_dataset(item: dict, reset: bool = False) -> None:
     existing_dataset = await repository.get_by_id(id_)
 
     if existing_dataset is not None:
-        update_command = UpdateDataset(id=id_, **item["params"])
+        update_command = UpdateDataset(account=Skip(), id=id_, **item["params"])
 
         changed = any(
             getattr(update_command, k) != _get_dataset_attr(existing_dataset, k)


### PR DESCRIPTION
Nouvelle tentative suite à #435 

Refs #388

### Motivation

Cette PR "officialise" le fait que dans notre modèle de données, un utilisateur a le droit d'ajouter un jeu de données à un catalogue seulement s'il fait partie de l'organisation.

(Jusqu'ici le front s'en assurait, mais il n'y avait aucune garantie côté règles métier dans le backend.)

Comme pour le front (https://github.com/etalab/catalogage-donnees/pull/441/files#diff-6debc9c1c928e75751dcea3a25cc55f9ac2b13c2a462592ccb0c9164b91920f1R5), cette contrainte s'applique aussi au rôle `ADMIN`, à comprendre désormais comme un respo d'organisation (cf #288). La possibilité de le faire pour les "super-admins" est remise à plus tard, cf #452.


### Implémentation

Concrètement, la commande `CreateDataset()` requiert désormais une valeur `account` qui est utilisée pour vérifier que l'utilisateur en question a le droit de créer un dataset au sein du catalogue visé par le `organization_siret`. Le cas échéant, une exception est levée et l'API l'intercepte pour renvoyer une 403.

La vérification de cette règle métier se fait donc au sein des couches métiers (dans la couche application).

Un artifice avec une classe-marqueur `Skip` permet de bypasser cette vérification lorsque le contexte ne fait pas intervenir d'utilisateur (en l'occurrence, dans un `initdata` ou dans `make randomdatasets`).

La même approche sera utilisée pour l'update et la suppression.