### PR TITLE
Fix non-breaking spaces sneaked in some markdown file headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,7 +4,7 @@ about: Signaler un problème détecté dans l'application
 labels: bug
 ---
 
-## Description du bug
+## Description du bug
 
 <!-- Décrire le bug de façon concise, en une ou deux phrases -->
 

--- a/docs/fr/architecture.md
+++ b/docs/fr/architecture.md
@@ -1,4 +1,4 @@
-# Architecture
+# Architecture
 
 ## Généralités
 


### PR DESCRIPTION
Je me demandais pourquoi quand on ouvrait un ticket bug avec le template, le premier titre "Description du bug" ne s'affichait pas comme un h2.

Puis j'ai vu un deuxième exemple de ce comportement ici https://github.com/etalab/catalogage-donnees/blob/21bd7856413c933d11a46a4ec8eab2a5b8d6fe0c/docs/fr/architecture.md

J'avais inséré des espaces insécables !

```python
>>> s = "## Description du bug"
>>> ord(s[2])
160  # non-breaking space
>>> ord(" ")
32  # space
```

https://www.ascii-code.com/