### PR TITLE
Move admin account to legacy org in demo/staging initdata

### DIFF
--- a/ops/ansible/environments/demo/assets/initdata.yml
+++ b/ops/ansible/environments/demo/assets/initdata.yml
@@ -1,5 +1,8 @@
 organizations:
   - params:
+      name: "Organisation par défaut"
+      siret: "00000000000000"
+  - params:
       name: "Ministère de la Culture"
       siret: "11004601800013"
 
@@ -21,7 +24,7 @@ users:
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:
-      organization_siret: "11004601800013"
+      organization_siret: "00000000000000"
       email: admin@catalogue.data.gouv.fr
       password: __env__
     extras:

--- a/ops/ansible/environments/staging/assets/initdata.yml
+++ b/ops/ansible/environments/staging/assets/initdata.yml
@@ -1,5 +1,8 @@
 organizations:
   - params:
+      name: "Organisation par défaut"
+      siret: "00000000000000"
+  - params:
       name: "Ministère de la Culture"
       siret: "11004601800013"
 
@@ -21,7 +24,7 @@ users:
 
   - id: "4c2cefce-ea47-4e6e-8c79-8befd4495f45"
     params:
-      organization_siret: "11004601800013"
+      organization_siret: "00000000000000"
       email: admin@catalogue.data.gouv.fr
       password: __env__
     extras:


### PR DESCRIPTION
* En lien avec #460 
* En lien avec #389 
* Suite à https://github.com/etalab/catalogage-donnees/issues/388#issuecomment-1267090461

Sur démo et staging, il serait attendu que le compte admin soit rattaché à l'orga "legacy", comme ça va être le cas sur la prod.

Cette PR met à jour les fichiers d'initdata, mais il y aura peut-être une intervention en base nécessaire pour migrer le compte admin existant (l'initdata verra que l'email existe et ne fera pas de mise à jour).