### PR TITLE
fix: remove svelte's a11y warning

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "node ./build",
-    "check": "svelte-check --tsconfig ./tsconfig.json --compiler-warnings 'a11y-no-redundant-roles:ignore'",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "npm run check -- --watch",
     "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",

--- a/client/src/lib/components/DatasetForm/DatasetForm.svelte
+++ b/client/src/lib/components/DatasetForm/DatasetForm.svelte
@@ -288,7 +288,6 @@
       aria-describedby={hasError($errors.dataFormats)
         ? "dataformats-desc-error"
         : null}
-      role="group"
     >
       <legend
         class="fr-fieldset__legend fr-text--regular"

--- a/client/src/lib/components/Footer/Footer.svelte
+++ b/client/src/lib/components/Footer/Footer.svelte
@@ -3,6 +3,7 @@
   import { SITE_DESCRIPTION } from "src/constants";
 </script>
 
+<!-- svelte-ignore a11y-no-redundant-roles // This is the main app's footer so we keep the role explicit -->
 <footer class="fr-footer" role="contentinfo" id="footer">
   <div class="fr-container">
     <div class="fr-footer__body">
@@ -44,13 +45,8 @@
     </div>
     <div class="fr-footer__bottom">
       <ul class="fr-footer__bottom-list">
-        <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="#">Plan du site</a>
-        </li>
-        <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="#"
-            >Accessibilité: non conforme</a
-          >
+        <li class="fr-footer__bottom-item fr-footer__bottom-link">
+          Accessibilité: non conforme
         </li>
         <li class="fr-footer__bottom-item">
           <a class="fr-footer__bottom-link" href={paths.mentionsLegales}>

--- a/client/src/lib/components/GenericModal/GenericModal.svelte
+++ b/client/src/lib/components/GenericModal/GenericModal.svelte
@@ -4,7 +4,6 @@
 
 <dialog
   aria-labelledby="fr-modal-title-modal-1"
-  role="dialog"
   id={controlId}
   class="fr-modal"
 >

--- a/client/src/lib/components/Header/Header.svelte
+++ b/client/src/lib/components/Header/Header.svelte
@@ -15,6 +15,7 @@
   };
 </script>
 
+<!-- svelte-ignore a11y-no-redundant-roles // This is the main app header so we keep the role explicit -->
 <header role="banner" class="fr-header">
   <div class="fr-header__body">
     <div class="fr-container">

--- a/client/src/lib/components/Pagination/Pagination.svelte
+++ b/client/src/lib/components/Pagination/Pagination.svelte
@@ -9,7 +9,7 @@
   $: pagination = makePagination({ currentPage, totalPages, numSiblings: 2 });
 </script>
 
-<nav role="navigation" class="fr-pagination" aria-label="Pagination">
+<nav class="fr-pagination" aria-label="Pagination">
   <ul class="fr-pagination__list" data-testid="pagination-list">
     <li>
       <a

--- a/client/src/routes/(app)/+layout.svelte
+++ b/client/src/routes/(app)/+layout.svelte
@@ -19,6 +19,7 @@
 
 <LayoutProviders>
   <div class="fr-skiplinks">
+    <!-- svelte-ignore a11y-no-redundant-roles // This is the main app's nav so we keep the role explicit -->
     <nav class="fr-container" role="navigation" aria-label="Accès rapide">
       <ul class="fr-skiplinks__list">
         <li>


### PR DESCRIPTION
closes #520 

## Cette PR ajoute:

- un correctif enlevant tous les warnings soulevés par svelte 

Issue : #520

### Deux cas de figures :

#### Le role était effectivement redondant

Dans ce cas ci, enlever la le `role` est la solution

### le role est redondant MAIS

Comme l'indiquait Benoît Dequick sur le mattermost de beta.gouv

> Pour les header, footer, navigation principale, main et moteur, il faut les 2 

Dans ce cas, j'ai rajouté un commentaire `svelte-ignore a11y-no-redundant-roles `
