### PR TITLE
fix: should be able to close the form if no change has been made

### DIFF
--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -186,8 +186,8 @@
   };
 
   const handleFieldChange = async (event: Event) => {
-    dispatch("touched", true);
     handleChange(event);
+    dispatch("touched", true);
   };
 
   const hasError = (error: string | string[]) => {
@@ -248,7 +248,6 @@
       value={$form.title}
       error={$errors.title}
       on:input={handleFieldChange}
-      on:blur={handleFieldChange}
     />
 
     <TextareaField
@@ -259,7 +258,6 @@
       value={$form.description}
       error={$errors.description}
       on:input={handleFieldChange}
-      on:blur={handleFieldChange}
     />
 
     <InputField
@@ -270,7 +268,6 @@
       value={$form.service}
       error={$errors.service}
       on:input={handleFieldChange}
-      on:blur={handleFieldChange}
     />
 
     <GeographicalCoverageField
@@ -337,7 +334,6 @@
       value={$form.technicalSource}
       error={$errors.technicalSource}
       on:input={handleFieldChange}
-      on:blur={handleFieldChange}
     />
   </div>
 
@@ -435,7 +431,6 @@
       value={$form.url}
       error={$errors.url}
       on:input={handleFieldChange}
-      on:blur={handleFieldChange}
     />
 
     <LicenseField

--- a/client/src/lib/components/ModalExitFormConfirmation/ModalExitFormConfirmation.svelte
+++ b/client/src/lib/components/ModalExitFormConfirmation/ModalExitFormConfirmation.svelte
@@ -19,7 +19,7 @@
     </h1>
     <p>
       Il semblerait que vous ayez effectué des modifications non sauvegardées
-      sur cette fiche de données. souhaitez-vous vraiment quitter ce formulaire
+      sur cette fiche de données. Souhaitez-vous vraiment quitter ce formulaire
       et perdre votre saisie ?
     </p>
   </div>

--- a/client/src/routes/(app)/fiches/[id]/edit/+page.svelte
+++ b/client/src/routes/(app)/fiches/[id]/edit/+page.svelte
@@ -18,7 +18,7 @@
 
   let loading = false;
 
-  let formHasBeenTouched = false;
+  let formHasbeenTouched = false;
 
   const onSave = async (event: CustomEvent<DatasetFormData>) => {
     if (!Maybe.Some(dataset)) {
@@ -80,8 +80,7 @@
         Catalogue : {dataset.catalogRecord.organization.name}
       </p>
     </div>
-
-    {#if formHasBeenTouched}
+    {#if formHasbeenTouched}
       <button
         class="fr-btn fr-icon-close-line fr-btn--icon fr-btn--secondary"
         data-fr-opened="false"
@@ -117,7 +116,7 @@
       submitLabel="Enregistrer les modifications"
       loadingLabel="Modification en cours..."
       on:save={onSave}
-      on:touched={() => (formHasBeenTouched = true)}
+      on:touched={() => (formHasbeenTouched = true)}
     />
 
     {#if $isAdmin}


### PR DESCRIPTION
Closes #509

## Cette PR ajoute:

- un correctif qui permet la fermeture du formulaire d'ajout/ de modification de jeu de donnée si aucun changement n'a été effectué

### Explication

D'un point de vue technique, il y avait une ambiguité sur la notion de "changement" du point de vue des champs texte.

L'événement "change" était lancé était lancé si la souris quittait le formulaire et ce même si aucun changement n'était effectué.

Pour que l'événement soit lancé, il faut que l'utilisateur modifie le contenu d'un input.

En résumé, on considère qu'un champs texte a été modifié uniquement si l'event `on:input` a été trigger.


### Pour tester 

#### Sans modale

- ouvrir le formulaire d'édition/ de contribution
- Cliquer sur la croix et la modale ne DEVRAIT pas s'ouvrir

#### Ouverture de la modale

- ouvrir le formulaire d'édition/ de contribution
- modifier le contenu d'un champs de formulaire
- cliquer sur le croix et la modale DEVRAIT s'ouvrir


