### PR TITLE
Fix: Reuse any datapass user account when creating a password user

### DIFF
--- a/tests/application/test_auth.py
+++ b/tests/application/test_auth.py
@@ -6,7 +6,13 @@ from server.application.auth.queries import LoginPasswordUser
 from server.application.organizations.views import OrganizationView
 from server.config.di import resolve
 from server.domain.auth.exceptions import LoginFailed
+from server.domain.auth.repositories import AccountRepository, PasswordUserRepository
 from server.seedwork.application.messages import MessageBus
+from tests.factories import (
+    CreateDataPassUserFactory,
+    CreateOrganizationFactory,
+    CreatePasswordUserFactory,
+)
 
 
 @pytest.mark.asyncio
@@ -30,3 +36,48 @@ async def test_changepassword(temp_org: OrganizationView) -> None:
         )
 
     await bus.execute(LoginPasswordUser(email=email, password=SecretStr("newpwd")))
+
+
+@pytest.mark.asyncio
+class TestCreatePasswordUser:
+    async def test_existing_datapass_user_reuses_account(self) -> None:
+        bus = resolve(MessageBus)
+
+        email = "johndoe@mydomain.org"
+        siret = "11122233344441"
+
+        await bus.execute(CreateOrganizationFactory.build(siret=siret))
+        await bus.execute(
+            CreateDataPassUserFactory.build(organization_siret=siret, email=email)
+        )
+        account_repository = resolve(AccountRepository)
+        existing_account = await account_repository.get_by_email(email)
+
+        await bus.execute(
+            CreatePasswordUserFactory.build(organization_siret=siret, email=email)
+        )
+        repository = resolve(PasswordUserRepository)
+        user = await repository.get_by_email(email)
+        assert user is not None
+        assert user.account == existing_account
+
+    async def test_existing_datapass_user_in_different_org_is_error(self) -> None:
+        bus = resolve(MessageBus)
+
+        email = "johndoe@mydomain.org"
+        siret_1 = "11122233344441"
+        siret_2 = "11122233344442"
+
+        await bus.execute(CreateOrganizationFactory.build(siret=siret_1))
+        await bus.execute(CreateOrganizationFactory.build(siret=siret_2))
+        await bus.execute(
+            CreateDataPassUserFactory.build(organization_siret=siret_1, email=email)
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="requested to create a PasswordUser in different organization",
+        ):
+            await bus.execute(
+                CreatePasswordUserFactory.build(organization_siret=siret_2, email=email)
+            )


### PR DESCRIPTION
Cette PR corrige un bug découvert en lançant un `make initdata` après s'être déjà connecté avec MonComptePro.

## Pour vérifier

Exécuter ceci sur `master` :

1. `dropdb cataloge && createdb catalogage && make migrate`
1. Créer l'orga et le catalogue du MC à partir du repo de config
  * Configurer `APP_CONFIG_REPO_API_KEY=abcd1234`
  * Côté repo de config, configurer `CATALOGAGE_API_URL=http://localhost:3579` et  `CATALOGAGE_API_KEY=abcd1234`
  * Lancer `make serve`, puis côté repo de config lancer `make upload`
1. Lancer `make serve` et se connecter avec `catalogue.demo@yopmail.com` via MonComptePro
1. Lancer `make initdata` : constater une erreur `EmailAlreadyExists("catalogue.demo@yopmail.com")`, alors qu'il n'y a pourtant encore aucun PasswordUser avec cet email

Basculer sur cette branche, puis relancer `make initdata` et constater qu'il fonctionne désormais.