### PR TITLE
Check user belongs to organization before update

### DIFF
--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -35,6 +35,8 @@ class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
 
 
 class UpdateDataset(UpdateDatasetValidationMixin, Command[None]):
+    account: Union[Account, Skip]
+
     id: ID
     title: str
     description: str

--- a/server/application/datasets/exceptions.py
+++ b/server/application/datasets/exceptions.py
@@ -1,2 +1,6 @@
 class CannotCreateDataset(Exception):
     pass
+
+
+class CannotUpdateDataset(Exception):
+    pass

--- a/server/application/datasets/specifications.py
+++ b/server/application/datasets/specifications.py
@@ -1,6 +1,11 @@
 from server.domain.auth.entities import Account
 from server.domain.catalogs.entities import Catalog
+from server.domain.datasets.entities import Dataset
 
 
 def can_create_dataset(catalog: Catalog, account: Account) -> bool:
     return catalog.organization.siret == account.organization_siret
+
+
+def can_update_dataset(dataset: Dataset, account: Account) -> bool:
+    return dataset.catalog_record.organization.siret == account.organization_siret

--- a/tests/api/test_datasets_search.py
+++ b/tests/api/test_datasets_search.py
@@ -183,7 +183,10 @@ async def test_search_results_change_when_data_changes(
 
     # Update dataset title
     update_command = UpdateDatasetFactory.build(
-        id=pk, title="Modifié", **command.dict(exclude={"title"})
+        account=temp_user.account,
+        id=pk,
+        title="Modifié",
+        **command.dict(exclude={"title", "account", "organization_siret"}),
     )
 
     await bus.execute(update_command)
@@ -200,7 +203,7 @@ async def test_search_results_change_when_data_changes(
     # Same on description
     update_command = UpdateDatasetFactory.build(
         description="Jeu de données spécial",
-        **update_command.dict(exclude={"description"})
+        **update_command.dict(exclude={"description"}),
     )
     await bus.execute(update_command)
     response = await client.get(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -7,7 +7,7 @@ from faker.providers import BaseProvider
 from pydantic import BaseModel
 from pydantic_factories import ModelFactory, Require, Use
 
-from server.api.datasets.schemas import DatasetCreate
+from server.api.datasets.schemas import DatasetCreate, DatasetUpdate
 from server.application.auth.commands import CreateDataPassUser, CreatePasswordUser
 from server.application.datasets.commands import CreateDataset, UpdateDataset
 from server.application.organizations.commands import CreateOrganization
@@ -93,11 +93,27 @@ class CreateDatasetPayloadFactory(_BaseCreateDatasetFactory, Factory[DatasetCrea
     __model__ = DatasetCreate
 
 
-class UpdateDatasetFactory(Factory[UpdateDataset]):
-    __model__ = UpdateDataset
-
+class _BaseUpdateDatasetFactory:
     tag_ids = Use(lambda: [])
     extra_field_values = Use(lambda: [])
+
+
+class UpdateDatasetFactory(_BaseCreateDatasetFactory, Factory[UpdateDataset]):
+    __model__ = UpdateDataset
+
+    account = Require()
+
+
+class UpdateDatasetPayloadFactory(_BaseUpdateDatasetFactory, Factory[DatasetUpdate]):
+    __model__ = DatasetUpdate
+
+    @classmethod
+    def build_from_create_command(
+        cls, command: CreateDataset, **kwargs: Any
+    ) -> DatasetUpdate:
+        return cls.build(
+            **command.dict(exclude={"account", "organization_siret"}), **kwargs
+        )
 
 
 class CreateOrganizationFactory(Factory[CreateOrganization]):

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -11,7 +11,7 @@ from server.application.auth.queries import LoginPasswordUser
 from server.application.datasets.commands import UpdateDataset
 from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
 from server.config.di import resolve
-from server.domain.common.types import ID
+from server.domain.common.types import ID, Skip
 from server.seedwork.application.messages import MessageBus
 from tools import initdata
 
@@ -146,6 +146,7 @@ async def test_repo_initdata(
 
     # Make a change.
     command = UpdateDataset(
+        account=Skip(),
         **dataset.dict(exclude={"title"}),
         tag_ids=[tag.id for tag in dataset.tags],
         title="Changed",

--- a/tools/initdata.py
+++ b/tools/initdata.py
@@ -159,7 +159,7 @@ async def handle_dataset(item: dict, reset: bool = False) -> None:
     existing_dataset = await repository.get_by_id(id_)
 
     if existing_dataset is not None:
-        update_command = UpdateDataset(id=id_, **item["params"])
+        update_command = UpdateDataset(account=Skip(), id=id_, **item["params"])
 
         changed = any(
             getattr(update_command, k) != _get_dataset_attr(existing_dataset, k)


### PR DESCRIPTION
Suite de #437 

Closes #388

Cette PR vérifie que l'utilisateur qui fait la requête de mise à jour d'un jeu de données a bien le droit de le faire, = appartient à l'organisation à laquelle le jeu de données est rattaché.