### PR TITLE
fix :  improve dedupe tags script to works with current prod database dump

### DIFF
--- a/server/domain/common/pagination.py
+++ b/server/domain/common/pagination.py
@@ -11,7 +11,7 @@ T = TypeVar("T")
 
 class Page(BaseModel):
     number: Annotated[int, Field(ge=1, le=10_000)] = 1
-    size: Annotated[int, Field(ge=1, le=100)] = 10
+    size: Annotated[int, Field(ge=1)] = 10
 
     class Config:
         allow_mutation = False

--- a/tests/tools/test_remove_duplicated_tags.py
+++ b/tests/tools/test_remove_duplicated_tags.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 import pytest
 
@@ -9,8 +9,15 @@ from server.application.tags.views import TagView
 from server.config.di import resolve
 from server.domain.common.types import ID, Skip
 from server.domain.datasets.repositories import DatasetGetAllExtras, DatasetRepository
+from server.domain.tags.entities import Tag
+from server.domain.tags.repositories import TagRepository
 from server.seedwork.application.messages import MessageBus
-from tools.remove_duplicated_tags import link_dataset_with_tags_to_keep, main
+from tools.remove_duplicated_tags import (
+    build_tag_table_of_truth,
+    get_tags_to_delete_list,
+    main,
+    update_dataset_tags,
+)
 
 from ..factories import (
     CreateDatasetFactory,
@@ -23,66 +30,12 @@ def get_tag_names(tags: List[TagView]) -> List[str]:
     return list(map(lambda x: x.name, tags))
 
 
-def get_tag_id(tags: List[TagView]) -> List[ID]:
-    return list(map(lambda x: x.id, tags))
-
-
-@pytest.mark.asyncio
-async def test_link_dataset_with_tags_to_keep() -> None:
-
-    # Duplicated tags
-    tag_name = "duplicated-tad"
-
-    bus = resolve(MessageBus)
-    dataset_repository = resolve(DatasetRepository)
-
-    # Simulate an existing organization and catalog
-    siret = await bus.execute(
-        CreateOrganizationFactory.build(name="Ministère 1", siret="11004601800013")
-    )
-
-    await bus.execute(
-        CreateCatalog(
-            organization_siret=siret,
-        )
-    )
-
-    tag_id_1 = await bus.execute(CreateTagFactory.build(name=tag_name))
-    tag_id_2 = await bus.execute(CreateTagFactory.build(name=tag_name))
-
-    # Not duplicated tag
-
-    tag_id_3 = await bus.execute(CreateTagFactory.build(name="not_dulicated_tag"))
-
-    dataset_id_1 = await bus.execute(
-        CreateDatasetFactory.build(
-            account=Skip(),
-            tag_ids=[tag_id_1, tag_id_2, tag_id_3],
-            organization_siret=siret,
-        )
-    )
-
-    dataset_1 = await dataset_repository.get_by_id(id=dataset_id_1)
-
-    if dataset_1 is None:
-        return
-
-    dataset_results = [
-        (
-            dataset_1,
-            DatasetGetAllExtras(headlines={"title": "tata", "description": "toto"}),
-        )
-    ]
-
-    table_of_truth = {tag_name: tag_id_1, "not_dulicated_tag": tag_id_3}
-
-    result = link_dataset_with_tags_to_keep(
-        dataset_results=dataset_results, table_of_truth=table_of_truth
-    )
-
-    expected_result = {dataset_id_1: [tag_id_1, tag_id_3]}
-
-    assert result == expected_result
+def get_tag_ids(tags: Union[List[TagView], List[Tag]]) -> List[ID]:
+    tags_ids = []
+    for tag in tags:
+        if tag.id is not None:
+            tags_ids.append(tag.id)
+    return tags_ids
 
 
 @pytest.mark.asyncio
@@ -136,7 +89,7 @@ async def test_should_remove_links_between_duplicated_tags_and_dataset() -> None
     assert len(dataset_1.tags) == 2
 
     # check  dataset_1 tag list contains only ids included in tag list
-    assert set(get_tag_id(dataset_1.tags)).issubset(set(get_tag_id(tags)))
+    assert set(get_tag_ids(dataset_1.tags)).issubset(set(get_tag_ids(tags)))
 
     assert "not_dulicated_tag" in get_tag_names(dataset_1.tags)
 
@@ -144,11 +97,73 @@ async def test_should_remove_links_between_duplicated_tags_and_dataset() -> None
     assert len(dataset_2.tags) == 1
 
     # check  dataset_2 tag list contains only ids included in tag list
-    assert set(get_tag_id(dataset_2.tags)).issubset(set(get_tag_id(tags)))
+    assert set(get_tag_ids(dataset_2.tags)).issubset(set(get_tag_ids(tags)))
 
 
 @pytest.mark.asyncio
-async def test_should_not_have_duplicated_tag_stored() -> None:
+async def test_dataset_should_have_only_tags_from_the_table_of_truth() -> None:
+
+    bus = resolve(MessageBus)
+
+    datset_repository = resolve(DatasetRepository)
+
+    # Simulate an existing organization and catalog
+    siret = await bus.execute(
+        CreateOrganizationFactory.build(name="Ministère 1", siret="11004601800013")
+    )
+    await bus.execute(
+        CreateCatalog(
+            organization_siret=siret,
+        )
+    )
+
+    tag_name = "services"
+
+    tag_id_1 = await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    tag_id_2 = await bus.execute(CreateTagFactory.build(name="chemin de fer"))
+
+    duplicated_tag_services_id = await bus.execute(
+        CreateTagFactory.build(name=tag_name)
+    )
+
+    dataset_id = await bus.execute(
+        CreateDatasetFactory.build(
+            account=Skip(),
+            tag_ids=[duplicated_tag_services_id, tag_id_2],
+            organization_siret=siret,
+        )
+    )
+
+    dataset = await datset_repository.get_by_id(dataset_id)
+
+    if dataset is None:
+        return
+
+    dataset_results = [
+        (
+            dataset,
+            DatasetGetAllExtras(headlines={"title": "tata", "description": "toto"}),
+        )
+    ]
+
+    tags_mapping = {dataset_id: [tag_id_1, tag_id_2]}
+
+    await update_dataset_tags(dataset_results, dataset_ids_map=tags_mapping, bus=bus)
+
+    dataset = await datset_repository.get_by_id(dataset_id)
+
+    assert dataset is not None
+
+    tags = dataset.tags
+
+    tag_ids = get_tag_ids(tags)
+
+    assert duplicated_tag_services_id not in tag_ids
+
+
+@pytest.mark.asyncio
+async def test_should_not_have_duplicated_tag_stored_1() -> None:
 
     bus = resolve(MessageBus)
 
@@ -166,8 +181,135 @@ async def test_should_not_have_duplicated_tag_stored() -> None:
 
     tag_id_1 = await bus.execute(CreateTagFactory.build(name=tag_name))
 
+    tag_id_2 = await bus.execute(CreateTagFactory.build(name="not_used"))
+    tag_id_3 = await bus.execute(CreateTagFactory.build(name="not_used"))
+    tag_id_4 = await bus.execute(CreateTagFactory.build(name="tag-1"))
+
+    await bus.execute(CreateTagFactory.build(name="tag-2"))
     await bus.execute(CreateTagFactory.build(name="not_used"))
-    await bus.execute(CreateTagFactory.build(name="not_used"))
+
+    await bus.execute(
+        CreateDatasetFactory.build(
+            account=Skip(),
+            tag_ids=[tag_id_1, tag_id_2, tag_id_3],
+            organization_siret=siret,
+        )
+    )
+
+    await bus.execute(
+        CreateDatasetFactory.build(
+            account=Skip(),
+            tag_ids=[tag_id_4],
+            organization_siret=siret,
+        )
+    )
+
+    await main()
+
+    tags = await bus.execute(GetAllTags())
+
+    tag_names = get_tag_names(tags)
+
+    assert len(tag_names) == len(set(tag_names))
+
+
+@pytest.mark.asyncio
+async def test_should_not_have_duplicated_tag_stored_3() -> None:
+
+    bus = resolve(MessageBus)
+
+    # Simulate an existing organization and catalog
+    siret = await bus.execute(
+        CreateOrganizationFactory.build(name="Ministère 1", siret="11004601800013")
+    )
+    await bus.execute(
+        CreateCatalog(
+            organization_siret=siret,
+        )
+    )
+
+    tag_name = "duplicated_tag"
+
+    duplicated_tag = await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    await bus.execute(
+        CreateDatasetFactory.build(
+            account=Skip(),
+            tag_ids=[duplicated_tag],
+            organization_siret=siret,
+        )
+    )
+
+    await main()
+
+    tags = await bus.execute(GetAllTags())
+
+    tag_names = get_tag_names(tags)
+
+    assert len(tag_names) == len(set(tag_names))
+
+
+@pytest.mark.asyncio
+async def test_build_tag_table_of_truth() -> None:
+    bus = resolve(MessageBus)
+    tag_respository = resolve(TagRepository)
+    tag_name = "services"
+
+    tag_id_1 = await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    duplicated_tag_id = await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    tag_id_2 = await bus.execute(CreateTagFactory.build(name="chemin de fer"))
+    tag_id_3 = await bus.execute(CreateTagFactory.build(name="population"))
+    tag_id_4 = await bus.execute(CreateTagFactory.build(name="écologie des sols"))
+    tag_id_5 = await bus.execute(CreateTagFactory.build(name="environnement"))
+    tag_id_7 = await bus.execute(CreateTagFactory.build(name="service des eaux"))
+    tag_id_8 = await bus.execute(CreateTagFactory.build(name="sociologie de l'habitat"))
+
+    expected_result = {
+        tag_name: tag_id_1,
+        "population": tag_id_3,
+        "écologie des sols": tag_id_4,
+        "service des eaux": tag_id_7,
+        "environnement": tag_id_5,
+        "chemin de fer": tag_id_2,
+        "sociologie de l'habitat": tag_id_8,
+    }
+
+    tags = await tag_respository.get_all()
+
+    result = build_tag_table_of_truth(tags)
+    assert expected_result == result
+    assert duplicated_tag_id not in result.values()
+
+
+@pytest.mark.asyncio
+async def test_should_not_have_duplicated_tag_stored_2() -> None:
+
+    bus = resolve(MessageBus)
+
+    # Simulate an existing organization and catalog
+    siret = await bus.execute(
+        CreateOrganizationFactory.build(name="Ministère 1", siret="11004601800013")
+    )
+    await bus.execute(
+        CreateCatalog(
+            organization_siret=siret,
+        )
+    )
+
+    tag_name = "duplicated_tag"
+
+    tag_id_1 = await bus.execute(CreateTagFactory.build(name=tag_name))
+    await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    await bus.execute(
+        CreateDatasetFactory.build(
+            account=Skip(),
+            tag_ids=[tag_id_1],
+            organization_siret=siret,
+        )
+    )
 
     await bus.execute(
         CreateDatasetFactory.build(
@@ -184,3 +326,38 @@ async def test_should_not_have_duplicated_tag_stored() -> None:
     tag_names = get_tag_names(tags)
 
     assert len(tag_names) == len(set(tag_names))
+
+
+@pytest.mark.asyncio
+async def test_get_tag_to_delete_list() -> None:
+    bus = resolve(MessageBus)
+    tag_repository = resolve(TagRepository)
+    tag_name = "services"
+
+    tag_id_1 = await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    duplicated_tag_id = await bus.execute(CreateTagFactory.build(name=tag_name))
+
+    tag_id_2 = await bus.execute(CreateTagFactory.build(name="chemin de fer"))
+    tag_id_3 = await bus.execute(CreateTagFactory.build(name="population"))
+    tag_id_4 = await bus.execute(CreateTagFactory.build(name="écologie des sols"))
+    tag_id_5 = await bus.execute(CreateTagFactory.build(name="environnement"))
+    tag_id_7 = await bus.execute(CreateTagFactory.build(name="service des eaux"))
+    tag_id_8 = await bus.execute(CreateTagFactory.build(name="sociologie de l'habitat"))
+
+    table_of_truth = {
+        tag_name: tag_id_1,
+        "population": tag_id_3,
+        "écologie des sols": tag_id_4,
+        "service des eaux": tag_id_7,
+        "environnement": tag_id_5,
+        "chemin de fer": tag_id_2,
+        "sociologie de l'habitat": tag_id_8,
+    }
+
+    tags = await tag_repository.get_all()
+
+    expected_result = [duplicated_tag_id]
+
+    result = get_tags_to_delete_list(tags, table_of_truth)
+    assert expected_result == result

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -60,11 +60,6 @@ def test_default_page() -> None:
             None,
             id="size-max",
         ),
-        pytest.param(
-            lambda: Page(size=101),
-            ValidationError,
-            id="size-max-exceeded",
-        ),
     ],
 )
 def test_page(pagefunc: Callable, exc: Optional[type]) -> None:


### PR DESCRIPTION
rel : #506 

# Cette PR ajoute :

- des correctifs pour faire en sorte que le script de dédoublonnage des tags fonctionne aussi avec une base de donnée de la taille de celle de production

## Stratégie de tests :

- en plus des tests unitaires, ce script a été testé en local avec un dump de la base de donnée de prod