### PR TITLE
Remove reliance on LEGACY_ORGANIZATION

### DIFF
--- a/server/api/auth/routes.py
+++ b/server/api/auth/routes.py
@@ -8,6 +8,7 @@ from server.config.di import resolve
 from server.domain.auth.entities import UserRole
 from server.domain.auth.exceptions import EmailAlreadyExists, LoginFailed
 from server.domain.common.types import ID
+from server.domain.organizations.exceptions import OrganizationDoesNotExist
 from server.seedwork.application.messages import MessageBus
 
 from . import datapass
@@ -37,6 +38,8 @@ async def create_password_user(data: PasswordUserCreate) -> AccountView:
     try:
         await bus.execute(command)
     except EmailAlreadyExists as exc:
+        raise HTTPException(400, detail=str(exc))
+    except OrganizationDoesNotExist as exc:
         raise HTTPException(400, detail=str(exc))
 
     query = GetAccountByEmail(email=data.email)

--- a/server/api/auth/routes.py
+++ b/server/api/auth/routes.py
@@ -28,7 +28,11 @@ router.include_router(datapass.router)
 async def create_password_user(data: PasswordUserCreate) -> AccountView:
     bus = resolve(MessageBus)
 
-    command = CreatePasswordUser(email=data.email, password=data.password)
+    command = CreatePasswordUser(
+        organization_siret=data.organization_siret,
+        email=data.email,
+        password=data.password,
+    )
 
     try:
         await bus.execute(command)

--- a/server/api/auth/schemas.py
+++ b/server/api/auth/schemas.py
@@ -1,7 +1,10 @@
 from pydantic import BaseModel, EmailStr, SecretStr
 
+from server.domain.organizations.types import Siret
+
 
 class PasswordUserCreate(BaseModel):
+    organization_siret: Siret
     email: EmailStr
     password: SecretStr
 

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -11,7 +11,6 @@ from server.application.datasets.validation import (
 )
 from server.domain.common.types import ID
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
-from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.domain.organizations.types import Siret
 
 
@@ -42,7 +41,7 @@ class DatasetListParams:
 
 
 class DatasetCreate(CreateDatasetValidationMixin, BaseModel):
-    organization_siret: Siret = LEGACY_ORGANIZATION.siret
+    organization_siret: Siret
     title: str
     description: str
     service: str

--- a/server/application/auth/commands.py
+++ b/server/application/auth/commands.py
@@ -1,13 +1,12 @@
 from pydantic import EmailStr, SecretStr
 
 from server.domain.common.types import ID
-from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
 
 class CreatePasswordUser(Command[ID]):
-    organization_siret: Siret = LEGACY_ORGANIZATION.siret
+    organization_siret: Siret
     email: EmailStr
     password: SecretStr
 

--- a/server/application/datasets/commands.py
+++ b/server/application/datasets/commands.py
@@ -7,7 +7,6 @@ from server.domain.auth.entities import Account
 from server.domain.catalogs.entities import ExtraFieldValue
 from server.domain.common.types import ID, Skip
 from server.domain.datasets.entities import DataFormat, UpdateFrequency
-from server.domain.organizations.entities import LEGACY_ORGANIZATION
 from server.domain.organizations.types import Siret
 from server.seedwork.application.commands import Command
 
@@ -17,7 +16,7 @@ from .validation import CreateDatasetValidationMixin, UpdateDatasetValidationMix
 class CreateDataset(CreateDatasetValidationMixin, Command[ID]):
     account: Union[Account, Skip]
 
-    organization_siret: Siret = LEGACY_ORGANIZATION.siret
+    organization_siret: Siret
     title: str
     description: str
     service: str

--- a/server/domain/organizations/entities.py
+++ b/server/domain/organizations/entities.py
@@ -6,11 +6,3 @@ from .types import Siret
 class Organization(Entity):
     name: str
     siret: Siret
-
-
-# This organization holds legacy users. Its catalog holds legacy datasets.
-# "Legacy" means "prior to multi-org system powered by DataPass".
-# Going forward SIRET numbers will come from DataPass via the user's organization(s).
-LEGACY_ORGANIZATION = Organization(
-    name="Organisation par défaut", siret=Siret("000 000 000 00000")
-)

--- a/tests/api/test_licenses.py
+++ b/tests/api/test_licenses.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 
+from server.application.organizations.views import OrganizationView
 from server.config.di import resolve
 from server.seedwork.application.messages import MessageBus
 
@@ -10,7 +11,7 @@ from ..helpers import TestPasswordUser
 
 @pytest.mark.asyncio
 async def test_license_list(
-    client: httpx.AsyncClient, temp_user: TestPasswordUser
+    client: httpx.AsyncClient, temp_org: OrganizationView, temp_user: TestPasswordUser
 ) -> None:
     bus = resolve(MessageBus)
 
@@ -19,7 +20,11 @@ async def test_license_list(
     assert response.json() == ["Licence Ouverte", "ODC Open Database License"]
 
     await bus.execute(
-        CreateDatasetFactory.build(account=temp_user.account, license="Autre licence")
+        CreateDatasetFactory.build(
+            account=temp_user.account,
+            organization_siret=temp_org.siret,
+            license="Autre licence",
+        )
     )
 
     response = await client.get("/licenses/", auth=temp_user.auth)

--- a/tests/api/test_organizations.py
+++ b/tests/api/test_organizations.py
@@ -1,6 +1,8 @@
 import httpx
 import pytest
 
+from server.application.organizations.views import OrganizationView
+
 from ..factories import CreateOrganizationFactory
 from ..helpers import TestPasswordUser, api_key_auth, to_payload
 
@@ -34,7 +36,6 @@ from ..helpers import TestPasswordUser, api_key_auth, to_payload
 )
 async def test_create_organization_invalid(
     client: httpx.AsyncClient,
-    temp_user: TestPasswordUser,
     payload: dict,
     expected_errors_attrs: list,
 ) -> None:
@@ -76,17 +77,13 @@ async def test_create_organization_many(client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_organization_already_exists(client: httpx.AsyncClient) -> None:
-    command = CreateOrganizationFactory.build()
-    payload = to_payload(command)
-    response = await client.post("/organizations/", json=payload, auth=api_key_auth)
-    assert response.status_code == 201
-    org = response.json()
-
-    payload = to_payload(CreateOrganizationFactory.build(siret=command.siret))
+async def test_create_organization_already_exists(
+    client: httpx.AsyncClient, temp_org: OrganizationView
+) -> None:
+    payload = to_payload(CreateOrganizationFactory.build(siret=temp_org.siret))
     response = await client.post("/organizations/", json=payload, auth=api_key_auth)
     assert response.status_code == 200
-    assert response.json() == org
+    assert response.json() == temp_org.dict()
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_auth.py
+++ b/tests/application/test_auth.py
@@ -3,17 +3,24 @@ from pydantic import EmailStr, SecretStr
 
 from server.application.auth.commands import ChangePassword, CreatePasswordUser
 from server.application.auth.queries import LoginPasswordUser
+from server.application.organizations.views import OrganizationView
 from server.config.di import resolve
 from server.domain.auth.exceptions import LoginFailed
 from server.seedwork.application.messages import MessageBus
 
 
 @pytest.mark.asyncio
-async def test_changepassword() -> None:
+async def test_changepassword(temp_org: OrganizationView) -> None:
     bus = resolve(MessageBus)
     email = EmailStr("changepassworduser@mydomain.org")
 
-    await bus.execute(CreatePasswordUser(email=email, password=SecretStr("initialpwd")))
+    await bus.execute(
+        CreatePasswordUser(
+            organization_siret=temp_org.siret,
+            email=email,
+            password=SecretStr("initialpwd"),
+        )
+    )
 
     await bus.execute(ChangePassword(email=email, password=SecretStr("newpwd")))
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,7 +15,6 @@ from server.application.tags.commands import CreateTag
 from server.domain.common import datetime as dtutil
 from server.domain.datasets.entities import DataFormat
 from server.domain.licenses.entities import BUILTIN_LICENSE_SUGGESTIONS
-from server.domain.organizations.entities import LEGACY_ORGANIZATION
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -42,7 +41,7 @@ class Factory(ModelFactory[T]):
 class CreatePasswordUserFactory(Factory[CreatePasswordUser]):
     __model__ = CreatePasswordUser
 
-    organization_siret = Use(lambda: LEGACY_ORGANIZATION.siret)
+    organization_siret = Require()
 
 
 class CreateDataPassUserFactory(Factory[CreateDataPassUser]):
@@ -64,7 +63,7 @@ _FAKE_GEOGRAPHICAL_COVERAGES = [
 
 
 class _BaseCreateDatasetFactory:
-    organization_siret = Use(lambda: LEGACY_ORGANIZATION.siret)
+    organization_siret = Require()
     title = Use(fake.sentence)
     description = Use(fake.text)
     service = Use(fake.company)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,15 @@ from server.application.auth.commands import CreatePasswordUser
 from server.config.di import resolve
 from server.domain.auth.entities import PasswordUser, UserRole
 from server.domain.auth.repositories import PasswordUserRepository
+from server.domain.organizations.entities import Organization
+from server.domain.organizations.types import Siret
 from server.seedwork.application.messages import MessageBus
+
+# This organization holds accounts that existed before introducing DataPass users.
+# It is created by migration `f2ef4eef61e3` (create-legacy-organization).
+LEGACY_ORGANIZATION = Organization(
+    name="Organisation par défaut", siret=Siret("000 000 000 00000")
+)
 
 
 def create_client(app: Callable) -> httpx.AsyncClient:

--- a/tests/infrastructure/test_datasets.py
+++ b/tests/infrastructure/test_datasets.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import contains_eager
 
 from server.application.datasets.commands import DeleteDataset
 from server.application.datasets.queries import GetDatasetByID
+from server.application.organizations.views import OrganizationView
 from server.config.di import resolve
 from server.domain.catalog_records.repositories import CatalogRecordRepository
 from server.infrastructure.database import Database
@@ -16,12 +17,18 @@ from ..factories import CreateDatasetFactory, CreateTagFactory
 
 
 @pytest.mark.asyncio
-async def test_dataset_cascades(temp_user: TestPasswordUser) -> None:
+async def test_dataset_cascades(
+    temp_org: OrganizationView, temp_user: TestPasswordUser
+) -> None:
     bus = resolve(MessageBus)
 
     tag_id = await bus.execute(CreateTagFactory.build(name="Architecture"))
     dataset_id = await bus.execute(
-        CreateDatasetFactory.build(account=temp_user.account, tag_ids=[tag_id])
+        CreateDatasetFactory.build(
+            account=temp_user.account,
+            organization_siret=temp_org.siret,
+            tag_ids=[tag_id],
+        )
     )
 
     dataset = await bus.execute(GetDatasetByID(id=dataset_id))

--- a/tests/tools/test_addrandomdatasets.py
+++ b/tests/tools/test_addrandomdatasets.py
@@ -1,25 +1,21 @@
 import pytest
 
-from server.application.catalogs.commands import CreateCatalog
 from server.application.datasets.queries import GetAllDatasets
+from server.application.organizations.views import OrganizationView
 from server.config.di import resolve
 from server.seedwork.application.messages import MessageBus
-from tests.factories import CreateOrganizationFactory
 from tools import addrandomdatasets
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("tags")
-async def test_addrandomdatasets() -> None:
+async def test_addrandomdatasets(temp_org: OrganizationView) -> None:
     bus = resolve(MessageBus)
-
-    siret = await bus.execute(CreateOrganizationFactory.build())
-    await bus.execute(CreateCatalog(organization_siret=siret))
 
     pagination = await bus.execute(GetAllDatasets())
     assert pagination.total_items == 0
 
-    await addrandomdatasets.main(n=20, siret=siret)
+    await addrandomdatasets.main(n=20, siret=temp_org.siret)
 
     pagination = await bus.execute(GetAllDatasets())
     assert pagination.total_items == 20

--- a/tests/tools/test_initdata.py
+++ b/tests/tools/test_initdata.py
@@ -10,6 +10,7 @@ from server.application.auth.commands import DeletePasswordUser
 from server.application.auth.queries import LoginPasswordUser
 from server.application.datasets.commands import UpdateDataset
 from server.application.datasets.queries import GetAllDatasets, GetDatasetByID
+from server.application.organizations.views import OrganizationView
 from server.config.di import resolve
 from server.domain.common.types import ID, Skip
 from server.seedwork.application.messages import MessageBus
@@ -47,7 +48,10 @@ async def test_initdata_empty(tmp_path: Path) -> None:
     ],
 )
 async def test_initdata_env_password_invalid(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    temp_org: OrganizationView,
+    value: str,
 ) -> None:
     path = tmp_path / "initdata.yml"
     path.write_text(
@@ -57,11 +61,14 @@ async def test_initdata_env_password_invalid(
         users:
           - id: 9c2cefce-ea47-4e6e-8c79-8befd4495f45
             params:
+              organization_siret: "{siret}"
               email: test@admin.org
               password: __env__
         tags: []
         datasets: []
-        """
+        """.format(
+            siret=temp_org.siret
+        )
     )
 
     monkeypatch.setenv("TOOLS_PASSWORDS", value)
@@ -72,7 +79,7 @@ async def test_initdata_env_password_invalid(
 
 @pytest.mark.asyncio
 async def test_initdata_env_password(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, temp_org: OrganizationView
 ) -> None:
     bus = resolve(MessageBus)
 
@@ -84,12 +91,15 @@ async def test_initdata_env_password(
         users:
           - id: 9c2cefce-ea47-4e6e-8c79-8befd4495f45
             params:
+              organization_siret: "{siret}"
               email: test@admin.org
               password: __env__
         tags: []
         datasets: []
 
-        """
+        """.format(
+            siret=temp_org.siret
+        )
     )
 
     # Env variable is used to create the user.


### PR DESCRIPTION
Refs #389 

Cette PR rend tous les paramètres de type `organization_siret: Siret` formellement obligatoires (les changements récents font qu'ils sont déjà passés explicitement là où il faut), et modifie les tests en conséquence.

La `LEGACY_ORGANIZATION` n'apparaît plus que dans le test du filtre "Catalogue". (Pour l'instant toute organisation dans le système apparaît dans ce filtre. Dans le cadre de #389 on pourra envisager de faire une exception pour "0000...".)