### PR TITLE
Refactor account retrieval in TokenAuthBackend

### DIFF
--- a/server/api/auth/models.py
+++ b/server/api/auth/models.py
@@ -2,15 +2,15 @@ from typing import Optional
 
 from starlette.authentication import BaseUser
 
-from server.application.auth.views import AccountView
+from server.domain.auth.entities import Account
 
 
 class ApiUser(BaseUser):
-    def __init__(self, account: Optional[AccountView]) -> None:
+    def __init__(self, account: Optional[Account]) -> None:
         self._account = account
 
     @property
-    def account(self) -> AccountView:
+    def account(self) -> Account:
         if self._account is None:
             raise RuntimeError(
                 "Cannot access .account, as the user is anonymous. "

--- a/server/api/auth/routes.py
+++ b/server/api/auth/routes.py
@@ -56,7 +56,7 @@ async def login_password_user(data: PasswordUserLogin) -> AuthenticatedAccountVi
     dependencies=[Depends(IsAuthenticated())],
 )
 async def get_connected_user(request: APIRequest) -> AccountView:
-    return request.user.account
+    return AccountView(**request.user.account.dict())
 
 
 @router.delete(

--- a/server/application/auth/handlers.py
+++ b/server/application/auth/handlers.py
@@ -21,12 +21,7 @@ from .commands import (
     DeletePasswordUser,
 )
 from .passwords import PasswordEncoder, generate_api_token
-from .queries import (
-    GetAccountByAPIToken,
-    GetAccountByEmail,
-    LoginDataPassUser,
-    LoginPasswordUser,
-)
+from .queries import GetAccountByEmail, LoginDataPassUser, LoginPasswordUser
 
 
 async def create_password_user(
@@ -153,17 +148,6 @@ async def get_account_by_email(query: GetAccountByEmail) -> AccountView:
 
     if account is None:
         raise AccountDoesNotExist(email)
-
-    return AccountView(**account.dict())
-
-
-async def get_account_by_api_token(query: GetAccountByAPIToken) -> AccountView:
-    repository = resolve(AccountRepository)
-
-    account = await repository.get_by_api_token(query.api_token)
-
-    if account is None:
-        raise AccountDoesNotExist("__token__")
 
     return AccountView(**account.dict())
 

--- a/server/application/auth/queries.py
+++ b/server/application/auth/queries.py
@@ -15,7 +15,3 @@ class LoginDataPassUser(Query[AuthenticatedAccountView]):
 
 class GetAccountByEmail(Query[AccountView]):
     email: EmailStr
-
-
-class GetAccountByAPIToken(Query[AccountView]):
-    api_token: str

--- a/server/infrastructure/auth/module.py
+++ b/server/infrastructure/auth/module.py
@@ -9,13 +9,11 @@ from server.application.auth.handlers import (
     create_datapass_user,
     create_password_user,
     delete_password_user,
-    get_account_by_api_token,
     get_account_by_email,
     login_datapass_user,
     login_password_user,
 )
 from server.application.auth.queries import (
-    GetAccountByAPIToken,
     GetAccountByEmail,
     LoginDataPassUser,
     LoginPasswordUser,
@@ -35,5 +33,4 @@ class AuthModule(Module):
         LoginPasswordUser: login_password_user,
         LoginDataPassUser: login_datapass_user,
         GetAccountByEmail: get_account_by_email,
-        GetAccountByAPIToken: get_account_by_api_token,
     }


### PR DESCRIPTION
Extrait de #437 

La requête `GetAccountByAPIToken` était en réalité utilisée seulement pour le `TokenAuthBackend`.

Cette PR recourt au `AccountRepository` directement, ce qui permet aux endpoints d'avoir accès à une véritable entité `Account` dans `request.user.account`. Cela fera plus sens lorsqu'on utilisera cette valeur pour vérifier des règles métier : on ne manipulera que des entités.