### PR TITLE
feat: filter search using boolean extra field filter

### DIFF
--- a/client/src/definitions/catalogs.ts
+++ b/client/src/definitions/catalogs.ts
@@ -4,7 +4,7 @@ import type { Organization } from "./organization";
 export type Catalog = {
   organization: Organization;
   extraFields: ExtraField[];
-}
+};
 export interface ExtraFieldValue {
   extraFieldId: string;
   value: string;

--- a/client/src/definitions/catalogs.ts
+++ b/client/src/definitions/catalogs.ts
@@ -1,35 +1,7 @@
+import type { ExtraField } from "./extraField";
 import type { Organization } from "./organization";
 
-type ExtraFieldBase = {
-  id: string;
-  name: string;
-  title: string;
-  hintText: string;
-};
-
-type TextExtraField = {
-  type: "TEXT";
-  data: Record<string, never>;
-} & ExtraFieldBase;
-
-type BoolExtraField = {
-  type: "BOOL";
-  data: {
-    trueValue: string;
-    falseValue: string;
-  };
-} & ExtraFieldBase;
-
-type EnumExtraField = {
-  type: "ENUM";
-  data: {
-    values: string[];
-  };
-} & ExtraFieldBase;
-
-export type ExtraField = TextExtraField | BoolExtraField | EnumExtraField;
-
-export interface Catalog {
+export type Catalog = {
   organization: Organization;
   extraFields: ExtraField[];
 }

--- a/client/src/definitions/datasetFilters.ts
+++ b/client/src/definitions/datasetFilters.ts
@@ -11,6 +11,7 @@ export type DatasetFiltersInfo = {
   technicalSource: string[];
   tagId: Tag[];
   license: string[];
+  extraFields: ExtraField[];
 };
 
 export type DatasetFiltersValue = {

--- a/client/src/definitions/datasetFilters.ts
+++ b/client/src/definitions/datasetFilters.ts
@@ -1,4 +1,6 @@
+import type { ExtraFieldValue } from "./catalogs";
 import type { DataFormat } from "./dataformat";
+import type { ExtraField } from "./extraField";
 import type { SelectOption } from "./form";
 import type { Organization } from "./organization";
 import type { Tag } from "./tag";
@@ -22,8 +24,11 @@ export type DatasetFiltersValue = {
   technicalSource: string | null;
   tagId: string | null;
   license: string | null;
+  extraFieldValue: ExtraFieldValue | null;
 };
 
 export type DatasetFiltersOptions = {
-  [K in keyof DatasetFiltersValue]: SelectOption<DatasetFiltersValue[K]>[];
+  [K in keyof Omit<DatasetFiltersValue, "extraFieldValue">]: SelectOption<
+    DatasetFiltersValue[K]
+  >[];
 };

--- a/client/src/definitions/extraField.ts
+++ b/client/src/definitions/extraField.ts
@@ -10,7 +10,7 @@ type TextExtraField = {
   data: Record<string, never>;
 } & ExtraFieldBase;
 
-type BoolExtraField = {
+export type BoolExtraField = {
   type: "BOOL";
   data: {
     trueValue: string;

--- a/client/src/definitions/extraField.ts
+++ b/client/src/definitions/extraField.ts
@@ -1,0 +1,28 @@
+type ExtraFieldBase = {
+  id: string;
+  name: string;
+  title: string;
+  hintText: string;
+};
+
+type TextExtraField = {
+  type: "TEXT";
+  data: Record<string, never>;
+} & ExtraFieldBase;
+
+type BoolExtraField = {
+  type: "BOOL";
+  data: {
+    trueValue: string;
+    falseValue: string;
+  };
+} & ExtraFieldBase;
+
+type EnumExtraField = {
+  type: "ENUM";
+  data: {
+    values: string[];
+  };
+} & ExtraFieldBase;
+
+export type ExtraField = TextExtraField | BoolExtraField | EnumExtraField;

--- a/client/src/definitions/url.ts
+++ b/client/src/definitions/url.ts
@@ -1,3 +1,1 @@
-import type { Maybe } from "src/lib/util/maybe";
-
-export type QueryParamRecord = [string, Maybe<string | number>][];
+export type QueryParamRecord = [string, string | number | null | undefined][];

--- a/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
+++ b/client/src/lib/components/DatasetForm/DatasetForm.spec.ts
@@ -11,8 +11,9 @@ import type {
 } from "src/definitions/datasets";
 import { login, logout } from "$lib/stores/auth";
 import { buildFakeTag } from "src/tests/factories/tags";
-import type { Catalog, ExtraField } from "src/definitions/catalogs";
+import type { Catalog } from "src/definitions/catalogs";
 import type { Organization } from "src/definitions/organization";
+import type { ExtraField } from "src/definitions/extraField";
 
 describe("Test the dataset form", () => {
   beforeAll(() =>

--- a/client/src/lib/components/DatasetForm/_ExtraField.spec.ts
+++ b/client/src/lib/components/DatasetForm/_ExtraField.spec.ts
@@ -4,7 +4,8 @@
 import "@testing-library/jest-dom";
 
 import { render } from "@testing-library/svelte";
-import type { ExtraField } from "src/definitions/catalogs";
+import type { ExtraField } from "src/definitions/extraField";
+
 import ExtraFieldComponent from "./_ExtraField.svelte";
 
 describe("Extra field", () => {

--- a/client/src/lib/components/DatasetForm/_ExtraField.svelte
+++ b/client/src/lib/components/DatasetForm/_ExtraField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ExtraField } from "src/definitions/catalogs";
+  import type { ExtraField } from "src/definitions/extraField";
   import { toSelectOptions } from "src/lib/transformers/form";
   import { renderMarkdown } from "src/lib/util/markdown";
   import InputField from "../InputField/InputField.svelte";

--- a/client/src/lib/components/SearchFilter/BooleanSearchFilter.svelte
+++ b/client/src/lib/components/SearchFilter/BooleanSearchFilter.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { SelectOption } from "src/definitions/form";
+  export let label: string;
+  export let options: SelectOption[];
+  export let name: string;
+
+  let value: "";
+</script>
+
+<div class="fr-form-group">
+  <legend class="fr-fieldset__legend fr-text--regular" id="radio-legend">
+    {label}
+  </legend>
+  <div class="fr-fieldset__content">
+    {#each options as option}
+      <div class="fr-radio-group">
+        <input
+          type="radio"
+          id={option.label}
+          {name}
+          value={option.value}
+          bind:group={value}
+          on:change
+        />
+        <label class="fr-label" for={option.label}>{option.label} </label>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/client/src/lib/components/SearchFilter/SearchFilterSkeleton.svelte
+++ b/client/src/lib/components/SearchFilter/SearchFilterSkeleton.svelte
@@ -40,7 +40,8 @@
     z-index: 10;
     max-height: 32vh;
     width: 100%;
-    overflow: scroll;
+    overflow-x: hidden;
+    overflow-y: scroll;
     position: absolute;
     border: 1px solid var(--background-contrast-grey);
   }

--- a/client/src/lib/components/SearchableComboBox/Basic.svelte
+++ b/client/src/lib/components/SearchableComboBox/Basic.svelte
@@ -129,7 +129,6 @@
           break;
 
         case "ArrowUp":
-          // console.log("tata");
           // if the textbox is not empty and the listbox is displayed, moves visual focus to the last suggested value.
 
           if (!value && showSuggestions) {

--- a/client/src/lib/repositories/datasetFilters.ts
+++ b/client/src/lib/repositories/datasetFilters.ts
@@ -6,13 +6,20 @@ import { toFiltersInfo } from "../transformers/datasetFilters";
 type GetDatasetFiltersInfo = (opts: {
   fetch: Fetch;
   apiToken: string;
+  organizationSiret?: string | null;
 }) => Promise<DatasetFiltersInfo>;
 
 export const getDatasetFiltersInfo: GetDatasetFiltersInfo = async ({
   fetch,
   apiToken,
+  organizationSiret,
 }) => {
-  const url = `${getApiUrl()}/datasets/filters/`;
+  const urlBase = `${getApiUrl()}/datasets/filters`;
+
+  const url = organizationSiret
+    ? `${urlBase}?organization_siret=${organizationSiret}`
+    : `${urlBase}/`;
+
 
   const request = new Request(url, {
     headers: new Headers(getHeaders(apiToken)),

--- a/client/src/lib/repositories/datasetFilters.ts
+++ b/client/src/lib/repositories/datasetFilters.ts
@@ -20,7 +20,6 @@ export const getDatasetFiltersInfo: GetDatasetFiltersInfo = async ({
     ? `${urlBase}?organization_siret=${organizationSiret}`
     : `${urlBase}/`;
 
-
   const request = new Request(url, {
     headers: new Headers(getHeaders(apiToken)),
   });

--- a/client/src/lib/repositories/datasets.ts
+++ b/client/src/lib/repositories/datasets.ts
@@ -49,7 +49,7 @@ type GetDatasets = (opts: {
   apiToken: string;
   page: number;
   q?: string;
-  filters?: Maybe<DatasetFiltersValue>;
+  filters?: DatasetFiltersValue;
 }) => Promise<Maybe<Paginated<Dataset>>>;
 
 export const getDatasets: GetDatasets = async ({
@@ -64,12 +64,13 @@ export const getDatasets: GetDatasets = async ({
     ["page_size", DATASETS_PER_PAGE.toString()],
   ];
 
-  if (Maybe.Some(q) && q) {
+  if (q) {
     queryItems.push(["q", q]);
   }
 
-  if (Maybe.Some(filters)) {
-    queryItems.push(...toFiltersParams(filters));
+  if (filters) {
+    const filterParams = toFiltersParams(filters);
+    queryItems.push(...filterParams);
   }
 
   const queryString = toQueryString(queryItems);

--- a/client/src/lib/transformers/catalogs.ts
+++ b/client/src/lib/transformers/catalogs.ts
@@ -1,4 +1,5 @@
-import type { Catalog, ExtraField } from "src/definitions/catalogs";
+import type { Catalog } from "src/definitions/catalogs";
+import type { ExtraField } from "src/definitions/extraField";
 import { toOrganization } from "./organization";
 
 const toExtraField = (data: any): ExtraField => {

--- a/client/src/lib/transformers/datasetFilters.spec.ts
+++ b/client/src/lib/transformers/datasetFilters.spec.ts
@@ -3,11 +3,13 @@ import type {
   DatasetFiltersOptions,
   DatasetFiltersValue,
 } from "src/definitions/datasetFilters";
+import type { BoolExtraField } from "src/definitions/extraField";
 import { toQueryString } from "../util/urls";
 import {
   toFiltersOptions,
   toFiltersParams,
   toFiltersValue,
+  transformRawExtraFieldToBoolExtraField,
 } from "./datasetFilters";
 
 describe("transformers -- Dataset filters", () => {
@@ -36,6 +38,7 @@ describe("transformers -- Dataset filters", () => {
       },
     ],
     license: ["*", "Licence Ouverte"],
+    extraFields: [],
   };
 
   const value: DatasetFiltersValue = {
@@ -46,6 +49,7 @@ describe("transformers -- Dataset filters", () => {
     technicalSource: "Serveur GIS",
     tagId: null,
     license: "Licence Ouverte",
+    extraFieldValue: null,
   };
 
   test("toFiltersParams", () => {
@@ -97,5 +101,35 @@ describe("transformers -- Dataset filters", () => {
     };
 
     expect(toFiltersOptions(info)).toEqual(options);
+  });
+
+  test("transformExtraFieldData", () => {
+    const rawExtraField = {
+      type: "BOOL",
+      id: "myid",
+      hintText: "my hint text",
+      name: "myName",
+      title: "myTitle",
+      data: {
+        true_value: "Oui",
+        false_value: "Non",
+      },
+    };
+
+    const expectedResult: BoolExtraField = {
+      type: "BOOL",
+      id: "myid",
+      hintText: "my hint text",
+      name: "myName",
+      title: "myTitle",
+      data: {
+        trueValue: "Oui",
+        falseValue: "Non",
+      },
+    };
+
+    expect(transformRawExtraFieldToBoolExtraField(rawExtraField)).toEqual(
+      expectedResult
+    );
   });
 });

--- a/client/src/lib/transformers/datasetFilters.spec.ts
+++ b/client/src/lib/transformers/datasetFilters.spec.ts
@@ -61,6 +61,7 @@ describe("transformers -- Dataset filters", () => {
       ["technical_source", "Serveur GIS"],
       ["tag_id", null],
       ["license", "Licence Ouverte"],
+      ["extra_field_value", null],
     ];
 
     expect(toFiltersParams(value)).toEqual(params);

--- a/client/src/lib/transformers/datasetFilters.ts
+++ b/client/src/lib/transformers/datasetFilters.ts
@@ -1,3 +1,4 @@
+import type { ExtraFieldValue } from "src/definitions/catalogs";
 import type {
   DatasetFiltersInfo,
   DatasetFiltersOptions,
@@ -20,6 +21,28 @@ export const transformRawExtraFieldToBoolExtraField = (
       trueValue: rawExtraField.data.true_value,
       falseValue: rawExtraField.data.false_value,
     },
+  };
+};
+
+const transformExtraFieldValueToAPIQueryParam = (
+  extraFieldValue: ExtraFieldValue
+): {
+  value: string;
+  extra_field_id: string;
+} => {
+  return {
+    extra_field_id: extraFieldValue.extraFieldId,
+    value: extraFieldValue.value,
+  };
+};
+
+export const transformAPIQueryParamToExtraFieldValue = (value: {
+  value: string;
+  extra_field_id: string;
+}): ExtraFieldValue => {
+  return {
+    extraFieldId: value.extra_field_id,
+    value: value.value,
   };
 };
 
@@ -59,7 +82,7 @@ export const toFiltersValue = (
 ): DatasetFiltersValue => {
   const formatId = searchParams.get("format_id");
 
-  const extraFields = searchParams.get("extra_fields");
+  const extraFieldValue = searchParams.get("extra_field_value");
   return {
     organizationSiret: searchParams.get("organization_siret"),
     geographicalCoverage: searchParams.get("geographical_coverage"),
@@ -68,7 +91,9 @@ export const toFiltersValue = (
     technicalSource: searchParams.get("technical_source"),
     tagId: searchParams.get("tag_id"),
     license: searchParams.get("license"),
-    extraFieldValue: extraFields ? JSON.parse(extraFields) : null,
+    extraFieldValue: extraFieldValue
+      ? transformAPIQueryParamToExtraFieldValue(JSON.parse(extraFieldValue))
+      : null,
   };
 };
 
@@ -94,7 +119,14 @@ export const toFiltersParams = (
     ["technical_source", technicalSource],
     ["tag_id", tagId],
     ["license", license],
-    ["extra_fields", JSON.stringify(extraFieldValue)],
+    [
+      "extra_field_value",
+      extraFieldValue
+        ? JSON.stringify(
+            transformExtraFieldValueToAPIQueryParam(extraFieldValue)
+          )
+        : null,
+    ],
   ];
 };
 

--- a/client/src/lib/transformers/datasetFilters.ts
+++ b/client/src/lib/transformers/datasetFilters.ts
@@ -13,6 +13,7 @@ export const toFiltersInfo = (data: any): DatasetFiltersInfo => {
     technical_source,
     tag_id,
     format_id,
+    extra_fields,
     ...rest
   } = data;
   return {
@@ -21,6 +22,7 @@ export const toFiltersInfo = (data: any): DatasetFiltersInfo => {
     technicalSource: technical_source,
     tagId: tag_id,
     formatId: format_id,
+    extraFields: extra_fields,
     ...rest,
   };
 };

--- a/client/src/lib/transformers/extraField.ts
+++ b/client/src/lib/transformers/extraField.ts
@@ -1,0 +1,15 @@
+import type { BoolExtraField } from "src/definitions/extraField";
+import type { SelectOption } from "src/definitions/form";
+
+export const toSelectOption = (extraField: BoolExtraField): SelectOption[] => {
+  return [
+    {
+      label: extraField.data.trueValue,
+      value: extraField.data.trueValue,
+    },
+    {
+      label: extraField.data.falseValue,
+      value: extraField.data.falseValue,
+    },
+  ];
+};

--- a/client/src/lib/util/string.ts
+++ b/client/src/lib/util/string.ts
@@ -2,3 +2,9 @@ export const escape = (value: string): string => {
   // See: https://stackoverflow.com/a/3561711
   return value.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
 };
+
+export const camelToSnake = (str: string): string => {
+  return str.replace(/[A-Z]/g, (c) => {
+    return "_" + c.toLowerCase();
+  });
+};

--- a/client/src/routes/(app)/fiches/[id]/_ExtraFieldsList.svelte
+++ b/client/src/routes/(app)/fiches/[id]/_ExtraFieldsList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { ExtraField, ExtraFieldValue } from "src/definitions/catalogs";
+  import type { ExtraFieldValue } from "src/definitions/catalogs";
+  import type { ExtraField } from "src/definitions/extraField";
   import { Maybe } from "src/lib/util/maybe";
 
   export let extraFields: ExtraField[];

--- a/client/src/routes/(app)/fiches/[id]/page.spec.ts
+++ b/client/src/routes/(app)/fiches/[id]/page.spec.ts
@@ -6,15 +6,12 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/svelte";
 import index from "./+page.svelte";
 import { getFakeDataset } from "src/tests/factories/dataset";
-import type {
-  Catalog,
-  ExtraField,
-  ExtraFieldValue,
-} from "src/definitions/catalogs";
+import type { Catalog, ExtraFieldValue } from "src/definitions/catalogs";
 import { login, logout } from "src/lib/stores/auth";
 import { getFakeOrganization } from "src/tests/factories/organizations";
 import { getFakeCatalogRecord } from "src/tests/factories/catalog_records";
 import { getFakeAccount } from "src/tests/factories/accounts";
+import type { ExtraField } from "src/definitions/extraField";
 
 const organization = getFakeOrganization();
 

--- a/client/src/routes/(app)/fiches/search/+page.svelte
+++ b/client/src/routes/(app)/fiches/search/+page.svelte
@@ -39,7 +39,6 @@
   };
 
   const handleFilterChange = async (e: CustomEvent<DatasetFiltersValue>) => {
-    console.log(e.detail);
     const href = patchQueryString($pageStore.url.searchParams, [
       ...toFiltersParams(e.detail),
       makePageParam(1),

--- a/client/src/routes/(app)/fiches/search/+page.svelte
+++ b/client/src/routes/(app)/fiches/search/+page.svelte
@@ -39,6 +39,7 @@
   };
 
   const handleFilterChange = async (e: CustomEvent<DatasetFiltersValue>) => {
+    console.log(e.detail);
     const href = patchQueryString($pageStore.url.searchParams, [
       ...toFiltersParams(e.detail),
       makePageParam(1),
@@ -82,16 +83,11 @@
     </div>
 
     {#if Maybe.Some(filtersInfo) && displayFilters}
-      <div
-        data-test-id="filter-panel"
-        class="fr-grid-row fr-grid-row--gutters fr-py-3w filters"
-      >
-        <FilterPanel
-          on:change={handleFilterChange}
-          info={filtersInfo}
-          value={filtersValue}
-        />
-      </div>
+      <FilterPanel
+        on:change={handleFilterChange}
+        info={filtersInfo}
+        value={filtersValue}
+      />
     {/if}
 
     <div class="fr-grid-row">
@@ -114,11 +110,6 @@
 
   h2 {
     padding: 0;
-  }
-
-  .filters {
-    border-bottom: 1px solid var(--border-default-grey);
-    justify-content: space-between;
   }
 
   .summary__header {

--- a/client/src/routes/(app)/fiches/search/+page.svelte
+++ b/client/src/routes/(app)/fiches/search/+page.svelte
@@ -43,6 +43,7 @@
       ...toFiltersParams(e.detail),
       makePageParam(1),
     ]);
+
     goto(href, { noscroll: true });
   };
 </script>

--- a/client/src/routes/(app)/fiches/search/+page.ts
+++ b/client/src/routes/(app)/fiches/search/+page.ts
@@ -12,6 +12,8 @@ export const load: PageLoad = async ({ fetch, url }) => {
   const q = url.searchParams.get("q") || "";
   const filtersValue = toFiltersValue(url.searchParams);
 
+  const organizationSiret = url.searchParams.get("organization_siret");
+
   const token = get(apiToken);
 
   const [paginatedDatasets, filtersInfo] = await Promise.all([
@@ -22,7 +24,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
       q,
       filters: filtersValue,
     }),
-    getDatasetFiltersInfo({ fetch, apiToken: token }),
+    getDatasetFiltersInfo({ fetch, apiToken: token, organizationSiret }),
   ]);
 
   return {

--- a/client/src/routes/(app)/fiches/search/_FilterPanel.svelte
+++ b/client/src/routes/(app)/fiches/search/_FilterPanel.svelte
@@ -7,11 +7,13 @@
   import type { SelectOption } from "src/definitions/form";
   import type { Organization } from "src/definitions/organization";
   import type { Tag } from "src/definitions/tag";
+  import BooleanSearchFilter from "src/lib/components/SearchFilter/BooleanSearchFilter.svelte";
   import TextSearchFilter from "src/lib/components/SearchFilter/TextSearchFilter.svelte";
   import {
     toFiltersButtonTexts,
     toFiltersOptions,
   } from "src/lib/transformers/datasetFilters";
+  import { toSelectOption } from "src/lib/transformers/extraField";
   import { createEventDispatcher } from "svelte";
 
   export let info: DatasetFiltersInfo;
@@ -56,81 +58,122 @@
     value[key] = e.detail?.value || null;
     dispatch("change", value);
   };
+
+  const handleExtraFieldChange = (name: string, event: Event) => {
+    value = {
+      ...value,
+      extraFieldValue: {
+        extraFieldId: name,
+        value: event.currentTarget?.value,
+      },
+    };
+
+    dispatch("change", value);
+  };
 </script>
 
-<section>
-  <h6>Informations générales</h6>
+<div
+  data-test-id="filter-panel"
+  class="fr-grid-row fr-grid-row--gutters fr-py-3w filters"
+>
+  <section>
+    <h6>Informations générales</h6>
 
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Couverture géographique"
-      options={filtersOptions.geographicalCoverage}
-      buttonText={buttonTexts.geographicalCoverage}
-      on:selectOption={(e) => handleSelectFilter("geographicalCoverage", e)}
-    />
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Couverture géographique"
+        options={filtersOptions.geographicalCoverage}
+        buttonText={buttonTexts.geographicalCoverage}
+        on:selectOption={(e) => handleSelectFilter("geographicalCoverage", e)}
+      />
+    </div>
+
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Service producteur de la donnée"
+        options={filtersOptions.service}
+        buttonText={buttonTexts.service}
+        on:selectOption={(e) => handleSelectFilter("service", e)}
+      />
+    </div>
+
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Licence de réutilisation"
+        options={filtersOptions.license}
+        buttonText={buttonTexts.license}
+        on:selectOption={(e) => handleSelectFilter("license", e)}
+      />
+    </div>
+
+    <h6 class="fr-mt-3w">Catalogues</h6>
+
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Catalogue"
+        options={filtersOptions.organizationSiret}
+        buttonText={buttonTexts.organizationSiret}
+        on:selectOption={(e) => handleSelectFilter("organizationSiret", e)}
+      />
+    </div>
+  </section>
+
+  <section>
+    <h6>Sources et formats</h6>
+
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Format de mise à disposition"
+        options={filtersOptions.formatId}
+        buttonText={buttonTexts.formatId}
+        on:selectOption={(e) => handleSelectFilter("formatId", e)}
+      />
+    </div>
+
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Système d'information source"
+        options={filtersOptions.technicalSource}
+        buttonText={buttonTexts.technicalSource}
+        on:selectOption={(e) => handleSelectFilter("technicalSource", e)}
+      />
+    </div>
+  </section>
+
+  <section>
+    <h6>Mots-clés thématiques</h6>
+
+    <div class="fr-mb-2w">
+      <TextSearchFilter
+        label="Mot-clé"
+        options={filtersOptions.tagId}
+        buttonText={buttonTexts.tagId}
+        on:selectOption={(e) => handleSelectFilter("tagId", e)}
+      />
+    </div>
+  </section>
+</div>
+{#if info.extraFields.length > 0}
+  <div class="fr-grid-row fr-grid-row--gutters fr-py-3w filters">
+    <section>
+      <h6>Champs complémentaires</h6>
+
+      {#each info.extraFields as extraField}
+        {#if extraField.type === "BOOL"}
+          <BooleanSearchFilter
+            name={extraField.name}
+            options={toSelectOption(extraField)}
+            label={extraField.title}
+            on:change={(e) => handleExtraFieldChange(extraField.id, e)}
+          />
+        {/if}
+      {/each}
+    </section>
   </div>
+{/if}
 
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Service producteur de la donnée"
-      options={filtersOptions.service}
-      buttonText={buttonTexts.service}
-      on:selectOption={(e) => handleSelectFilter("service", e)}
-    />
-  </div>
-
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Licence de réutilisation"
-      options={filtersOptions.license}
-      buttonText={buttonTexts.license}
-      on:selectOption={(e) => handleSelectFilter("license", e)}
-    />
-  </div>
-
-  <h6 class="fr-mt-3w">Catalogues</h6>
-
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Catalogue"
-      options={filtersOptions.organizationSiret}
-      buttonText={buttonTexts.organizationSiret}
-      on:selectOption={(e) => handleSelectFilter("organizationSiret", e)}
-    />
-  </div>
-</section>
-
-<section>
-  <h6>Sources et formats</h6>
-
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Format de mise à disposition"
-      options={filtersOptions.formatId}
-      buttonText={buttonTexts.formatId}
-      on:selectOption={(e) => handleSelectFilter("formatId", e)}
-    />
-  </div>
-
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Système d'information source"
-      options={filtersOptions.technicalSource}
-      buttonText={buttonTexts.technicalSource}
-      on:selectOption={(e) => handleSelectFilter("technicalSource", e)}
-    />
-  </div>
-</section>
-
-<section>
-  <h6>Mots-clés thématiques</h6>
-
-  <div class="fr-mb-2w">
-    <TextSearchFilter
-      label="Mot-clé"
-      options={filtersOptions.tagId}
-      buttonText={buttonTexts.tagId}
-      on:selectOption={(e) => handleSelectFilter("tagId", e)}
-    />
-  </div>
-</section>
+<style>
+  .filters {
+    justify-content: space-between;
+  }
+</style>

--- a/client/src/routes/(app)/fiches/search/_FilterPanel.svelte
+++ b/client/src/routes/(app)/fiches/search/_FilterPanel.svelte
@@ -51,20 +51,25 @@
 
   const dispatch = createEventDispatcher<{ change: DatasetFiltersValue }>();
 
-  const handleSelectFilter = (
-    key: string,
-    e: CustomEvent<SelectOption<any>>
+  const handleSelectFilter = <K extends keyof DatasetFiltersValue>(
+    key: K,
+    e: CustomEvent<SelectOption<any> | null>
   ) => {
+    if (key === "organizationSiret" && !e.detail?.value) {
+      value.extraFieldValue = null;
+    }
+
     value[key] = e.detail?.value || null;
     dispatch("change", value);
   };
 
-  const handleExtraFieldChange = (name: string, event: Event) => {
+  const handleExtraFieldValueChange = (name: string, event: Event) => {
+    const target = event.target as HTMLInputElement;
     value = {
       ...value,
       extraFieldValue: {
         extraFieldId: name,
-        value: event.currentTarget?.value,
+        value: target.value,
       },
     };
 
@@ -153,7 +158,7 @@
     </div>
   </section>
 </div>
-{#if info.extraFields.length > 0}
+{#if info.extraFields.length > 0 && info.extraFields.some((item) => item.type === "BOOL")}
   <div class="fr-grid-row fr-grid-row--gutters fr-py-3w filters">
     <section>
       <h6>Champs complémentaires</h6>
@@ -164,7 +169,7 @@
             name={extraField.name}
             options={toSelectOption(extraField)}
             label={extraField.title}
-            on:change={(e) => handleExtraFieldChange(extraField.id, e)}
+            on:change={(e) => handleExtraFieldValueChange(extraField.id, e)}
           />
         {/if}
       {/each}

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -140,7 +140,10 @@ datasets:
       tag_ids:
         - "9c1549a5-02ef-43a9-aa20-6babdce0b733"
         - "5fb62590-7398-431a-bd60-cce1fd7bd45b" # This dataset has a duplicated tag : "environement"
-      extra_field_values: []
+      extra_field_values:
+          - dataset_id: "16b398af-f8c7-48b9-898a-18ad3404f528"
+            extra_field_id: "97668c15-5cd3-4efa-9ded-89a47eae6e99"
+            value: "Oui"
       publication_restriction: "no_restriction"
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/ensemble-des-lieux-de-restauration-des-crous-france-entiere-1/


### PR DESCRIPTION
close #563 

# Cette PR

- permet à un utilisateur de filtrer une recherche de jeu de donnée en utilisant un champs complémentaire de type boolean

## UI

Mon parti pris pour l'UI était de directement afficher les bouton radio sans qu'ils soient dans un sous menu.

Pour moi cela évite à l'utilisateur de devoir faire une action supplémentaire pour activer le filtre

## Pour tester

- aller sur staging et sur la page de recherche
- sélectionner le filtre "catalogue" et choisir  "Ministère de la Culture"

=> Un champs complémentaire devrait apparaître

- Selectionner une valeur

=> la recherche devrait afficher moins de jeu de donnée

