### PR TITLE
Set API docs title

### DIFF
--- a/server/api/app.py
+++ b/server/api/app.py
@@ -25,6 +25,8 @@ def create_app(settings: Settings = None) -> App:
 
     app = App(
         debug=settings.debug,
+        title="API - catalogue.data.gouv.fr",
+        version="0.1.0",  # Required by FastAPI, but meaningless for now.
         docs_url=settings.docs_url,
     )
 


### PR DESCRIPTION
Le titre de https://catalogue.data.gouv.fr/api/docs est "FastAPI", c'est un peu malencontreux. Cette PR utilise "API - catalogue.data.gouv.fr"

Ce titre est utilisé quelque soit l'environnement, il sera donc par ex le même sur staging.catalogue.multi.coop, ça ne me semble pas être un pb.