### PR TITLE
chore: a11y tests few more pages

### DIFF
--- a/client/src/tests/e2e/a11y.spec.ts
+++ b/client/src/tests/e2e/a11y.spec.ts
@@ -1,17 +1,35 @@
-import AxeBuilder from "@axe-core/playwright";
-import { test, expect } from "@playwright/test";
+import { test } from "./fixtures.js";
+import { expect } from "@playwright/test";
 
-test.describe("homepage", () => {
-  // 2
-  test("should not have any automatically detectable accessibility issues", async ({
+test.describe("acesssibility", () => {
+  test("home page should not have any automatically detectable accessibility issues", async ({
     page,
+    makeAxeBuilder,
   }) => {
-    await page.goto("/"); // 3
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore this is a hot fix untild this isssue will be resolved https://github.com/dequelabs/axe-core-npm/issues/601
-    const accessibilityScanResults = await new AxeBuilder.default({
-      page,
-    }).analyze(); // 4
-    expect(accessibilityScanResults.violations).toEqual([]); // 5
+    await page.goto("/");
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+
+  test("accessibility declaration page should not have any automatically detectable accessibility issues", async ({
+    page,
+    makeAxeBuilder,
+  }) => {
+    await page.goto("/declaration-daccessibilite");
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+
+  test("'mentions légales' page should not have any automatically detectable accessibility issues", async ({
+    page,
+    makeAxeBuilder,
+  }) => {
+    await page.goto("/mentions-legales");
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
   });
 });

--- a/client/src/tests/e2e/fixtures.ts
+++ b/client/src/tests/e2e/fixtures.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from "@axe-core/playwright";
 import { test as base, expect, type APIRequestContext } from "@playwright/test";
 import type { Dataset } from "../../definitions/datasets.js";
 import { toDataset } from "../../lib/transformers/dataset.js";
@@ -20,6 +21,7 @@ type AppFixtures = {
   adminApiToken: string;
   apiToken: string;
   dataset: Dataset;
+  makeAxeBuilder: () => AxeBuilder;
 };
 
 export type AppTestArgs = AppFixtures;
@@ -91,5 +93,11 @@ export const test = base.extend<AppTestArgs>({
       headers,
     });
     expect(response.ok()).toBeTruthy();
+  },
+  makeAxeBuilder: async ({ page }, use) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore this is a hot fix untild this isssue will be resolved https://github.com/dequelabs/axe-core-npm/issues/601
+    const makeAxeBuilder = () => new AxeBuilder.default({ page });
+    await use(makeAxeBuilder);
   },
 });


### PR DESCRIPTION
rel : #518 

# Cette PR ajoute:

- les tests automatiques d'a11y pour les pages "mentions légales" et "déclaration d'accessibilité"