### PR TITLE
Fix missing organization_siret in datapass login params payload

### DIFF
--- a/client/src/lib/repositories/auth.ts
+++ b/client/src/lib/repositories/auth.ts
@@ -41,14 +41,14 @@ type LoginWithDataPass = (opts: {
 }) => Promise<Maybe<AuthenticatedUser>>;
 
 export const loginWithDataPass: LoginWithDataPass = async ({ params }) => {
-  const encoded = params.get("user_info");
+  const userInfo = params.get("user_info");
 
-  if (!encoded) {
+  if (!userInfo) {
     return null;
   }
 
   try {
-    const data = JSON.parse(encoded);
+    const data = JSON.parse(userInfo);
     return {
       account: toAccount(data),
       apiToken: data.api_token,

--- a/client/src/lib/repositories/auth.ts
+++ b/client/src/lib/repositories/auth.ts
@@ -41,18 +41,21 @@ type LoginWithDataPass = (opts: {
 }) => Promise<Maybe<AuthenticatedUser>>;
 
 export const loginWithDataPass: LoginWithDataPass = async ({ params }) => {
-  const email = params.get("email");
-  const role = params.get("role");
-  const api_token = params.get("api_token");
+  const encoded = params.get("user_info");
 
-  if (!email || !role || !api_token) {
+  if (!encoded) {
     return null;
   }
 
-  return {
-    account: toAccount({ email, role }),
-    apiToken: api_token,
-  };
+  try {
+    const data = JSON.parse(encoded);
+    return {
+      account: toAccount(data),
+      apiToken: data.api_token,
+    };
+  } catch (e) {
+    return null;
+  }
 };
 
 type GetMe = (opts: {

--- a/client/src/tests/e2e/constants.ts
+++ b/client/src/tests/e2e/constants.ts
@@ -13,9 +13,10 @@ export const ADMIN_PASSWORD_SANTE = getToolsPassword(
 );
 
 export const TEST_ORGANIZATION: Organization = {
-  siret: "44229377500031",
+  siret: "11004601800013",
   name: "Ministère de la culture",
 };
+
 export const STATE_AUTHENTICATED = "./src/tests/e2e/storage/authenticated.json";
 export const STATE_AUTHENTICATED_SANTE =
   "./src/tests/e2e/storage/authenticated-sante.json";

--- a/tests/api/test_auth_datapass.py
+++ b/tests/api/test_auth_datapass.py
@@ -208,10 +208,12 @@ class TestCallback:
             assert location.scheme == "http"
             assert location.netloc == b"client.testserver"
             assert location.path == "/auth/datapass/login"
-            assert location.params["organization_siret"] == siret_1
-            assert location.params["email"] == "johndoe@mydomain.org"
-            assert location.params["role"] == "USER"
-            assert location.params["api_token"] == user.account.api_token
+            assert json.loads(location.params["user_info"]) == {
+                "organization_siret": siret_1,
+                "email": "johndoe@mydomain.org",
+                "role": "USER",
+                "api_token": user.account.api_token,
+            }
 
     async def test_existing_password_user_reuses_account(
         self, client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Refs https://github.com/etalab/catalogage-donnees/issues/388#issuecomment-1265929234

Le `loginWithDatapass` ne lisait pas le query param `organization_siret`, dès lors on avait dans le front `userInfo.account.organizationSiret === null`, ce qui provoquait des pb comme celui relevé par Johan.

Pour réduire le risque de répétition de ce pb à l'avenir, le front reçoit désormais les infos utilisateur dans un `AuthenticatedUserView` encodé en JSON, qu'il passe directement à `toAccount()`, comme pour `loginWithPassword`.