### PR TITLE
feat: handle multiple extra fields filters

### DIFF
--- a/client/src/definitions/catalogs.ts
+++ b/client/src/definitions/catalogs.ts
@@ -5,7 +5,7 @@ export type Catalog = {
   organization: Organization;
   extraFields: ExtraField[];
 };
-export interface ExtraFieldValue {
+export type ExtraFieldValue = {
   extraFieldId: string;
   value: string;
-}
+};

--- a/client/src/definitions/datasetFilters.ts
+++ b/client/src/definitions/datasetFilters.ts
@@ -24,11 +24,11 @@ export type DatasetFiltersValue = {
   technicalSource: string | null;
   tagId: string | null;
   license: string | null;
-  extraFieldValue: ExtraFieldValue | null;
+  extraFieldValues: ExtraFieldValue[] | null;
 };
 
 export type DatasetFiltersOptions = {
-  [K in keyof Omit<DatasetFiltersValue, "extraFieldValue">]: SelectOption<
+  [K in keyof Omit<DatasetFiltersValue, "extraFieldValues">]: SelectOption<
     DatasetFiltersValue[K]
   >[];
 };

--- a/client/src/lib/components/SearchFilter/BooleanSearchFilter.svelte
+++ b/client/src/lib/components/SearchFilter/BooleanSearchFilter.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div class="fr-form-group">
-  <legend class="fr-fieldset__legend fr-text--regular" id="radio-legend">
+  <legend class="fr-text--regular fr-mb-2w">
     {label}
   </legend>
   <div class="fr-fieldset__content">

--- a/client/src/lib/transformers/datasetFilters.spec.ts
+++ b/client/src/lib/transformers/datasetFilters.spec.ts
@@ -49,7 +49,7 @@ describe("transformers -- Dataset filters", () => {
     technicalSource: "Serveur GIS",
     tagId: null,
     license: "Licence Ouverte",
-    extraFieldValue: null,
+    extraFieldValues: null,
   };
 
   test("toFiltersParams", () => {
@@ -61,7 +61,7 @@ describe("transformers -- Dataset filters", () => {
       ["technical_source", "Serveur GIS"],
       ["tag_id", null],
       ["license", "Licence Ouverte"],
-      ["extra_field_value", null],
+      ["extra_field_values", null],
     ];
 
     expect(toFiltersParams(value)).toEqual(params);

--- a/client/src/lib/transformers/datasetFilters.ts
+++ b/client/src/lib/transformers/datasetFilters.ts
@@ -77,12 +77,37 @@ export const toFiltersInfo = (data: any): DatasetFiltersInfo => {
   };
 };
 
+const getExtraFieldValues = (
+  extraFieldValuesString: string | null
+): ExtraFieldValue[] | null => {
+  if (!extraFieldValuesString) {
+    return null;
+  }
+
+  return JSON.parse(extraFieldValuesString).map(
+    transformAPIQueryParamToExtraFieldValue
+  );
+};
+
+const getExtraFieldValuesString = (
+  extraFieldValues: ExtraFieldValue[] | null
+): string | null => {
+  if (!extraFieldValues) {
+    return null;
+  }
+
+  return JSON.stringify(
+    extraFieldValues.map(transformExtraFieldValueToAPIQueryParam)
+  );
+};
+
 export const toFiltersValue = (
   searchParams: URLSearchParams
 ): DatasetFiltersValue => {
   const formatId = searchParams.get("format_id");
 
-  const extraFieldValue = searchParams.get("extra_field_value");
+  const extraFieldValuesString = searchParams.get("extra_field_values");
+
   return {
     organizationSiret: searchParams.get("organization_siret"),
     geographicalCoverage: searchParams.get("geographical_coverage"),
@@ -91,9 +116,7 @@ export const toFiltersValue = (
     technicalSource: searchParams.get("technical_source"),
     tagId: searchParams.get("tag_id"),
     license: searchParams.get("license"),
-    extraFieldValue: extraFieldValue
-      ? transformAPIQueryParamToExtraFieldValue(JSON.parse(extraFieldValue))
-      : null,
+    extraFieldValues: getExtraFieldValues(extraFieldValuesString),
   };
 };
 
@@ -108,7 +131,7 @@ export const toFiltersParams = (
     technicalSource,
     tagId,
     license,
-    extraFieldValue,
+    extraFieldValues,
   } = value;
 
   return [
@@ -119,14 +142,7 @@ export const toFiltersParams = (
     ["technical_source", technicalSource],
     ["tag_id", tagId],
     ["license", license],
-    [
-      "extra_field_value",
-      extraFieldValue
-        ? JSON.stringify(
-            transformExtraFieldValueToAPIQueryParam(extraFieldValue)
-          )
-        : null,
-    ],
+    ["extra_field_values", getExtraFieldValuesString(extraFieldValues)],
   ];
 };
 
@@ -165,7 +181,7 @@ export const toFiltersButtonTexts = (
   tagIdToName: Record<string, string>,
   formatIdToName: Record<string, string>
 ): {
-  [K in keyof Omit<DatasetFiltersValue, "extraFieldValue">]: Maybe<string>;
+  [K in keyof Omit<DatasetFiltersValue, "extraFieldValues">]: Maybe<string>;
 } => {
   return {
     organizationSiret: Maybe.map(

--- a/client/src/lib/util/array.spec.ts
+++ b/client/src/lib/util/array.spec.ts
@@ -1,4 +1,4 @@
-import { range } from "./array";
+import { chunk, range } from "./array";
 
 describe("range", () => {
   const startEndCases: [number, number, number[]][] = [
@@ -27,5 +27,24 @@ describe("range", () => {
 
   test.each(endCases)("when end=%s", (end, expected) => {
     expect(range(end)).toStrictEqual(expected);
+  });
+});
+
+describe("chunck", () => {
+  const cases: [string[], number, string[][] | string[]][] = [
+    [
+      ["a", "b", "c", "d", "e", "f", "g"],
+      1,
+      [["a"], ["b"], ["c"], ["d"], ["e"], ["f"], ["g"]],
+    ],
+    [
+      ["a", "b", "c", "d", "e", "f", "g"],
+      3,
+      [["a", "b", "c"], ["d", "e", "f"], ["g"]],
+    ],
+  ];
+
+  test.each(cases)("chunk this array", (data, chunckSize, expected) => {
+    expect(chunk(data, chunckSize)).toStrictEqual(expected);
   });
 });

--- a/client/src/lib/util/array.ts
+++ b/client/src/lib/util/array.ts
@@ -28,3 +28,14 @@ export const last = <T>(arr: ArrayWithItems<T>): T => {
 
 export const removeEmptyValues = (items: Array<string | null>): Array<string> =>
   items.filter((item) => item) as string[];
+
+export const chunk = <T = string>(
+  arr: T[],
+  chunkSize = 1,
+  cache: T[][] = []
+): T[][] => {
+  const tmp: T[] = [...arr];
+  if (chunkSize <= 0) return cache;
+  while (tmp.length) cache.push(tmp.splice(0, chunkSize));
+  return cache;
+};

--- a/client/src/routes/(app)/fiches/search/_FilterPanel.svelte
+++ b/client/src/routes/(app)/fiches/search/_FilterPanel.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import type { ExtraFieldValue } from "src/definitions/catalogs";
   import type { DataFormat } from "src/definitions/dataformat";
   import type {
     DatasetFiltersInfo,
     DatasetFiltersValue,
   } from "src/definitions/datasetFilters";
+  import type { ExtraField } from "src/definitions/extraField";
   import type { SelectOption } from "src/definitions/form";
   import type { Organization } from "src/definitions/organization";
   import type { Tag } from "src/definitions/tag";
+
   import BooleanSearchFilter from "src/lib/components/SearchFilter/BooleanSearchFilter.svelte";
   import TextSearchFilter from "src/lib/components/SearchFilter/TextSearchFilter.svelte";
   import {
@@ -14,6 +17,7 @@
     toFiltersOptions,
   } from "src/lib/transformers/datasetFilters";
   import { toSelectOption } from "src/lib/transformers/extraField";
+  import { chunk } from "src/lib/util/array";
   import { createEventDispatcher } from "svelte";
 
   export let info: DatasetFiltersInfo;
@@ -34,6 +38,8 @@
     items.forEach(({ id, name }) => (map[id] = name));
     return map;
   };
+
+  $: extraFieldChunks = chunk<ExtraField>(info.extraFields, 5);
 
   $: organizationSiretToName = createOrganizationSiretToNameMap(
     info.organizationSiret
@@ -56,21 +62,69 @@
     e: CustomEvent<SelectOption<any> | null>
   ) => {
     if (key === "organizationSiret" && !e.detail?.value) {
-      value.extraFieldValue = null;
+      value.extraFieldValues = null;
     }
 
     value[key] = e.detail?.value || null;
     dispatch("change", value);
   };
 
+  const removeExistingExtraFieldValue = (
+    arr: ExtraFieldValue[],
+    id: string
+  ) => {
+    return arr.filter((obj) => obj.extraFieldId !== id);
+  };
+
+  const hasAlreadyTheFilter = (
+    extraFieldValues: ExtraFieldValue[],
+    id: string
+  ) => {
+    return extraFieldValues.some((item) => item.extraFieldId === id);
+  };
+
   const handleExtraFieldValueChange = (name: string, event: Event) => {
     const target = event.target as HTMLInputElement;
+
+    let newExtraFieldValues: ExtraFieldValue[] = [];
+
+    if (value.extraFieldValues) {
+      if (hasAlreadyTheFilter(value.extraFieldValues, name)) {
+        const filteredExtraFields = removeExistingExtraFieldValue(
+          value.extraFieldValues,
+          name
+        );
+
+        newExtraFieldValues = [
+          ...filteredExtraFields,
+          {
+            extraFieldId: name,
+            value: target.value,
+          },
+        ];
+      } else {
+        newExtraFieldValues = [
+          ...value.extraFieldValues,
+          {
+            extraFieldId: name,
+            value: target.value,
+          },
+        ];
+      }
+    }
+
+    if (!value.extraFieldValues) {
+      newExtraFieldValues = [
+        {
+          extraFieldId: name,
+          value: target.value,
+        },
+      ];
+    }
+
     value = {
       ...value,
-      extraFieldValue: {
-        extraFieldId: name,
-        value: target.value,
-      },
+      extraFieldValues: newExtraFieldValues,
     };
 
     dispatch("change", value);
@@ -79,7 +133,7 @@
 
 <div
   data-test-id="filter-panel"
-  class="fr-grid-row fr-grid-row--gutters fr-py-3w filters"
+  class="fr-grid-row fr-grid-row--gutters fitler_section fr-mt-3w"
 >
   <section>
     <h6>Informations générales</h6>
@@ -159,26 +213,38 @@
   </section>
 </div>
 {#if info.extraFields.length > 0 && info.extraFields.some((item) => item.type === "BOOL")}
-  <div class="fr-grid-row fr-grid-row--gutters fr-py-3w filters">
-    <section>
-      <h6>Champs complémentaires</h6>
+  <section
+    class="fr-py-3w fr-grid-row fr-grid-row--gutters extra_field_filters_section"
+  >
+    <h6>Champs complémentaires</h6>
 
-      {#each info.extraFields as extraField}
-        {#if extraField.type === "BOOL"}
-          <BooleanSearchFilter
-            name={extraField.name}
-            options={toSelectOption(extraField)}
-            label={extraField.title}
-            on:change={(e) => handleExtraFieldValueChange(extraField.id, e)}
-          />
-        {/if}
-      {/each}
-    </section>
-  </div>
+    {#each extraFieldChunks as extraFieldChunk}
+      <div class="fr-grid-row  extra_field_filter_chunck">
+        {#each extraFieldChunk as extraField}
+          {#if extraField.type === "BOOL"}
+            <BooleanSearchFilter
+              name={extraField.name}
+              options={toSelectOption(extraField)}
+              label={extraField.title}
+              on:change={(e) => handleExtraFieldValueChange(extraField.id, e)}
+            />
+          {/if}
+        {/each}
+      </div>
+    {/each}
+  </section>
 {/if}
 
 <style>
-  .filters {
+  .extra_field_filters_section {
+    flex-direction: column;
+  }
+
+  .fitler_section {
     justify-content: space-between;
+  }
+
+  .extra_field_filter_chunck {
+    gap: 80px;
   }
 </style>

--- a/server/api/datasets/routes.py
+++ b/server/api/datasets/routes.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
@@ -53,11 +53,11 @@ async def list_datasets(
 
     page = Page(number=params.page_number, size=params.page_size)
 
-    extra_field_value: Optional[ExtraFieldValue] = None
+    extra_field_values: Optional[List[ExtraFieldValue]] = None
 
-    if params.extra_field_value is not None:
-        item = json.loads(params.extra_field_value)
-        extra_field_value = ExtraFieldValue(**item)
+    if params.extra_field_values is not None:
+        items = json.loads(params.extra_field_values)
+        extra_field_values = [ExtraFieldValue(**item) for item in items]
 
     query = GetAllDatasets(
         page=page,
@@ -70,7 +70,7 @@ async def list_datasets(
             technical_source__in=params.technical_source,
             tag__id__in=params.tag_id,
             license=params.license,
-            extra_field_value=extra_field_value,
+            extra_field_values=extra_field_values,
         ),
         account=request.user.account,
     )

--- a/server/api/datasets/schemas.py
+++ b/server/api/datasets/schemas.py
@@ -28,7 +28,7 @@ class DatasetListParams:
         tag_id: Optional[List[ID]] = Query(None),
         license: Optional[str] = Query(None),
         publication_restriction: Optional[PublicationRestriction] = Query(None),
-        extra_field_value: Optional[str] = Query(None),
+        extra_field_values: Optional[str] = Query(None),
     ) -> None:
         self.q = q
         self.organization_siret = organization_siret
@@ -41,7 +41,7 @@ class DatasetListParams:
         self.tag_id = tag_id
         self.license = license
         self.publication_restriction = publication_restriction
-        self.extra_field_value = extra_field_value
+        self.extra_field_values = extra_field_values
 
 
 class DatasetCreate(CreateDatasetValidationMixin, BaseModel):

--- a/server/domain/datasets/specifications.py
+++ b/server/domain/datasets/specifications.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 from server.domain.common.types import ID
 from server.domain.extra_fields.entities import ExtraFieldValue
@@ -17,5 +17,5 @@ class DatasetSpec:
     technical_source__in: Optional[Sequence[str]] = None
     tag__id__in: Optional[Sequence[ID]] = None
     license: Optional[str] = None
-    extra_field_value: Optional[ExtraFieldValue] = None
+    extra_field_values: Optional[List[ExtraFieldValue]] = None
     include_all_datasets: bool = False

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -1,5 +1,6 @@
 import json
 import random
+from turtle import title
 from typing import Any, List, Tuple
 
 import httpx
@@ -19,7 +20,12 @@ from server.domain.dataformats.entities import DataFormat
 from server.domain.dataformats.repositories import DataFormatRepository
 from server.domain.datasets.entities import PublicationRestriction, UpdateFrequency
 from server.domain.datasets.exceptions import DatasetDoesNotExist
-from server.domain.extra_fields.entities import ExtraFieldValue, TextExtraField
+from server.domain.extra_fields.entities import (
+    BoolExtraField,
+    ExtraField,
+    ExtraFieldValue,
+    TextExtraField,
+)
 from server.domain.organizations.types import Siret
 from server.infrastructure.database import Database
 from server.infrastructure.extra_fields.models import ExtraFieldValueModel
@@ -1135,16 +1141,65 @@ class TestExtraFieldValues:
         self, client: httpx.AsyncClient
     ) -> None:
         bus = resolve(MessageBus)
-        siret, user, extra_field_id = await self._setup()
+        siret = await bus.execute(CreateOrganizationFactory.build())
 
-        value = "204 Go"
+        extra_fields: List[ExtraField] = [
+            TextExtraField(
+                title="Latitude GPS du MTE",
+                hint_text="La latitude où se trouve le MTE",
+                name="latitude_mte",
+                organization_siret=siret,
+            ),
+            BoolExtraField(
+                data={
+                    "false_value": "Oui",
+                    "true_value": "Non",
+                },
+                title="Type de données",
+                hint_text="Est-ce que ces données sont des données ?",
+                name="type_donnees",
+                organization_siret=siret,
+            ),
+        ]
+
+        await bus.execute(
+            CreateCatalog(organization_siret=siret, extra_fields=extra_fields)
+        )
+
+        catalog = await bus.execute(GetCatalogBySiret(siret=siret))
+
+        user = await create_test_password_user(
+            CreatePasswordUserFactory.build(organization_siret=siret)
+        )
+
+        value_1 = "48.891980000000046"
+        value_2 = "Non"
 
         command = CreateDatasetFactory.build(
             account=user.account,
             organization_siret=siret,
             format_ids=[1, 2],
             extra_field_values=[
-                ExtraFieldValue(extra_field_id=extra_field_id, value=value)
+                ExtraFieldValue(
+                    extra_field_id=catalog.extra_fields[0].id, value=value_1
+                ),
+                ExtraFieldValue(
+                    extra_field_id=catalog.extra_fields[1].id, value=value_2
+                ),
+            ],
+        )
+
+        await bus.execute(command)
+
+        command = CreateDatasetFactory.build(
+            account=user.account,
+            organization_siret=siret,
+            format_ids=[1, 2],
+            extra_field_values=[
+                ExtraFieldValue(
+                    extra_field_id=catalog.extra_fields[0].id, value="85Go"
+                ),
+                ExtraFieldValue(extra_field_id=catalog.extra_fields[1].id, value="Oui"),
             ],
         )
 
@@ -1160,8 +1215,21 @@ class TestExtraFieldValues:
         await bus.execute(command)
 
         params = {
-            "extra_field_value": json.dumps(
-                {"extra_field_id": str(extra_field_id), "value": value}
+            "extra_field_values": json.dumps(
+                [
+                    {
+                        "extra_field_id": str(
+                            catalog.extra_fields[0].id,
+                        ),
+                        "value": value_1,
+                    },
+                    {
+                        "extra_field_id": str(
+                            catalog.extra_fields[1].id,
+                        ),
+                        "value": value_2,
+                    },
+                ]
             )
         }
 

--- a/tests/api/test_datasets.py
+++ b/tests/api/test_datasets.py
@@ -1,6 +1,5 @@
 import json
 import random
-from turtle import title
 from typing import Any, List, Tuple
 
 import httpx

--- a/tools/initdata.yml
+++ b/tools/initdata.yml
@@ -42,11 +42,40 @@ catalogs:
               - Radio
               - Presse
               - Télévision
+          
         - id: "f8afd98d-d2a7-413f-9942-46810a3ea56e"
           name: donnees_con
           title: Données confidentielles
           hint_text: |
             Est-ce que cette donnée possède un caractère confidentiel ?
+          type: BOOL
+          data:
+            true_value: Oui
+            false_value: Non
+
+        - id: "3c866a2c-8958-46c5-8a45-672f4b756888"
+          name: donnees_géographiques
+          title: Données géographiques
+          hint_text: |
+            Est-ce que cette donnée est utilisable partout?
+          type: BOOL
+          data:
+            true_value: Oui
+            false_value: Non
+        - id: "ce5bc496-95c0-4bba-95f0-b65028ad738b"
+          name: donnees_temporelles
+          title: Données Temporelles
+          hint_text: |
+            Est-ce que cette donnée doit être conservée ad vitam eternam ?
+          type: BOOL
+          data:
+            true_value: Oui
+            false_value: Non
+        - id: "8973dff2-ece7-461e-ac2b-bad09af26ed6"
+          name: donnees_partielles
+          title: Données Partielles
+          hint_text: |
+            Est-ce que cette donnée est partielle ?
           type: BOOL
           data:
             true_value: Oui
@@ -156,6 +185,12 @@ datasets:
           - dataset_id: "16b398af-f8c7-48b9-898a-18ad3404f528"
             extra_field_id: "f8afd98d-d2a7-413f-9942-46810a3ea56e"
             value: "Non"
+          - dataset_id: "16b398af-f8c7-48b9-898a-18ad3404f528"
+            extra_field_id: "8973dff2-ece7-461e-ac2b-bad09af26ed6"
+            value: "Non"
+          - dataset_id: "16b398af-f8c7-48b9-898a-18ad3404f528"
+            extra_field_id: "ce5bc496-95c0-4bba-95f0-b65028ad738b"
+            value: "Oui"
                
       publication_restriction: "no_restriction"
 
@@ -179,7 +214,13 @@ datasets:
       license: Autre (Open)
       tag_ids:
         - "ceb19363-1681-4052-813c-f771d4459295"
-      extra_field_values: []
+      extra_field_values:
+        - dataset_id: "16b398af-f8c7-48b9-898a-18ad3404f528"
+          extra_field_id: "8973dff2-ece7-461e-ac2b-bad09af26ed6"
+          value: "Oui"
+        - dataset_id: "16b398af-f8c7-48b9-898a-18ad3404f528"
+          extra_field_id: "f8afd98d-d2a7-413f-9942-46810a3ea56e"
+          value: "Oui"
       publication_restriction: "no_restriction"
 
   - # Mimicks: https://www.data.gouv.fr/fr/datasets/restaurants-brasseries-et-cafeterias-des-crous/


### PR DESCRIPTION
Suite de #563 , rel #290 

# Cette PR:

Apporte plusieurs améliorations : 


## 1. Amélioration de l'affichage des filtres 

l'affichage était pas terrible quand il y avait plusieurs filtres. Ceux-ci s'affichaient en une seule longue colonne. 

Cette PR fait en sorte que les filtres soient affichés en plusieurs colonnes

## 2. Donne la possibilité de filtrer la recherche en fonction de plusieurs filtres de champs complémentaires

Maintenant, un utilisateur peut sélectionner plusieurs filtres de champ complémentaire et la recherche sera effectuée en fonction de chacun d'eux.



## Pour tester

Aller sur la page de recherche et utiliser les filtres de recherches