### PR TITLE
Test that all environment initdata files are valid

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, AsyncIterator, Iterator, List
 
 import httpx
@@ -120,3 +121,8 @@ async def fixture_temp_user() -> TestPasswordUser:
 async def admin_user() -> TestPasswordUser:
     command = CreatePasswordUserFactory.build()
     return await create_test_password_user(command, role=UserRole.ADMIN)
+
+
+@pytest.fixture
+def ops_environments_dir() -> Path:
+    return Path("ops/ansible/environments")


### PR DESCRIPTION
Suite à un échec du lancement de l'initdata prod (#460) car le fichier n'avait pas de bon format,

Cette PR ajoute un test qui vérifie que tous les `initdata.yml` présents dans `ops/ansible/environments/*/assets/initdata.yml` sont "valides". Pour l'instant "valide" veut dire : a les champs attendus (organizations, catalogs, users, tags, datasets).

En effet, il vaut mieux détecter tôt qu'un fichier est non-valide plutôt qu'une fois qu'on essaie de lancer l'initdata.