### PR TITLE
Fix logout from dataset detail page

### DIFF
--- a/client/src/lib/permissions.ts
+++ b/client/src/lib/permissions.ts
@@ -1,6 +1,13 @@
 import type { Account } from "src/definitions/auth";
 import type { Dataset } from "src/definitions/datasets";
+import { Maybe } from "./util/maybe";
 
-export const canEditDataset = (dataset: Dataset, account: Account): boolean => {
-  return dataset.catalogRecord.organization.siret === account.organizationSiret;
+export const canEditDataset = (
+  dataset: Dataset,
+  account: Maybe<Account>
+): boolean => {
+  return (
+    Maybe.Some(account) &&
+    dataset.catalogRecord.organization.siret === account.organizationSiret
+  );
 };

--- a/client/src/routes/(app)/fiches/[id]/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/+page.svelte
@@ -47,7 +47,7 @@
       <ul
         class="fr-grid-row fr-grid-row--right fr-btns-group fr-btns-group--inline fr-btns-group--icon-right fr-my-5w"
       >
-        {#if canEditDataset(dataset, Maybe.expect($account, "$account"))}
+        {#if canEditDataset(dataset, $account)}
           <li>
             <a
               href={editUrl}

--- a/client/src/tests/e2e/details.spec.ts
+++ b/client/src/tests/e2e/details.spec.ts
@@ -33,4 +33,18 @@ test.describe("Dataset details", () => {
       await expect(page.locator("text='Modifier'")).toBeHidden();
     });
   });
+
+  test.describe("Regressions -- Logout", () => {
+    test.use({ storageState: STATE_AUTHENTICATED });
+
+    test("Logout from detail page", async ({ page, dataset }) => {
+      // Regression test: logout used to fail.
+      // See: https://github.com/etalab/catalogage-donnees/issues/467
+      await page.goto(`/fiches/${dataset.id}`);
+      await page.click("text=Déconnexion");
+      await page
+        .locator("text=Bienvenue sur le service de catalogage")
+        .waitFor();
+    });
+  });
 });


### PR DESCRIPTION
Closes #467 

C'était bien un pb introduit dans #441 : quand on logout, on a une _race condition_ entre `$account` qui devient `null` et le changement de page/layout, donc `Maybe.expect($account)` peut échouer. Je passe directement le `Maybe<Account>` à la fonction désormais.