### PR TITLE
Drop legacy org from catalog filter choices

### DIFF
--- a/tests/api/test_datasets_filters.py
+++ b/tests/api/test_datasets_filters.py
@@ -18,7 +18,7 @@ from ..factories import (
     CreatePasswordUserFactory,
     CreateTagFactory,
 )
-from ..helpers import LEGACY_ORGANIZATION, TestPasswordUser, create_test_password_user
+from ..helpers import TestPasswordUser, create_test_password_user
 
 
 @pytest.mark.asyncio
@@ -96,7 +96,6 @@ async def test_dataset_filters_info(
             "siret": str(siret_empty),
             "name": "B - Organization with an empty catalog",
         },
-        LEGACY_ORGANIZATION.dict(),
     ]
 
     assert data["geographical_coverage"] == [

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,15 +8,7 @@ from server.application.auth.commands import CreatePasswordUser
 from server.config.di import resolve
 from server.domain.auth.entities import PasswordUser, UserRole
 from server.domain.auth.repositories import PasswordUserRepository
-from server.domain.organizations.entities import Organization
-from server.domain.organizations.types import Siret
 from server.seedwork.application.messages import MessageBus
-
-# This organization holds accounts that existed before introducing DataPass users.
-# It is created by migration `f2ef4eef61e3` (create-legacy-organization).
-LEGACY_ORGANIZATION = Organization(
-    name="Organisation par défaut", siret=Siret("000 000 000 00000")
-)
 
 
 def create_client(app: Callable) -> httpx.AsyncClient:


### PR DESCRIPTION
Closes #389 

Cette PR s'assure que l'"Organisation par défaut" (SIRET "factice" 00000 000 000 000) n'apparaît pas dans les choix possibles du filtre "Catalogue".

## Aperçu

![Screenshot 2022-10-10 at 17-52-34 Rechercher un jeu de données](https://user-images.githubusercontent.com/15911462/194906638-66e2c74e-fdce-4fff-8a65-5bb8dae790bc.png) (12 kB)

