### PR TITLE
Add missing prod env to environment list

### DIFF
--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -6,4 +6,5 @@ Table des matières :
 
 - [Démarrage](./demarrage.md) - Un guide pour vous mettre en route.
 - [Outils de développement](./outils.md) - Description des outils de développement à disposition.
+- [Opérations](./ops.md) - Un guide concernant l'infrastructure, le déploiement, les environnements, etc.
 - [Trucs et astuces](./trucs-et-astuces.md) - Quelques "conseils de pro" qui peuvent vous simplifier la vie.

--- a/docs/fr/ops.md
+++ b/docs/fr/ops.md
@@ -53,20 +53,21 @@ Par ailleurs :
 
 Les différents déploiements sont organisés en _environnements_ (copies de l'infrastructure) :
 
-| Nom     | Description | À déployer depuis |
-|---------|-------------|-------------------|
-| demo    | Environnement de démo | `master` |
-| sandbox | Environnement "bac à sable" destiné à des utilisateurs test | `master` |
-| staging | Environnement de staging | `staging` |
+| Nom     | Description | URL | À déployer depuis |
+|---------|-------------|-----|-------------------|
+| prod    | Environnement de production | https://catalogue.data.gouv.fr | `master` |
+| demo    | Environnement de démo | https://demo.catalogue.multi.coop | `master` |
+| sandbox | Environnement "bac à sable" destiné à des utilisateurs test | https://catalogue.multi.coop | `master` |
+| staging | Environnement de staging | https://staging.catalogue.multi.coop | `staging` |
 
 Voici, à date, une liste des ressources pour chaque environnement et leur localisation.
 
 | Ressource | Environnements | Lieu | Contact |
 |-----------|----------------|------|---------|
-| Instance cloud (VM) | sandbox, staging, demo | Console Scaleway de Multi| johan.richer[ @ ]multi.coop |
-| Instance PostgreSQL | sandbox, staging, demo | Console Scaleway de Multi | johan.richer[ @ ]multi.coop |
-| Enregistrement DNS | sandbox, staging, demo | Service DNS de Multi | johan.richer[ @ ]multi.coop |
-| URLs de callback OpenID Connect pour "Comptes DataPass" | sandbox, staging, demo | Infrastructure BetaGouv | Contacter l'équipe "Compte DataPass" sur BetaGouv, ou ouvrir un billet sur [betagouv/api-auth](https://github.com/betagouv/api-auth) |
+| Instance cloud (VM) | Tous | Console Scaleway de Multi| johan.richer[ @ ]multi.coop |
+| Instance PostgreSQL | Tous | Console Scaleway de Multi | johan.richer[ @ ]multi.coop |
+| Enregistrement DNS | Tous | Service DNS de Multi | johan.richer[ @ ]multi.coop |
+| URLs de callback OpenID Connect pour "Comptes DataPass" | Tous | Infrastructure BetaGouv | Contacter l'équipe "Compte DataPass" sur BetaGouv, ou ouvrir un billet sur [betagouv/api-auth](https://github.com/betagouv/api-auth) |
 
 ### Versions
 


### PR DESCRIPTION
Dans #458 j'ai oublié d'ajouter `prod` à la liste des environnements existants

J'en profite pour préciser l'URL de chaque environnement et ajouter la page au README de la doc.