### PR TITLE
Implement org-based write permissions in frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 APP_SECRET_KEY="h(tz!4a)llr+gm9g%f7vo%@br8q5!ec$7vifheax267av3lnk+"
 APP_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/${DB:-catalogage}"
 
-TOOLS_PASSWORDS='{"admin@catalogue.data.gouv.fr": "admin"}'
+TOOLS_PASSWORDS='{"admin@catalogue.data.gouv.fr": "admin", "admin.sante@catalogue.data.gouv.fr": "admin"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     env:
-      APP_SECRET_KEY: "<testing>"
       APP_DATABASE_URL: "postgresql+asyncpg://username:password@localhost:5432/catalogage"
-      TOOLS_PASSWORDS: '{"admin@catalogue.data.gouv.fr": "ci-admin"}'
 
     steps:
       - uses: actions/checkout@v3
@@ -44,6 +42,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-node-${{ hashFiles('**/client/package-lock.json') }}
+
+      - name: "Setup .env"
+        run: cp .env.example .env
 
       - name: "Install dependencies"
         run: make install

--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -2,28 +2,9 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { logout, account } from "$lib/stores/auth";
+  import { navigationItems } from "$lib/stores/layout";
   import paths from "$lib/paths";
   import { Maybe } from "$lib/util/maybe";
-
-  type NavItem = {
-    label: string;
-    href: string;
-  };
-
-  const navigationItems: NavItem[] = [
-    {
-      label: "Accueil",
-      href: paths.home,
-    },
-    {
-      label: "Rechercher",
-      href: paths.datasetSearch,
-    },
-    {
-      label: "Contribuer",
-      href: paths.contribute,
-    },
-  ];
 
   $: path = $page.url.pathname;
 
@@ -129,7 +110,7 @@
           data-fr-js-navigation="true"
         >
           <ul class="fr-nav__list">
-            {#each navigationItems as { label, href }}
+            {#each $navigationItems as { label, href }}
               <li class="fr-nav__item" data-fr-js-navigaton-item="true">
                 <a
                   {href}

--- a/client/src/lib/permissions.spec.ts
+++ b/client/src/lib/permissions.spec.ts
@@ -2,7 +2,7 @@ import { getFakeAccount } from "src/tests/factories/accounts";
 import { getFakeCatalogRecord } from "src/tests/factories/catalog_records";
 import { getFakeDataset } from "src/tests/factories/dataset";
 import { getFakeOrganization } from "src/tests/factories/organizations";
-import permissions from "./permissions";
+import { canEditDataset } from "./permissions";
 
 describe("permissions", () => {
   describe("dataset", () => {
@@ -12,13 +12,13 @@ describe("permissions", () => {
         catalogRecord: getFakeCatalogRecord({ organization }),
       });
       const account = getFakeAccount({ organizationSiret: organization.siret });
-      expect(permissions.dataset.edit(dataset, account)).toBeTruthy();
+      expect(canEditDataset(dataset, account)).toBeTruthy();
     });
 
     test("Account with different SIRET than dataset cannot edit", () => {
       const dataset = getFakeDataset();
       const account = getFakeAccount();
-      expect(permissions.dataset.edit(dataset, account)).toBeFalsy();
+      expect(canEditDataset(dataset, account)).toBeFalsy();
     });
   });
 });

--- a/client/src/lib/permissions.spec.ts
+++ b/client/src/lib/permissions.spec.ts
@@ -5,7 +5,7 @@ import { getFakeOrganization } from "src/tests/factories/organizations";
 import { canEditDataset } from "./permissions";
 
 describe("permissions", () => {
-  describe("dataset", () => {
+  describe("canEditDataset", () => {
     test("Account with same SIRET as dataset can edit", () => {
       const organization = getFakeOrganization();
       const dataset = getFakeDataset({

--- a/client/src/lib/permissions.spec.ts
+++ b/client/src/lib/permissions.spec.ts
@@ -1,0 +1,24 @@
+import { getFakeAccount } from "src/tests/factories/accounts";
+import { getFakeCatalogRecord } from "src/tests/factories/catalog_records";
+import { getFakeDataset } from "src/tests/factories/dataset";
+import { getFakeOrganization } from "src/tests/factories/organizations";
+import permissions from "./permissions";
+
+describe("permissions", () => {
+  describe("dataset", () => {
+    test("Account with same SIRET as dataset can edit", () => {
+      const organization = getFakeOrganization();
+      const dataset = getFakeDataset({
+        catalogRecord: getFakeCatalogRecord({ organization }),
+      });
+      const account = getFakeAccount({ organizationSiret: organization.siret });
+      expect(permissions.dataset.edit(dataset, account)).toBeTruthy();
+    });
+
+    test("Account with different SIRET than dataset cannot edit", () => {
+      const dataset = getFakeDataset();
+      const account = getFakeAccount();
+      expect(permissions.dataset.edit(dataset, account)).toBeFalsy();
+    });
+  });
+});

--- a/client/src/lib/permissions.ts
+++ b/client/src/lib/permissions.ts
@@ -1,0 +1,12 @@
+import type { Account } from "src/definitions/auth";
+import type { Dataset } from "src/definitions/datasets";
+
+export default {
+  dataset: {
+    edit: (dataset: Dataset, account: Account): boolean => {
+      return (
+        dataset.catalogRecord.organization.siret === account.organizationSiret
+      );
+    },
+  },
+};

--- a/client/src/lib/permissions.ts
+++ b/client/src/lib/permissions.ts
@@ -1,12 +1,6 @@
 import type { Account } from "src/definitions/auth";
 import type { Dataset } from "src/definitions/datasets";
 
-export default {
-  dataset: {
-    edit: (dataset: Dataset, account: Account): boolean => {
-      return (
-        dataset.catalogRecord.organization.siret === account.organizationSiret
-      );
-    },
-  },
+export const canEditDataset = (dataset: Dataset, account: Account): boolean => {
+  return dataset.catalogRecord.organization.siret === account.organizationSiret;
 };

--- a/client/src/lib/stores/layout/index.ts
+++ b/client/src/lib/stores/layout/index.ts
@@ -1,0 +1,52 @@
+import { derived, get, writable } from "svelte/store";
+import type { Catalog } from "src/definitions/catalogs";
+import { Maybe } from "$lib/util/maybe";
+import { debounce } from "$lib/util/store";
+import paths from "$lib/paths";
+import { getCatalogBySiret } from "$lib/repositories/catalogs";
+import { account, apiToken } from "../auth";
+
+type NavItem = {
+  label: string;
+  href: string;
+};
+
+const currentCatalog = writable<Maybe<Catalog>>();
+
+// XXX: Upon login, $account may be set a few times in a row.
+// Make only one HTTP request once things have settled.
+debounce(account, 100).subscribe((accountValue) => {
+  if (!Maybe.Some(accountValue)) {
+    currentCatalog.set(null);
+    return;
+  }
+
+  getCatalogBySiret({
+    fetch,
+    apiToken: Maybe.expect(get(apiToken), "$apiToken"),
+    siret: accountValue.organizationSiret,
+  }).then((catalog) => {
+    currentCatalog.set(catalog);
+  });
+});
+
+export const navigationItems = derived(currentCatalog, (catalog): NavItem[] => {
+  return [
+    {
+      label: "Accueil",
+      href: paths.home,
+    },
+    {
+      label: "Rechercher",
+      href: paths.datasetSearch,
+    },
+    ...(Maybe.Some(catalog)
+      ? [
+          {
+            label: "Contribuer",
+            href: paths.contribute,
+          },
+        ]
+      : []),
+  ];
+});

--- a/client/src/lib/util/array.spec.ts
+++ b/client/src/lib/util/array.spec.ts
@@ -1,7 +1,7 @@
 import { range } from "./array";
 
 describe("range", () => {
-  const cases: [number, number, number[]][] = [
+  const startEndCases: [number, number, number[]][] = [
     [1, 1, []],
     [2, 1, []],
     [2, 2, []],
@@ -11,7 +11,21 @@ describe("range", () => {
     [-3, 2, [-3, -2, -1, 0, 1]],
   ];
 
-  test.each(cases)("when start=%s and end=%s", (start, end, expected) => {
-    expect(range(start, end)).toStrictEqual(expected);
+  test.each(startEndCases)(
+    "when start=%s and end=%s",
+    (start, end, expected) => {
+      expect(range(start, end)).toStrictEqual(expected);
+    }
+  );
+
+  const endCases: [number, number[]][] = [
+    [0, []],
+    [1, [0]],
+    [4, [0, 1, 2, 3]],
+    [-3, []],
+  ];
+
+  test.each(endCases)("when end=%s", (end, expected) => {
+    expect(range(end)).toStrictEqual(expected);
   });
 });

--- a/client/src/lib/util/array.ts
+++ b/client/src/lib/util/array.ts
@@ -1,4 +1,11 @@
-export const range = (start: number, end: number): number[] => {
+/**
+ * @returns An array of integers from `start` (included) to `end` (excluded).
+ */
+export const range = (start: number, end?: number): number[] => {
+  if (end === undefined) {
+    end = start;
+    start = 0;
+  }
   const length = end - start;
   return Array.from({ length }, (_, idx) => start + idx);
 };

--- a/client/src/lib/util/random.ts
+++ b/client/src/lib/util/random.ts
@@ -1,0 +1,6 @@
+/**
+ * @returns A random integer between `start` (included) and `end` (excluded)
+ */
+export const randint = (start: number, end: number): number => {
+  return Math.floor(start + Math.random() * (end - start));
+};

--- a/client/src/lib/util/store.ts
+++ b/client/src/lib/util/store.ts
@@ -1,0 +1,21 @@
+import { writable, type Readable } from "svelte/store";
+
+/**
+ * @returns A new store that sends a value once `store` has not been called for `delay` milliseconds.
+ *
+ * Inspired by: https://docs-lodash.com/v4/debounce/
+ */
+export const debounce = <T>(store: Readable<T>, delay: number): Readable<T> => {
+  const newStore = writable<T>();
+
+  let timer: NodeJS.Timeout;
+
+  store.subscribe((value) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      newStore.set(value);
+    }, delay);
+  });
+
+  return newStore;
+};

--- a/client/src/playwright.config.ts
+++ b/client/src/playwright.config.ts
@@ -2,22 +2,10 @@ import path from "path";
 import dotenv from "dotenv";
 import type { PlaywrightTestConfig } from "@playwright/test";
 import type { AppTestArgs } from "src/tests/e2e/fixtures";
-import { ADMIN_EMAIL } from "./tests/e2e/constants.js";
 
 dotenv.config({
   path: path.resolve("..", ".env"),
 });
-
-const getAdminTestPassword = (): string => {
-  const passwords = JSON.parse(process.env.TOOLS_PASSWORDS || "{}");
-  const adminPassword = passwords[ADMIN_EMAIL];
-  if (!adminPassword) {
-    throw new Error(
-      `Password for ${ADMIN_EMAIL} not defined in TOOLS_PASSWORDS`
-    );
-  }
-  return adminPassword;
-};
 
 const config: PlaywrightTestConfig<AppTestArgs> = {
   testDir: "./tests/e2e/",
@@ -30,14 +18,6 @@ const config: PlaywrightTestConfig<AppTestArgs> = {
     screenshot: "only-on-failure",
     video: "on-first-retry",
   },
-  projects: [
-    {
-      name: "default",
-      use: {
-        adminTestPassword: getAdminTestPassword(),
-      },
-    },
-  ],
 };
 
 export default config;

--- a/client/src/routes/(app)/fiches/[id]/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/+page.svelte
@@ -3,7 +3,9 @@
   import paths from "$lib/paths";
   import { UPDATE_FREQUENCY_LABELS } from "src/constants";
   import { formatFullDate, splitParagraphs } from "src/lib/util/format";
+  import { account } from "$lib/stores/auth";
   import { Maybe } from "$lib/util/maybe";
+  import permissions from "$lib/permissions";
   import AsideItem from "./_AsideItem.svelte";
   import ExtraFieldsList from "./_ExtraFieldsList.svelte";
 
@@ -45,15 +47,17 @@
       <ul
         class="fr-grid-row fr-grid-row--right fr-btns-group fr-btns-group--inline fr-btns-group--icon-right fr-my-5w"
       >
-        <li>
-          <a
-            href={editUrl}
-            class="fr-btn fr-btn--secondary fr-icon-edit-fill"
-            title="Modifier ce jeu de données"
-          >
-            Modifier
-          </a>
-        </li>
+        {#if permissions.dataset.edit(dataset, Maybe.expect($account, "$account"))}
+          <li>
+            <a
+              href={editUrl}
+              class="fr-btn fr-btn--secondary fr-icon-edit-fill"
+              title="Modifier ce jeu de données"
+            >
+              Modifier
+            </a>
+          </li>
+        {/if}
         <li>
           <a
             class="fr-btn fr-btn--secondary fr-icon-mail-line"

--- a/client/src/routes/(app)/fiches/[id]/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/+page.svelte
@@ -5,7 +5,7 @@
   import { formatFullDate, splitParagraphs } from "src/lib/util/format";
   import { account } from "$lib/stores/auth";
   import { Maybe } from "$lib/util/maybe";
-  import permissions from "$lib/permissions";
+  import { canEditDataset } from "$lib/permissions";
   import AsideItem from "./_AsideItem.svelte";
   import ExtraFieldsList from "./_ExtraFieldsList.svelte";
 
@@ -47,7 +47,7 @@
       <ul
         class="fr-grid-row fr-grid-row--right fr-btns-group fr-btns-group--inline fr-btns-group--icon-right fr-my-5w"
       >
-        {#if permissions.dataset.edit(dataset, Maybe.expect($account, "$account"))}
+        {#if canEditDataset(dataset, Maybe.expect($account, "$account"))}
           <li>
             <a
               href={editUrl}

--- a/client/src/routes/(app)/fiches/[id]/edit/+page.ts
+++ b/client/src/routes/(app)/fiches/[id]/edit/+page.ts
@@ -5,16 +5,22 @@ import { getDatasetByID } from "$lib/repositories/datasets";
 import { getTags } from "src/lib/repositories/tags";
 import { getLicenses } from "src/lib/repositories/licenses";
 import { getDatasetFiltersInfo } from "src/lib/repositories/datasetFilters";
-import { apiToken as apiTokenStore, account } from "$lib/stores/auth";
+import { apiToken as apiTokenStore } from "$lib/stores/auth";
 import { Maybe } from "$lib/util/maybe";
 
 export const load: PageLoad = async ({ fetch, params }) => {
   const apiToken = get(apiTokenStore);
-  const siret = Maybe.expect(get(account), "$account").organizationSiret;
 
-  const [catalog, dataset, tags, licenses, filtersInfo] = await Promise.all([
-    getCatalogBySiret({ fetch, apiToken, siret }),
-    getDatasetByID({ fetch, apiToken, id: params.id }),
+  const dataset = await getDatasetByID({ fetch, apiToken, id: params.id });
+
+  const [catalog, tags, licenses, filtersInfo] = await Promise.all([
+    Maybe.map(dataset, (dataset) =>
+      getCatalogBySiret({
+        fetch,
+        apiToken,
+        siret: dataset.catalogRecord.organization.siret,
+      })
+    ),
     getTags({ fetch, apiToken }),
     getLicenses({ fetch, apiToken }),
     getDatasetFiltersInfo({ fetch, apiToken }),

--- a/client/src/tests/e2e/constants.ts
+++ b/client/src/tests/e2e/constants.ts
@@ -1,13 +1,19 @@
 import type { Organization } from "src/definitions/organization";
+import { getToolsPassword } from "./helpers.js";
 
 export const TEST_EMAIL = "catalogue.demo@yopmail.com";
 export const TEST_PASSWORD = "password1234";
+export const TEST_EMAIL_SANTE = "catalogue.demo2@yopmail.com";
+export const TEST_PASSWORD_SANTE = "password1234";
 export const ADMIN_EMAIL = "admin@catalogue.data.gouv.fr";
+export const ADMIN_PASSWORD = getToolsPassword("admin@catalogue.data.gouv.fr");
 
 export const TEST_ORGANIZATION: Organization = {
   siret: "44229377500031",
   name: "Ministère de la culture",
 };
 export const STATE_AUTHENTICATED = "./src/tests/e2e/storage/authenticated.json";
+export const STATE_AUTHENTICATED_SANTE =
+  "./src/tests/e2e/storage/authenticated-sante.json";
 export const STATE_AUTHENTICATED_ADMIN =
   "./src/tests/e2e/storage/authenticated-admin.json";

--- a/client/src/tests/e2e/constants.ts
+++ b/client/src/tests/e2e/constants.ts
@@ -7,6 +7,10 @@ export const TEST_EMAIL_SANTE = "catalogue.demo2@yopmail.com";
 export const TEST_PASSWORD_SANTE = "password1234";
 export const ADMIN_EMAIL = "admin@catalogue.data.gouv.fr";
 export const ADMIN_PASSWORD = getToolsPassword("admin@catalogue.data.gouv.fr");
+export const ADMIN_EMAIL_SANTE = "admin.sante@catalogue.data.gouv.fr";
+export const ADMIN_PASSWORD_SANTE = getToolsPassword(
+  "admin.sante@catalogue.data.gouv.fr"
+);
 
 export const TEST_ORGANIZATION: Organization = {
   siret: "44229377500031",
@@ -17,3 +21,5 @@ export const STATE_AUTHENTICATED_SANTE =
   "./src/tests/e2e/storage/authenticated-sante.json";
 export const STATE_AUTHENTICATED_ADMIN =
   "./src/tests/e2e/storage/authenticated-admin.json";
+export const STATE_AUTHENTICATED_ADMIN_SANTE =
+  "./src/tests/e2e/storage/authenticated-sante-admin.json";

--- a/client/src/tests/e2e/datapass.spec.ts
+++ b/client/src/tests/e2e/datapass.spec.ts
@@ -1,8 +1,15 @@
-import { TEST_EMAIL, TEST_ORGANIZATION } from "./constants.js";
 import { test } from "./fixtures.js";
 import { expect } from "@playwright/test";
+import type { Organization } from "src/definitions/organizations";
 
 test.describe("Datapass", () => {
+  const TEST_EMAIL = "user@mydomain.org";
+
+  const TEST_ORGANIZATION: Organization = {
+    siret: "44229377500031",
+    name: "Ministère de la culture",
+  };
+
   test("A user tried to log in but no organization has been found", async ({
     page,
   }) => {

--- a/client/src/tests/e2e/details.spec.ts
+++ b/client/src/tests/e2e/details.spec.ts
@@ -1,23 +1,36 @@
 import { expect } from "@playwright/test";
-import { STATE_AUTHENTICATED } from "./constants.js";
+import { STATE_AUTHENTICATED, STATE_AUTHENTICATED_SANTE } from "./constants.js";
 import { test } from "./fixtures.js";
 
 test.describe("Dataset details", () => {
-  test.use({ storageState: STATE_AUTHENTICATED });
+  test.describe("As a user in same organization than dataset", () => {
+    test.use({ storageState: STATE_AUTHENTICATED });
 
-  test("Displays dataset details", async ({ page, dataset }) => {
-    await page.goto(`/fiches/${dataset.id}`);
+    test("Displays dataset details", async ({ page, dataset }) => {
+      await page.goto(`/fiches/${dataset.id}`);
 
-    const title = page.locator("h1");
-    await expect(title).toHaveText(dataset.title);
+      const title = page.locator("h1");
+      await expect(title).toHaveText(dataset.title);
 
-    const description = page.locator("[data-testid=dataset-description]");
-    await expect(description).toHaveText(dataset.description);
+      const description = page.locator("[data-testid=dataset-description]");
+      await expect(description).toHaveText(dataset.description);
+    });
 
-    const editUrl = page.locator("text=Modifier");
+    test("The edit button is shown", async ({ page, dataset }) => {
+      await page.goto(`/fiches/${dataset.id}`);
+      const editUrl = page.locator("text='Modifier'");
+      await expect(editUrl).toBeVisible();
+      expect(await editUrl.getAttribute("href")).toBe(
+        `/fiches/${dataset.id}/edit`
+      );
+    });
+  });
 
-    expect(await editUrl.getAttribute("href")).toBe(
-      `/fiches/${dataset.id}/edit`
-    );
+  test.describe("As a user in different organization", () => {
+    test.use({ storageState: STATE_AUTHENTICATED_SANTE });
+    test("The edit button is not shown", async ({ page, dataset }) => {
+      await page.goto(`/fiches/${dataset.id}`);
+      await expect(page.locator("text='Modifier'")).toBeHidden();
+    });
   });
 });

--- a/client/src/tests/e2e/edit.spec.ts
+++ b/client/src/tests/e2e/edit.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from "@playwright/test";
-import { STATE_AUTHENTICATED, STATE_AUTHENTICATED_ADMIN } from "./constants.js";
+import {
+  STATE_AUTHENTICATED,
+  STATE_AUTHENTICATED_ADMIN,
+  STATE_AUTHENTICATED_ADMIN_SANTE,
+  STATE_AUTHENTICATED_SANTE,
+} from "./constants.js";
 import { test } from "./fixtures.js";
 
 const DELETE_DATASET_BUTTON_LOCATOR = "text=Supprimer ce jeu de données";
@@ -157,6 +162,37 @@ test.describe("confirm before exit", () => {
 
     // check if the user has been redirected to the home page
     await page.waitForURL("/");
+  });
+});
+
+test.describe("Edit as outside contributor", () => {
+  test.describe("As a user", () => {
+    test.use({ storageState: STATE_AUTHENTICATED_SANTE });
+
+    test("Visits edit page as user from other org and gets permission denied", async ({
+      page,
+      dataset,
+    }) => {
+      await page.goto(`/fiches/${dataset.id}/edit`);
+      await page.locator("form [name=title]").waitFor();
+    });
+  });
+
+  test.describe("As an admin", () => {
+    test.use({ storageState: STATE_AUTHENTICATED_ADMIN_SANTE });
+
+    test("Visits edit page as admin from other org", async ({
+      page,
+      dataset,
+    }) => {
+      /**
+       * [Regression test] Legitimate users outside the dataset's organization used
+       * to not be able to access the page because we fetched their organization's
+       * catalog, instead of the catalog of the dataset.
+       */
+      await page.goto(`/fiches/${dataset.id}/edit`);
+      await page.locator("form [name=title]").waitFor();
+    });
   });
 });
 

--- a/client/src/tests/e2e/fixtures.ts
+++ b/client/src/tests/e2e/fixtures.ts
@@ -1,7 +1,12 @@
 import { test as base, expect, type APIRequestContext } from "@playwright/test";
 import type { Dataset } from "../../definitions/datasets.js";
 import { toDataset } from "../../lib/transformers/dataset.js";
-import { ADMIN_EMAIL, TEST_EMAIL, TEST_PASSWORD } from "./constants.js";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  TEST_EMAIL,
+  TEST_PASSWORD,
+} from "./constants.js";
 
 /**
  * These fixtures allow simplifying setup/teardown logic in tests,
@@ -10,10 +15,6 @@ import { ADMIN_EMAIL, TEST_EMAIL, TEST_PASSWORD } from "./constants.js";
  * See: https://playwright.dev/docs/test-api-testing#sending-api-requests-from-ui-tests
  */
 
-type AppOptions = {
-  adminTestPassword: string;
-};
-
 type AppFixtures = {
   apiContext: APIRequestContext;
   adminApiToken: string;
@@ -21,10 +22,9 @@ type AppFixtures = {
   dataset: Dataset;
 };
 
-export type AppTestArgs = AppOptions & AppFixtures;
+export type AppTestArgs = AppFixtures;
 
 export const test = base.extend<AppTestArgs>({
-  adminTestPassword: ["admin", { option: true }],
   apiContext: async ({ playwright }, use) => {
     const baseURL = "http://localhost:3579";
     const apiContext = await playwright.request.newContext({ baseURL });
@@ -32,10 +32,10 @@ export const test = base.extend<AppTestArgs>({
     await apiContext.dispose();
   },
 
-  adminApiToken: async ({ apiContext, adminTestPassword }, use) => {
+  adminApiToken: async ({ apiContext }, use) => {
     const data = {
       email: ADMIN_EMAIL,
-      password: adminTestPassword,
+      password: ADMIN_PASSWORD,
     };
     const response = await apiContext.post("/auth/login/", { data });
     expect(response.ok()).toBeTruthy();

--- a/client/src/tests/e2e/global-setup.ts
+++ b/client/src/tests/e2e/global-setup.ts
@@ -7,10 +7,14 @@ import {
 
 import {
   ADMIN_EMAIL,
+  ADMIN_PASSWORD,
   STATE_AUTHENTICATED,
   STATE_AUTHENTICATED_ADMIN,
+  STATE_AUTHENTICATED_SANTE,
   TEST_EMAIL,
+  TEST_EMAIL_SANTE,
   TEST_PASSWORD,
+  TEST_PASSWORD_SANTE,
 } from "./constants.js";
 import type { AppTestArgs } from "./fixtures.js";
 
@@ -28,8 +32,14 @@ export default async function globalSetup(
   });
 
   await saveAuthenticatedState(browser, config, {
+    email: TEST_EMAIL_SANTE,
+    password: TEST_PASSWORD_SANTE,
+    path: STATE_AUTHENTICATED_SANTE,
+  });
+
+  await saveAuthenticatedState(browser, config, {
     email: ADMIN_EMAIL,
-    password: config.projects[0].use.adminTestPassword || "",
+    password: ADMIN_PASSWORD,
     path: STATE_AUTHENTICATED_ADMIN,
   });
 

--- a/client/src/tests/e2e/global-setup.ts
+++ b/client/src/tests/e2e/global-setup.ts
@@ -7,9 +7,12 @@ import {
 
 import {
   ADMIN_EMAIL,
+  ADMIN_EMAIL_SANTE,
   ADMIN_PASSWORD,
+  ADMIN_PASSWORD_SANTE,
   STATE_AUTHENTICATED,
   STATE_AUTHENTICATED_ADMIN,
+  STATE_AUTHENTICATED_ADMIN_SANTE,
   STATE_AUTHENTICATED_SANTE,
   TEST_EMAIL,
   TEST_EMAIL_SANTE,
@@ -41,6 +44,12 @@ export default async function globalSetup(
     email: ADMIN_EMAIL,
     password: ADMIN_PASSWORD,
     path: STATE_AUTHENTICATED_ADMIN,
+  });
+
+  await saveAuthenticatedState(browser, config, {
+    email: ADMIN_EMAIL_SANTE,
+    password: ADMIN_PASSWORD_SANTE,
+    path: STATE_AUTHENTICATED_ADMIN_SANTE,
   });
 
   await browser.close();

--- a/client/src/tests/e2e/helpers.ts
+++ b/client/src/tests/e2e/helpers.ts
@@ -1,0 +1,8 @@
+export const getToolsPassword = (email: string): string => {
+  const passwords = JSON.parse(process.env.TOOLS_PASSWORDS || "{}");
+  const password = passwords[email];
+  if (!password) {
+    throw new Error(`Password for ${email} not defined in TOOLS_PASSWORDS`);
+  }
+  return password;
+};

--- a/client/src/tests/e2e/login.spec.ts
+++ b/client/src/tests/e2e/login.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from "@playwright/test";
-import { TEST_EMAIL, TEST_PASSWORD } from "./constants.js";
+import {
+  TEST_EMAIL,
+  TEST_EMAIL_SANTE,
+  TEST_PASSWORD,
+  TEST_PASSWORD_SANTE,
+} from "./constants.js";
 import { test } from "./fixtures.js";
 
 test.describe("Login", () => {
@@ -69,5 +74,25 @@ test.describe("Login", () => {
     const exampleProtectedPage = "/contribuer";
     await page.goto(exampleProtectedPage);
     await page.waitForURL("/");
+  });
+});
+
+test.describe("Login -- Multi-organization support", () => {
+  test("Contribute button is switched on or off when changing accounts in organizations that have/don't have a catalog", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.fill("[name=email]", TEST_EMAIL);
+    await page.fill("[name=password]", TEST_PASSWORD);
+    await page.click("button[type='submit']");
+    await expect(page.locator("text=Contribuer")).toBeVisible();
+
+    await page.click("text=Déconnexion");
+
+    await page.click("text=Se connecter");
+    await page.fill("[name=email]", TEST_EMAIL_SANTE);
+    await page.fill("[name=password]", TEST_PASSWORD_SANTE);
+    await page.click("button[type='submit']");
+    await expect(page.locator("text=Contribuer")).toBeHidden();
   });
 });

--- a/client/src/tests/factories/accounts.ts
+++ b/client/src/tests/factories/accounts.ts
@@ -1,0 +1,10 @@
+import type { Account } from "src/definitions/auth";
+import { getFakeSiret } from "./organizations";
+
+export const getFakeAccount = (obj: Partial<Account> = {}): Account => {
+  return {
+    organizationSiret: obj.organizationSiret || getFakeSiret(),
+    email: obj.email || "test@mydomain.org",
+    role: obj.role || "USER",
+  };
+};

--- a/client/src/tests/factories/catalog_records.ts
+++ b/client/src/tests/factories/catalog_records.ts
@@ -1,0 +1,11 @@
+import type { CatalogRecord } from "src/definitions/catalog_records";
+import { getFakeOrganization } from "./organizations";
+
+export const getFakeCatalogRecord = (
+  obj: Partial<CatalogRecord> = {}
+): CatalogRecord => {
+  return {
+    createdAt: obj.createdAt || new Date(),
+    organization: obj.organization || getFakeOrganization(),
+  };
+};

--- a/client/src/tests/factories/organizations.ts
+++ b/client/src/tests/factories/organizations.ts
@@ -1,0 +1,18 @@
+import type { Organization } from "src/definitions/organizations";
+import { range } from "$lib/util/array";
+import { randint } from "src/lib/util/random";
+
+export const getFakeSiret = (): string => {
+  return range(14)
+    .map(() => randint(0, 10).toString())
+    .join("");
+};
+
+export const getFakeOrganization = (
+  obj: Partial<Organization> = {}
+): Organization => {
+  return {
+    name: obj.name || "Test org",
+    siret: obj.siret || getFakeSiret(),
+  };
+};

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -1,4 +1,5 @@
 import json
+import re
 import uuid
 from pathlib import Path
 
@@ -116,11 +117,12 @@ async def test_repo_initdata(
 ) -> None:
     bus = resolve(MessageBus)
     path = Path("tools", "initdata.yml")
-    monkeypatch.setenv(
-        "TOOLS_PASSWORDS", json.dumps({"admin@catalogue.data.gouv.fr": "test"})
-    )
+    env_example = Path(".env.example").read_text()
+    m = re.search("TOOLS_PASSWORDS='(.*)'", env_example)
+    assert m is not None
+    monkeypatch.setenv("TOOLS_PASSWORDS", m.group(1))
 
-    num_users = 3
+    num_users = 4
     num_tags = 7
     num_datasets = 4
     num_organizations = 2

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -63,6 +63,14 @@ users:
     extras:
       role: ADMIN
 
+  - id: "17bda0c7-5bf0-46a3-b89b-9aeb2fa47974"
+    params:
+      organization_siret: "13001653800014"
+      email: admin.sante@catalogue.data.gouv.fr
+      password: __env__
+    extras:
+      role: ADMIN
+
 tags:
   - id: "9c1549a5-02ef-43a9-aa20-6babdce0b733"
     params:


### PR DESCRIPTION
Refs #388 

Cette PR implémente des changements pour tenir compte des droits de chaque utilisateur vis-à-vis des catalogues:

* Cacher le bouton "Contribuer" si l'organisation de l'utilisateur n'a pas de catalogue.
* Cacher le bouton "Modifier" sur une fiche si l'utilisateur fait partie d'une organisation différente de celle du jeu de données.

Je peux éventuellement couper ça en 2.

(Les PRs côté backend ne feront que "verrouiller" ces comportements côté backend, mais on n'en a pas besoin pour adapter l'UI dès à présent.)

## TODO

* [x] Cacher "Contribuer"  si l'organisation de l'utilisateur n'a pas de catalogue
* [x] Cacher "Modifier" si l'utilisateur ne fait pas partie de l'organisation de la fiche
* [x] Vérifier mise à jour de ces affichags si on change de compte utilisateur (avec/sans catalogue) 
* [x] Tests unitaires
* [x] Tests E2E

## Pour tester

En local :

* Se connecter avec catalogue.demo@yopmail.com / password1234 (orga "MC")
* Constater que le bouton "Contribuer" est présent, que l'on peut modifier les jeux de données (car ils sont dans l'orga MC)
* Se déconnecter, puis se connecter avec catalogue.demo2@yopmail.com / password1234 (orga "Ministère santé", n'a pas de catalogue)
* Constater qu'il n'y a pas de bouton "Contribuer", et qu'on ne peut pas modifier les jeux de données de l'orga MC
* Se connecter avec admin.sante@catalogue.data.gouv.fr / admin (mettre à jour `TOOLS_PASSWORDS` dans son `.env` et relancer `make initdata`)
* Constater que l'on peut toujours modifier les jeux de données même s'ils ne sont pas de notre orga. (Est-ce que c'est souhaitable ?)