### PR TITLE
Add experimental import tool and documentation

### DIFF
--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -6,5 +6,6 @@ Table des matières :
 
 - [Démarrage](./demarrage.md) - Un guide pour vous mettre en route.
 - [Outils de développement](./outils.md) - Description des outils de développement à disposition.
+- [Outils de gestion des organisations et catalogues](./outils-orgas.md) - Description de l'outillage permettant de gérer les organisations et catalogues enregistrés dans l'outil (dépôt de config, import, etc).
 - [Opérations](./ops.md) - Un guide concernant l'infrastructure, le déploiement, les environnements, etc.
 - [Trucs et astuces](./trucs-et-astuces.md) - Quelques "conseils de pro" qui peuvent vous simplifier la vie.

--- a/docs/fr/outils-orgas.md
+++ b/docs/fr/outils-orgas.md
@@ -1,0 +1,87 @@
+# Outils de gestion des organisations et catalogues
+
+## Dépôt de configuration
+
+_Aussi appelé "repo de config"_
+
+Lien GitHub : [etalab/catalogage-donnees-config](https://github.com/etalab/catalogage-donnees-config)
+
+Ce dépôt sert à stocker les organisations enregistrées sur l'instance de production [catalogue.data.gouv.fr](https://catalogue.data.gouv.fr) ainsi que leur catalogue au format [TableSchema](https://specs.frictionlessdata.io/table-schema/).
+
+Pour en savoir plus sur son utilisation, consulter le README du dépôt de configuration.
+
+## Importer un catalogue
+
+Un outil expérimental _[lire : testé sommairement, et à modifier ou adapter selon les besoins]_ est disponible pour importer un catalogue.
+
+### Utilisation
+
+L'organisation et le catalogue doivent avoir été créés au préalable.
+
+1. Écrire un fichier de configuration pour l'import à partir de l'exemple [import.config.example.yml](https://github.com/etalab/catalogage-donnees/blob/master/tools/import.config.example.yml).
+
+1. Générer un fichier d'initdata grâce à l'outil :
+
+    ```bash
+    python -m tools.import_catalog <CONFIG_PATH> <OUT_PATH>
+    ```
+
+    Où `<CONFIG_PATH>` est le chemin du fichier de configuration écrit à l'instant, et `<OUT_PATH>` un chemin de sortie pour le fichier d'initdata résultant.
+
+1. Tester l'import en local :
+
+    * Partir d'une base de données vierge. Par exemple :
+    
+        ```
+        dropdb catalogage
+        createdb catalogage
+        make migrate
+        ```
+
+    * Importer les organisations et catalogues à partir du dépôt de configuration. Pour ce faire :
+        * Dans le `.env`, définir :
+            ```dotenv
+            APP_CONFIG_REPO_API_KEY=abcd1234  # N'importe quelle valeur
+            ```
+        * Démarrer le serveur d'API local avec `make serve`.
+        * Dans le `.env` du dépôt de configuration, définir :
+            ```dotenv
+            CATALOGAGE_API_URL=abcd1234  # La même valeur que côté catalogage-donnees
+            ```
+            Puis lancer `make upload`.
+
+    * Lancer l'initdata :
+
+        ```bash
+        python -m tools.initdata <OUT_PATH>
+        ```
+
+    * Démarrer le serveur et vérifier que l'import s'est correctement déroulé.
+
+1. Si et seulement si le comportement local est validé, procéder à l'import en production :
+
+    * Remplacer temporairement (sans faire de commit) le fichier d'initdata de la prod `ops/ansible/prod/assets/initdata.yml` par le fichier d'initdata généré.
+    * Lancer `make ops-initdata env=prod`.
+    * Remettre le fichier d'initdata de la prod dans son état d'origine (le git diff doit être vierge).
+    * Vérifier le comportement en production.
+
+### Options notables
+
+* _(Requis)_ `organization_siret` - `str`
+
+    SIRET de l'organisation dont il faut peupler le catalogue.
+
+* _(Requis)_ `input_file.path` - `str`
+
+    Chemin vers le fichier CSV contenant le catalogue.
+    
+    Les colonnes du CSV doivent refléter le schéma du catalogue tel que défini dans le dépôt de configuration :
+
+    * Champs du schéma communs (`titre`, `description`, etc) ;
+    * Champs complémentaires.
+
+    Les colonnes ne correspondant ni au schéma commun, ni aux champs complémentaires, doivent être supprimées du fichier CSV ou, à défaut, explicitement indiquées dans `ignore_fields` (voir ci-dessous). Toute incohérence avec les champs complémentaires du catalogue en base de données entraînera une erreur.
+
+* `ignore_fields` - `List[str]`
+
+    La liste des colonnes ne correspondant ni au schéma commun, ni aux champs complémentaires.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ addopts =
     -rxXs
     --cov=server
     --cov=tests
+    --cov=tools
     --cov-report=term-missing
     --cov-config=.coveragerc
     --cov-fail-under=90

--- a/tests/tools/test_import_catalog.py
+++ b/tests/tools/test_import_catalog.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+import yaml
+
+from server.application.catalogs.commands import CreateCatalog
+from server.config.di import resolve
+from server.domain.catalogs.entities import BoolExtraField
+from server.seedwork.application.messages import MessageBus
+from tools import import_catalog
+
+from ..factories import CreateOrganizationFactory, CreateTagFactory
+
+
+@pytest.mark.asyncio
+async def test_import_catalog_example(tmp_path: Path) -> None:
+    csv_path = tmp_path / "catalog.csv"
+    example_config_path = Path() / "tools" / "import.config.example.yml"
+    out_path = tmp_path / "initdata.yml"
+
+    bus = resolve(MessageBus)
+
+    # Simulate an existing organization and catalog
+    siret = await bus.execute(
+        CreateOrganizationFactory.build(name="Ministère 1", siret="11004601800013")
+    )
+    await bus.execute(
+        CreateCatalog(
+            organization_siret=siret,
+            extra_fields=[
+                BoolExtraField(
+                    organization_siret=siret,
+                    name="donnees_geoloc",
+                    title="Données géolocalisées",
+                    hint_text="Les données sont-elles géolocalisées ?",
+                    data={"true_value": "Oui", "false_value": "Non"},
+                )
+            ],
+        )
+    )
+
+    # Simulate a pre-existing tag.
+    await bus.execute(CreateTagFactory.build(name="Tag 1"))
+
+    csv_path.write_text(
+        dedent(
+            """\
+            titre;description;mots_cles;nom_orga;siret_orga;id_alt_orga;service;si;contact_service;contact_personne;date_pub;date_maj;freq_maj;couv_geo;url;format;licence;donnees_geoloc
+            Titre1;Description1;"Tag 1,Tag 2";Ministère 1;11004601800013;;Direction1;SI1;service@mydomain.org;contact@mydomain.org;;2022-10-06;annuelle;aquitaine;;geojson, xls, oracle et shp;etalab-2.0;oui
+            Titre2;Description2;"Tag 1,Tag 3";Ministère 1;11004601800013;;Direction1;SI2;service@mydomain.org;contact@mydomain.org;;;Invalid;NSP;;Information manquante;etalab-2.0;oui
+            """  # noqa
+        )
+    )
+
+    config_path = tmp_path / "catalogue.csv"
+    config_path.write_text(
+        example_config_path.read_text().replace("REPLACE_ME", str(csv_path))
+    )
+
+    code = await import_catalog.main(config_path, out_path)
+    assert code == 0
+
+    with out_path.open() as f:
+        initdata = yaml.safe_load(f)
+
+    assert not initdata["organizations"]
+    assert not initdata["catalogs"]
+    assert not initdata["users"]
+    assert [t["params"] for t in initdata["tags"]] == [
+        # "Tag 1" already existed
+        {"name": "Tag 2"},
+        {"name": "Tag 3"},
+    ]
+
+    assert len(initdata["datasets"]) == 2
+
+    assert all(d["params"]["organization_siret"] == siret for d in initdata["datasets"])
+
+    d0 = initdata["datasets"][0]["params"]
+    assert sorted(d0["formats"]) == ["database", "file_gis", "file_tabular"]
+    assert d0["geographical_coverage"] == "aquitaine"
+    assert d0["update_frequency"] == "yearly"
+    assert "[[ Notes d'import automatique ]]" not in d0["description"]
+
+    d1 = initdata["datasets"][1]["params"]
+    assert d1["geographical_coverage"] == "(Information manquante)"
+    assert d1["formats"] == ["other"]
+    assert d1["update_frequency"] is None
+    assert d1["url"] is None
+    assert "[[ Notes d'import automatique ]]" in d1["description"]
+    assert "Format : (Information manquante)" in d1["description"]
+    assert "Fréquence de mise à jour (valeur originale) : Invalid" in d1["description"]

--- a/tools/import.config.example.yml
+++ b/tools/import.config.example.yml
@@ -9,8 +9,6 @@ input_csv:
 organization_siret: "11004601800013"
 
 ignore_fields:
-  - nom_orga
-  - siret_orga
   - id_alt_orga
   - date_pub
 

--- a/tools/import.config.example.yml
+++ b/tools/import.config.example.yml
@@ -1,0 +1,32 @@
+input_csv:
+  path: REPLACE_ME
+  encoding: utf-8
+  delimiter: ";"
+  na_values:
+    - "Information manquante"
+    - "NSP"
+
+organization_siret: "11004601800013"
+
+ignore_fields:
+  - nom_orga
+  - siret_orga
+  - id_alt_orga
+  - date_pub
+
+formats:
+  list_map:
+    "oracle et shp": [database, file_gis]
+
+  map:
+    "xls": file_tabular
+    "geojson": file_gis
+
+update_frequency:
+  map:
+    "aucune": never
+    "en continu": realtime
+    "annuelle": yearly
+
+last_updated_at:
+  format: "%Y-%M-%d"  # See: https://docs.python.org/fr/3/library/datetime.html#strftime-and-strptime-format-codes

--- a/tools/import_catalog.py
+++ b/tools/import_catalog.py
@@ -197,6 +197,8 @@ async def main(config_path: Path, out_path: Path) -> int:
     common_fields = {
         "titre",
         "description",
+        "siret_orga",
+        "nom_orga",
         "service",
         "couv_geo",
         "format",
@@ -221,12 +223,16 @@ async def main(config_path: Path, out_path: Path) -> int:
     tags_to_create: List[dict] = []
     datasets = []
 
-    for row in rows:
-        if "siret_orga" in row:
-            assert row["siret_orga"] == organization.siret
+    for k, row in enumerate(rows):
+        if (siret_orga := row["siret_orga"]) != organization.siret:
+            raise ValueError(
+                f"at row {k}: {siret_orga=!r} does not match {organization.siret=!r}"
+            )
 
-        if "nom_orga" in row:
-            assert row["nom_orga"] == organization.name
+        if "nom_orga" in row and (nom_orga := row["nom_orga"]) != organization.name:
+            raise ValueError(
+                f"at row {k}: {nom_orga=!r} does not match {organization.name=!r}"
+            )
 
         import_notes = io.StringIO()
 

--- a/tools/import_catalog.py
+++ b/tools/import_catalog.py
@@ -1,0 +1,293 @@
+import argparse
+import asyncio
+import csv
+import datetime as dt
+import io
+import sys
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Set, TextIO
+
+import yaml
+from pydantic import BaseModel, Field
+
+from server.application.catalogs.queries import GetCatalogBySiret
+from server.application.catalogs.views import ExtraFieldView
+from server.application.organizations.queries import GetOrganizationBySiret
+from server.application.tags.queries import GetAllTags
+from server.config.di import bootstrap, resolve
+from server.domain.common.types import id_factory
+from server.domain.datasets.entities import DataFormat, UpdateFrequency
+from server.domain.organizations.types import Siret
+from server.seedwork.application.messages import MessageBus
+from tools.initdata import InitData
+
+
+class InputCsv(BaseModel):
+    path: Path
+    encoding: str = "utf-8"
+    delimiter: str = ","
+    na_values: Set[str] = Field(default_factory=set)
+
+
+class FormatsConfig(BaseModel):
+    map: Dict[str, str] = Field(default_factory=dict)
+    list_map: Dict[str, List[str]] = Field(default_factory=dict)
+
+
+class UpdateFrequencyConfig(BaseModel):
+    map: Dict[str, str] = Field(default_factory=dict)
+
+
+class LastUpdatedAtConfig(BaseModel):
+    format: str = "%Y-%M-%d"
+
+
+class Config(BaseModel):
+    input_csv: InputCsv
+    organization_siret: Siret
+    ignore_fields: Set[str] = Field(default_factory=set)
+    formats: FormatsConfig = Field(default_factory=FormatsConfig)
+    update_frequency: UpdateFrequencyConfig = Field(
+        default_factory=UpdateFrequencyConfig
+    )
+    last_updated_at: LastUpdatedAtConfig = Field(default_factory=LastUpdatedAtConfig)
+
+
+def _map_geographical_coverage(value: Optional[str], config: Config) -> str:
+    if not value or value in config.input_csv.na_values:
+        return "(Information manquante)"  # Field is required
+
+    return value
+
+
+def _map_formats(
+    value: Optional[str], import_notes: TextIO, config: Config
+) -> List[str]:
+    if value is None or value in config.input_csv.na_values:
+        import_notes.write("Format : (Information manquante)\n")
+        return [DataFormat.OTHER.value]  # At least one value is required.
+
+    value = value.lower().strip()
+
+    unknown_formats = []
+
+    def _map_format(value: str) -> List[DataFormat]:
+        if value in config.formats.list_map:
+            return [DataFormat(f) for f in config.formats.list_map[value]]
+
+        dataformat = config.formats.map.get(value, value)
+
+        try:
+            return [DataFormat(dataformat)]
+        except ValueError:
+            unknown_formats.append(value)
+            return [DataFormat.OTHER]
+
+    result = list(
+        set(f.value for val in value.split(",") for f in _map_format(val.strip()))
+    )
+
+    if unknown_formats:
+        line = f"Format (valeurs non-reconnues) : {', '.join(unknown_formats)}"
+        import_notes.writelines([line, "\n"])
+
+    return result
+
+
+def _map_contact_emails(value: Optional[str]) -> List[str]:
+    if value is None:
+        return []
+
+    return [value.strip().replace("<", "").replace(">", "")]
+
+
+def _map_update_frequency(
+    value: Optional[str], import_notes: TextIO, config: Config
+) -> Optional[str]:
+    if not value or value in config.input_csv.na_values:
+        return None
+
+    value = config.update_frequency.map.get(value.lower(), value)
+
+    try:
+        update_frequency = UpdateFrequency(value)
+    except ValueError:
+        import_notes.write(f"Fréquence de mise à jour (valeur originale) : {value}\n")
+        return None
+
+    return update_frequency.value
+
+
+def _map_last_updated_at(value: Optional[str], config: Config) -> Optional[dt.datetime]:
+    if value is None:
+        return None
+
+    return dt.datetime.strptime(value, config.last_updated_at.format)
+
+
+def _map_tag_ids(
+    value: Optional[str], tags_by_name: Mapping[str, dict], tags_to_create: List[dict]
+) -> List[str]:
+    if not value:
+        return []
+
+    tag_ids = []
+
+    # "périmètre délimité des abords (PDA), urbanisme; géolocalisation"
+    # -> {"périmètre délimité des abords (PDA)", "urbanisme", "géolocalisation"}
+    cleaned_names = set(name.strip() for name in value.replace(";", ",").split(","))
+
+    for name in cleaned_names:
+        try:
+            tag = tags_by_name[name]
+        except KeyError:
+            tag = {"id": str(id_factory()), "params": {"name": name}}
+            tags_to_create.append(tag)
+
+        tag_ids.append(str(tag["id"]))
+
+    return tag_ids
+
+
+def _map_extra_field_values(
+    row: dict, extra_fields: List[ExtraFieldView]
+) -> List[dict]:
+    return [
+        {"extra_field_id": str(extra_field.id), "value": value}
+        for extra_field in extra_fields
+        if (value := row[extra_field.name])
+    ]
+
+
+def _maybe_append_import_notes(description: str, import_notes: str) -> str:
+    s = io.StringIO()
+
+    s.write(description)
+
+    if import_notes:
+        s.writelines(
+            ["\n", "[[ Notes d'import automatique ]]", "\n", import_notes, "\n"]
+        )
+
+    return s.getvalue()
+
+
+async def main(config_path: Path, out_path: Path) -> int:
+    bus = resolve(MessageBus)
+
+    with config_path.open() as f:
+        initdata = yaml.safe_load(f)
+
+    config = Config(**initdata)
+
+    organization = await bus.execute(
+        GetOrganizationBySiret(siret=config.organization_siret)
+    )
+    catalog = await bus.execute(GetCatalogBySiret(siret=organization.siret))
+    expected_extra_fields = {field.name for field in catalog.extra_fields}
+
+    tags = await bus.execute(GetAllTags())
+    tags_by_name = {tag.name: tag.dict() for tag in tags}
+
+    with config.input_csv.path.open(encoding=config.input_csv.encoding) as f:
+        reader = csv.DictReader(f, delimiter=config.input_csv.delimiter)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+
+    common_fields = {
+        "titre",
+        "description",
+        "service",
+        "couv_geo",
+        "format",
+        "si",
+        "contact_service",
+        "contact_personne",
+        "freq_maj",
+        "date_maj",
+        "url",
+        "licence",
+        "mots_cles",
+    }
+
+    actual_extra_fields = set(fieldnames) - common_fields - config.ignore_fields
+
+    if actual_extra_fields != expected_extra_fields:
+        raise ValueError(
+            f"Extra fields don't match: "
+            f"{expected_extra_fields=}, {actual_extra_fields=}"
+        )
+
+    tags_to_create: List[dict] = []
+    datasets = []
+
+    for row in rows:
+        if "siret_orga" in row:
+            assert row["siret_orga"] == organization.siret
+
+        if "nom_orga" in row:
+            assert row["nom_orga"] == organization.name
+
+        import_notes = io.StringIO()
+
+        params: dict = {}
+
+        params["organization_siret"] = organization.siret
+        params["title"] = row["titre"]
+        params["description"] = row["description"]
+        params["service"] = row["service"] or None
+        params["geographical_coverage"] = _map_geographical_coverage(
+            row["couv_geo"] or None, config
+        )
+        params["formats"] = _map_formats(row["format"] or None, import_notes, config)
+        params["technical_source"] = row["si"] or None
+        params["producer_email"] = row["contact_service"] or None
+        params["contact_emails"] = _map_contact_emails(row["contact_personne"] or None)
+        params["update_frequency"] = _map_update_frequency(
+            row["freq_maj"] or None, import_notes, config
+        )
+        params["last_updated_at"] = _map_last_updated_at(
+            row["date_maj"] or None, config
+        )
+        params["url"] = row["url"] or None
+        params["license"] = row["licence"] or None
+        params["tag_ids"] = _map_tag_ids(
+            row["mots_cles"] or None, tags_by_name, tags_to_create
+        )
+
+        params["extra_field_values"] = _map_extra_field_values(
+            row, catalog.extra_fields
+        )
+
+        params["description"] = _maybe_append_import_notes(
+            params["description"], import_notes.getvalue()
+        )
+
+        pk = id_factory()
+        datasets.append({"id": str(pk), "params": params})
+
+    initdata = InitData(
+        organizations=[],
+        catalogs=[],
+        users=[],
+        tags=tags_to_create,
+        datasets=datasets,
+    ).dict()
+
+    out_path.write_text(yaml.safe_dump(initdata))
+
+    return 0
+
+
+if __name__ == "__main__":
+    bootstrap()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config_path", type=Path)
+    parser.add_argument("out_path", type=Path)
+
+    args = parser.parse_args()
+
+    code = asyncio.run(main(config_path=args.config_path, out_path=args.out_path))
+
+    sys.exit(code)

--- a/tools/import_catalog.py
+++ b/tools/import_catalog.py
@@ -180,9 +180,7 @@ async def main(config_path: Path, out_path: Path) -> int:
     bus = resolve(MessageBus)
 
     with config_path.open() as f:
-        initdata = yaml.safe_load(f)
-
-    config = Config(**initdata)
+        config = Config(**yaml.safe_load(f))
 
     organization = await bus.execute(
         GetOrganizationBySiret(siret=config.organization_siret)


### PR DESCRIPTION
Refs #343 

Cette PR ajoute une version "expérimentale" du script que j'ai utilisé pour importé le contenu du catalogue du Ministère de la Culture.

Il permet d'accepter un fichier CSV à l'allure de celui utilisé pour le MC : colonnes correspondant au schéma commun + colonnes correspondant aux champs complémentaires (tous ceux qui ne sont pas dans le schéma commun ni explicitement ignoré).

J'y adjoins une documentation qui parle aussi rapidement du repo de config (qui n'est pas encore mentionné dans la doc de développement).

Tout ça est à destination de l'équipe de développement, à des fins d'import manuel, pas des utilisateurs finaux.

La création du fichier d'initdata à partir d'un fichier CSV fait essentiellement l'inverse de l'opération de génération de CSV (#480). Pour un import plus automatisé, il faudrait donc formaliser et standardiser ce conversion bidirectionnelle.

@johanricher À noter, le "schéma commun" contient des champs qui n'ont pas d'existence dans l'outil actuel : `id_alt_orga`, `date_pub`. Ils sont présents dans les fichiers CSV de catalogue ce qui est cohérent. Ce script expérimental nécessite de les exclure explicitement du traitement (ne pas les considérer comme des champs complémentaires). Mais ça fait revenir la question de #346 ?